### PR TITLE
Release Some Template-x Fixes

### DIFF
--- a/express/blocks/template-x/template-search-api-v3.js
+++ b/express/blocks/template-x/template-search-api-v3.js
@@ -26,6 +26,7 @@ function formatFilterString(filters) {
   const {
     animated,
     locales,
+    behaviors,
     premium,
     tasks,
     topics,
@@ -38,14 +39,18 @@ function formatFilterString(filters) {
       str += '&filters=licensingCategory==premium';
     }
   }
-  if (animated && animated !== 'all') {
+  if (animated && animated !== 'all' && !behaviors) {
     if (animated.toLowerCase() === 'false') {
       str += '&filters=behaviors==still';
     } else {
       str += '&filters=behaviors==animated';
     }
   }
-
+  if (behaviors) {
+    extractFilterTerms(behaviors).forEach((b) => {
+      str += `&filters=behaviors==${b}`;
+    });
+  }
   extractFilterTerms(tasks).forEach((t) => {
     str += `&filters=pages.task.name==${t}`;
   });
@@ -116,12 +121,12 @@ export async function fetchTemplates(props, fallback = true) {
   }
   const { filters: { tasks } } = props;
   if (tasks) {
-    response = await fetchSearchUrl({ ...props, filters: { tasks } });
+    response = await fetchSearchUrl({ ...props, filters: { tasks, premium: 'false' } });
     if (response?.metadata?.totalHits > 0) {
       return { response, fallbackMsg: await getFallbackMsg(tasks) };
     }
   }
-  response = await fetchSearchUrl({ ...props, filters: {} });
+  response = await fetchSearchUrl({ ...props, filters: { premium: 'false' } });
   return { response, fallbackMsg: await getFallbackMsg() };
 }
 

--- a/express/blocks/template-x/template-search-api-v3.js
+++ b/express/blocks/template-x/template-search-api-v3.js
@@ -119,14 +119,14 @@ export async function fetchTemplates(props, fallback = true) {
   if (!fallback) {
     return { response: null };
   }
-  const { filters: { tasks } } = props;
+  const { filters: { tasks, locales } } = props;
   if (tasks) {
-    response = await fetchSearchUrl({ ...props, filters: { tasks, premium: 'false' } });
+    response = await fetchSearchUrl({ ...props, filters: { tasks, locales, premium: 'false' } });
     if (response?.metadata?.totalHits > 0) {
       return { response, fallbackMsg: await getFallbackMsg(tasks) };
     }
   }
-  response = await fetchSearchUrl({ ...props, filters: { premium: 'false' } });
+  response = await fetchSearchUrl({ ...props, filters: { locales, premium: 'false' } });
   return { response, fallbackMsg: await getFallbackMsg() };
 }
 

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -185,7 +185,7 @@ function constructProps(block) {
 
       if (key && value) {
         // FIXME: facebook-post
-        if (['tasks', 'topics', 'locales'].includes(key) || (['premium', 'animated'].includes(key) && value.toLowerCase() !== 'all')) {
+        if (['tasks', 'topics', 'locales', 'behaviors'].includes(key) || (['premium', 'animated'].includes(key) && value.toLowerCase() !== 'all')) {
           props.filters[camelize(key)] = value;
         } else if (['yes', 'true', 'on', 'no', 'false', 'off'].includes(value.toLowerCase())) {
           props[camelize(key)] = ['yes', 'true', 'on'].includes(value.toLowerCase());


### PR DESCRIPTION
**Description:**
Adding behaviors param to template-x block
behaviors will always override animated param (old) if present
added fallback query with licensing set to free
added fallback query always inherit the locales

**Test URLs:**
- Before: https://main--express--adobecom.hlx.page/express/create/flyer/party?lighthouse=on
- After: https://stage--express--adobecom.hlx.page/express/create/flyer/party?lighthouse=on
When testing, stage preview url should see a lot less results as it validates the behaviors param, looking for only templates that are both **still** and **multiple-pages**
