### PR TITLE
ckg always use prod api to allow non-vpn access

### DIFF
--- a/express/scripts/api-v3-controller.js
+++ b/express/scripts/api-v3-controller.js
@@ -51,7 +51,7 @@ export async function getPillWordsMapping() {
 }
 
 export default async function getData(env = '', data = {}) {
-  const endpoint = endpoints[env];
+  const endpoint = endpoints.prod;
   const response = await fetch(endpoint.cdn, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

The CKG API requires VPN connections to work on .page urls. This might be inconvenient for authors and SEO people. This should address that.

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/templates/flyer/christmas
- After: https://enable-non-vpn-access-ckg--express--adobecom.hlx.page/express/templates/flyer/christmas
