### PR TITLE
[CHORE]: fstab file update

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -4,18 +4,32 @@ mountpoints:
 
 folders:
   /express/templates/: /express/templates/default
-  /br/express/templates/: /express/templates/default
-  /cn/express/templates/: /express/templates/default
-  /de/express/templates/: /express/templates/default
-  /dk/express/templates/: /express/templates/default
-  /es/express/templates/: /express/templates/default
-  /fi/express/templates/: /express/templates/default
-  /fr/express/templates/: /express/templates/default
-  /it/express/templates/: /express/templates/default
-  /jp/express/templates/: /express/templates/default
-  /kr/express/templates/: /express/templates/default
-  /nl/express/templates/: /express/templates/default
-  /no/express/templates/: /express/templates/default
-  /se/express/templates/: /express/templates/default
-  /tw/express/templates/: /express/templates/default
-
+  /br/express/templates/: /br/express/templates/default
+  /cn/express/templates/: /cn/express/templates/default
+  /de/express/templates/: /de/express/templates/default
+  /dk/express/templates/: /dk/express/templates/default
+  /es/express/templates/: /es/express/templates/default
+  /fi/express/templates/: /fi/express/templates/default
+  /fr/express/templates/: /fr/express/templates/default
+  /it/express/templates/: /it/express/templates/default
+  /jp/express/templates/: /jp/express/templates/default
+  /kr/express/templates/: /kr/express/templates/default
+  /nl/express/templates/: /nl/express/templates/default
+  /no/express/templates/: /no/express/templates/default
+  /se/express/templates/: /se/express/templates/default
+  /tw/express/templates/: /tw/express/templates/default
+  /express/colors/: /express/colors/default
+  /br/express/colors/: /br/express/colors/default
+  /cn/express/colors/: /cn/express/colors/default
+  /de/express/colors/: /de/express/colors/default
+  /dk/express/colors/: /dk/express/colors/default
+  /es/express/colors/: /es/express/colors/default
+  /fi/express/colors/: /fi/express/colors/default
+  /fr/express/colors/: /fr/express/colors/default
+  /it/express/colors/: /it/express/colors/default
+  /jp/express/colors/: /jp/express/colors/default
+  /kr/express/colors/: /kr/express/colors/default
+  /nl/express/colors/: /nl/express/colors/default
+  /no/express/colors/: /no/express/colors/default
+  /se/express/colors/: /se/express/colors/default
+  /tw/express/colors/: /tw/express/colors/default


### PR DESCRIPTION
**Descriptions**
Added /colors pages
Both /colors pages and /templates are in each of their localized metadata sheet now.

No ticket

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/?lighthouse=on
- After: https://fstab-update--express--adobecom.hlx.page/express/?lighthouse=on
