### PR TITLE
[MWPW-128737-E] Bug fixes and enhancements on Create Marquee

### DIFF
--- a/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.css
+++ b/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.css
@@ -17,8 +17,12 @@ main .fullscreen-marquee-desktop {
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  padding-bottom: 160px;
+  padding-bottom: 80px;
   padding-top: 80px;
+}
+
+main .fullscreen-marquee-desktop.has-background {
+  padding-bottom: 160px;
 }
 
 main .fullscreen-marquee-desktop .fullscreen-marquee-desktop-heading {

--- a/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.css
+++ b/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.css
@@ -17,7 +17,7 @@ main .fullscreen-marquee-desktop {
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  padding-bottom: 80px;
+  padding-bottom: 40px;
   padding-top: 80px;
 }
 

--- a/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.css
+++ b/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.css
@@ -175,6 +175,8 @@ main .fullscreen-marquee-desktop .fullscreen-marquee-desktop-app-editor {
   top: 58px;
   left: 66px;
   width: 196px;
+  transition: transform 0.5s ease-out;
+  transform: translate3d(0px, 0px, 15px);
 }
 
 main .fullscreen-marquee-desktop .fullscreen-marquee-desktop-app-editor img {

--- a/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.css
+++ b/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.css
@@ -153,11 +153,13 @@ main .fullscreen-marquee-desktop .fullscreen-marquee-desktop-app-content {
 }
 
 main .fullscreen-marquee-desktop .fullscreen-marquee-desktop-app-content {
-  height: 90%;
+  max-width: 90%;
+  max-height: 90%;
 }
 
 main .fullscreen-marquee-desktop .fullscreen-marquee-desktop-app-content img {
-  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
 }
 
 main .fullscreen-marquee-desktop .fullscreen-marquee-desktop-app-frame .fullscreen-marquee-desktop-app {

--- a/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.css
+++ b/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.css
@@ -197,6 +197,7 @@ main .fullscreen-marquee-desktop .fullscreen-marquee-desktop-app-thumbnail-conta
   height: 40px;
   overflow: hidden;
   border-radius: 5px;
+  transform: translate3d(0px, 0px, 15px);
   z-index: 10;
 }
 

--- a/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.css
+++ b/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.css
@@ -197,7 +197,6 @@ main .fullscreen-marquee-desktop .fullscreen-marquee-desktop-app-thumbnail-conta
   height: 40px;
   overflow: hidden;
   border-radius: 5px;
-  transform: translate3d(0px, 0px, 15px);
   z-index: 10;
 }
 

--- a/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.css
+++ b/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.css
@@ -66,6 +66,7 @@ main .fullscreen-marquee-desktop-heading h1 em {
 main .fullscreen-marquee-desktop .fullscreen-marquee-desktop-background {
   position: absolute;
   height: 100%;
+  width: 100%;
   top: 0;
   left: 50%;
   z-index: -5;
@@ -77,6 +78,8 @@ main .fullscreen-marquee-desktop .fullscreen-marquee-desktop-background {
 main .fullscreen-marquee-desktop .fullscreen-marquee-desktop-background img {
   max-width: none;
   height: 100%;
+  width: 100%;
+  object-fit: cover;
 }
 
 main .fullscreen-marquee-desktop .fullscreen-marquee-desktop-app-frame {

--- a/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.js
+++ b/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.js
@@ -68,9 +68,7 @@ async function buildApp(block, content) {
   let editor;
   let variant;
 
-  if (block.classList.contains('image')) {
-    variant = 'image';
-  } else {
+  if (block.classList.contains('video')) {
     variant = 'video';
 
     if (content) {
@@ -83,7 +81,6 @@ async function buildApp(block, content) {
       content.addEventListener('loadedmetadata', () => {
         const framesContainer = createTag('div', { class: 'fullscreen-marquee-desktop-app-frames-container' });
         function createFrame(current, total) {
-          console.log(`Creating frame ${current} out of ${total}`);
           const frame = createTag('video', { src: `${content.currentSrc}#t=${current}` });
           framesContainer.append(frame);
 
@@ -97,10 +94,12 @@ async function buildApp(block, content) {
           });
         }
 
-        createFrame( 1, 10);
+        createFrame(1, 10);
         app.append(framesContainer);
       });
     }
+  } else {
+    variant = 'image';
   }
 
   await fetchPlaceholders().then((placeholders) => {

--- a/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.js
+++ b/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.js
@@ -22,8 +22,8 @@ function buildContent(content) {
   let formattedContent = content;
 
   if (contentLink && contentLink.href.endsWith('.mp4')) {
-    const video = new URL(contentLink.href);
-    const looping = ['true', 'yes', 'on'].includes(video.searchParams.get('looping')) ? 'yes' : null;
+    const video = new URL(contentLink.textContent.trim());
+    const looping = ['true', 'yes', 'on'].includes(video.searchParams.get('loop'));
     formattedContent = transformLinkToAnimation(contentLink, looping);
   } else {
     const contentImage = content.querySelector('picture');

--- a/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.js
+++ b/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.js
@@ -158,6 +158,7 @@ export default async function decorate(block) {
   }
 
   if (background) {
+    block.classList.add('has-background');
     block.append(buildBackground(block, background));
   }
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -376,13 +376,13 @@ export function getIconElement(icons, size, alt, additionalClassName) {
   return ($div.firstElementChild);
 }
 
-export function transformLinkToAnimation($a, $videoLooping = 'yes') {
+export function transformLinkToAnimation($a, $videoLooping = true) {
   if (!$a || !$a.href.endsWith('.mp4')) {
     return null;
   }
   const params = new URL($a.href).searchParams;
   const attribs = {};
-  let dataAttr = ($videoLooping && $videoLooping === 'yes') ? ['playsinline', 'autoplay', 'loop', 'muted'] : ['playsinline', 'autoplay', 'muted'];
+  const dataAttr = $videoLooping ? ['playsinline', 'autoplay', 'loop', 'muted'] : ['playsinline', 'autoplay', 'muted'];
   dataAttr.forEach((p) => {
     if (params.get(p) !== 'false') attribs[p] = '';
   });


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://jira.corp.adobe.com/browse/MWPW-128737

Fixing the following issues
- The bottom spacing is now halved if there is no background.
- Images will now properly resize within the allowed space in the app.
- The block without variant will no longer break, and will now default to Image.
- The left-side editor is now also animated.

Test URLs:

- Before: 
  - [Full Screen Marquee (previous version)](https://main--express--adobecom.hlx.page/drafts/williambsm/mwpw-128737/fullscreen-marquee-previous?lighthouse=on)
- After: 
  - [Full Screen Marquee (Image variant)](https://mwpw-128737-e--express--adobecom.hlx.page/drafts/williambsm/mwpw-128737/fullscreen-marquee-v2?lighthouse=on)
  - [Full Screen Marquee (Image variant without background)](https://mwpw-128737-e--express--adobecom.hlx.page/drafts/williambsm/mwpw-128737/fullscreen-marquee-v2-without-background-with-row?lighthouse=on)
  - [Full Screen Marquee (Video variant)](https://mwpw-128737-e--express--adobecom.hlx.page/drafts/williambsm/mwpw-128737/fullscreen-marquee-v2-video-variant?lighthouse=on)

