### PR TITLE
[MWPW-133231] Download webp rendition from component directly in A.com pages

### DIFF
--- a/express/blocks/template-x/template-search-api-v3.js
+++ b/express/blocks/template-x/template-search-api-v3.js
@@ -142,7 +142,6 @@ function isValidBehaviors(behaviors) {
 }
 
 export function isValidTemplate(template) {
-  console.log(template)
   return !!(template.status === 'approved'
     && template.customLinks?.branchUrl
     && template['dc:title']?.['i-default']

--- a/express/blocks/template-x/template-search-api-v3.js
+++ b/express/blocks/template-x/template-search-api-v3.js
@@ -142,6 +142,7 @@ function isValidBehaviors(behaviors) {
 }
 
 export function isValidTemplate(template) {
+  console.log(template)
   return !!(template.status === 'approved'
     && template.customLinks?.branchUrl
     && template['dc:title']?.['i-default']


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix [MWPW-133231](https://jira.corp.adobe.com/browse/MWPW-133231)

**Description:**
Template X will now always prioritize component link over rendition link and fallback to rendition only when there isn't a rendition link.

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/templates/flyer/party?lighthouse=on
- After: https://mwpw-133231--express--adobecom.hlx.page/express/templates/flyer/party?lighthouse=on
