### PR TITLE
Mwpw 133909 and 133231 video use rendition link

### DIFF
--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -57,18 +57,18 @@ function widthToSize(widthHeightRatio, targetWidth) {
   return Math.round(targetWidth / widthHeightRatio);
 }
 
-function getImageThumbnailSrc(renditionLinkHref, page) {
+function getImageThumbnailSrc(renditionLinkHref, page, width) {
   const thumbnail = extractImageThumbnail(page);
-  return renditionLinkHref.replace(
-    '{&page,size,type,fragment}',
-    `&size=${widthToSize(getWidthHeightRatio(page), thumbnail.width)}&type=image/jpg&fragment=id=${thumbnail.componentId}`,
-  );
-}
+  if (page.rendition.image.thumbnail.mediaType === 'image/webp') {
+    return renditionLinkHref.replace(
+      '{&revision,component_id}',
+      `&revision=0&component_id=${thumbnail.componentId}`,
+    );
+  }
 
-function getImageCustomWidthSrc(renditionLinkHref, page, image) {
   return renditionLinkHref.replace(
     '{&page,size,type,fragment}',
-    `&size=${widthToSize(getWidthHeightRatio(page), 151)}&type=image/jpg&fragment=id=${image.componentId}`,
+    `&size=${widthToSize(getWidthHeightRatio(page), width || thumbnail.width)}&type=image/jpg&fragment=id=${thumbnail.componentId}`,
   );
 }
 
@@ -340,13 +340,12 @@ function renderHoverWrapper(template, placeholders, props) {
 
 function renderStillWrapper(template) {
   const stillWrapper = createTag('div', { class: 'still-wrapper' });
-  const firstPage = template.pages[0];
 
   const templateTitle = getTemplateTitle(template);
   const renditionLinkHref = template._links['http://ns.adobe.com/adobecloud/rel/rendition'].href;
 
-  const thumbnailImageHref = getImageCustomWidthSrc(renditionLinkHref,
-    template.pages[0], firstPage.rendition.image?.thumbnail);
+  const thumbnailImageHref = getImageThumbnailSrc(renditionLinkHref,
+    template.pages[0], 151);
 
   const imgWrapper = createTag('div', { class: 'image-wrapper' });
 
@@ -389,7 +388,7 @@ function renderStillWrapper(template) {
     imgWrapper.append(videoIcon);
   }
 
-  loadBetterAssetInBackground(img, firstPage);
+  loadBetterAssetInBackground(img, template.pages[0]);
 
   stillWrapper.append(imgWrapper);
   // TODO: API not ready for creator yet

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -57,18 +57,19 @@ function widthToSize(widthHeightRatio, targetWidth) {
   return Math.round(targetWidth / widthHeightRatio);
 }
 
-function getImageThumbnailSrc(renditionLinkHref, page, width) {
+function getImageThumbnailSrc(renditionLinkHref, page) {
   const thumbnail = extractImageThumbnail(page);
-  if (page.rendition.image.thumbnail.mediaType === 'image/webp') {
+  const { mediaType, componentId, width } = thumbnail;
+  if (mediaType === 'image/webp') {
     return renditionLinkHref.replace(
       '{&revision,component_id}',
-      `&revision=0&component_id=${thumbnail.componentId}`,
+      `&revision=0&component_id=${componentId}`,
     );
   }
 
   return renditionLinkHref.replace(
     '{&page,size,type,fragment}',
-    `&size=${widthToSize(getWidthHeightRatio(page), width || thumbnail.width)}&type=image/jpg&fragment=id=${thumbnail.componentId}`,
+    `&size=${width}&type=${mediaType}&fragment=id=${componentId}`,
   );
 }
 
@@ -344,8 +345,7 @@ function renderStillWrapper(template) {
   const templateTitle = getTemplateTitle(template);
   const renditionLinkHref = template._links['http://ns.adobe.com/adobecloud/rel/rendition'].href;
 
-  const thumbnailImageHref = getImageThumbnailSrc(renditionLinkHref,
-    template.pages[0], 151);
+  const thumbnailImageHref = getImageThumbnailSrc(renditionLinkHref, template.pages[0]);
 
   const imgWrapper = createTag('div', { class: 'image-wrapper' });
 
@@ -388,7 +388,8 @@ function renderStillWrapper(template) {
     imgWrapper.append(videoIcon);
   }
 
-  loadBetterAssetInBackground(img, template.pages[0]);
+  // keep it simple for now
+  // loadBetterAssetInBackground(img, template.pages[0]);
 
   stillWrapper.append(imgWrapper);
   // TODO: API not ready for creator yet


### PR DESCRIPTION
Resolves: [MWPW-133231](https://jira.corp.adobe.com/browse/MWPW-133231) and [MWPW-133909](https://jira.corp.adobe.com/browse/MWPW-133909)

All images and videos should now try to use renditionLink and fallback to componentLink now. For videos, the renditionLink will be first used to retrieve a cdn video url, and that cdn video url will be embedded as video src.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/jingle/template-x-animated?lighthouse=on
- After: https://mwpw-133909-video-use-rendition-link--express--adobecom.hlx.page/drafts/jingle/template-x-animated?lighthouse=on
