### PR TITLE
[MWPW-132418] Fullscreen Marquee: fix large vertical img overflowing

### DIFF
--- a/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.css
+++ b/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.css
@@ -164,6 +164,7 @@ main .fullscreen-marquee-desktop .fullscreen-marquee-desktop-app-frame .fullscre
 
 main .fullscreen-marquee-desktop .fullscreen-marquee-desktop-app-frame .fullscreen-marquee-desktop-app img {
   vertical-align: middle;
+  max-height: 100%;
 }
 
 main .fullscreen-marquee-desktop .fullscreen-marquee-desktop-app-editor {


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix [MWPW-132418](https://jira.corp.adobe.com/browse/MWPW-132418)

**Description:**
Fixes the overflowing vertical images on fullscreen marquee.

**Test URLs:**
- Before: https://main--express--adobecom.hlx.page/de/express/create/card?lighthouse=on
- After: https://fullscreen-marquee-img-fix--express--adobecom.hlx.page/de/express/create/card?lighthouse=on
