### PR TITLE
[MWPW 130582] Inject Browse by Category into Templates Page

### DIFF
--- a/express/scripts/templates.js
+++ b/express/scripts/templates.js
@@ -314,15 +314,8 @@ async function updateEagerBlocks() {
     await replaceDefaultPlaceholders(templateX);
   }
 
-  if (browseByCat) {
-    if (['yes', 'true', 'on', 'Y'].includes(getMetadata('show-browse-by-category'))) {
-      const placeholders = await fetchPlaceholders().then((result) => result);
-      browseByCat.innerHTML = browseByCat.innerHTML
-        .replaceAll('https://www.adobe.com/express/templates/default', getMetadata('categories-view-all-link') || '/')
-        .replaceAll('default-view-all-text', placeholders['view-all'] || '');
-    } else {
-      browseByCat.remove();
-    }
+  if (browseByCat && !['yes', 'true', 'on', 'Y'].includes(getMetadata('browse-by-category'))) {
+    browseByCat.remove();
   }
 }
 


### PR DESCRIPTION
Fix: https://jira.corp.adobe.com/browse/MWPW-130582

Test URLs:

Before: https://main--express--adobecom.hlx.page/express/templates/
After: https://mwpw-130582-2--express--adobecom.hlx.page/express/templates/?lighthouse=on

'Browse by Category' block is injected based on the 'browse by category' column of the templates spreadsheet

- Note that this will only function for the English site until we localize the templates folders & files.