### PR TITLE
[NO-TICKET] Free Plan Checkmark Alignment Fix

### DIFF
--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -1009,7 +1009,6 @@ main .block .button-container.free-plan-container .free-plan-bullet .free-plan-b
 
 main .block .button-container.free-plan-container .free-plan-bullet .free-plan-bullet-tray > div > div:first-child {
   position: relative;
-  margin-top: 5px;
   margin-right: 6px;
   width: 14px;
   height: 14px;
@@ -1020,6 +1019,7 @@ main .block .button-container.free-plan-container .free-plan-bullet .free-plan-b
 main .block .button-container.free-plan-container .free-plan-bullet .free-plan-bullet-tray .free-plan-tag {
   display: flex;
   font-size: 16px;
+  align-items: center;
 }
 
 main .block .free-plan-optout {


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

No ticket:
**Description**
We caught the misalignment of the checkmarks in the free-plan widget. The reason of it is the alignment was managed by margin-top while display: flex; + align-items: center; could provide a more consistent result.

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/create/flyer?lighthouse=on
- After: https://free-plan-checkmark-align--express--adobecom.hlx.page/express/create/flyer?lighthouse=on
Note: might not be evident on the preview links but should the `free-plan-tag` line-height or font-size change, the before would show the checkmark misaligned and the after won't
