### PR TITLE
Delete Mismatching Sections by Data Device

### DIFF
--- a/express/blocks/fragment/fragment.js
+++ b/express/blocks/fragment/fragment.js
@@ -53,7 +53,7 @@ export default async function decorate(block) {
       const audience = fragmentSection.dataset?.audience;
       if (audience) {
         if (audience !== document.body.dataset?.device) {
-          fragmentSection.remove();
+          block.closest('.section').remove();
           return;
         }
         block.closest('.section').dataset.audience = audience;

--- a/express/blocks/fragment/fragment.js
+++ b/express/blocks/fragment/fragment.js
@@ -50,8 +50,13 @@ export default async function decorate(block) {
     const fragmentSection = fragment.querySelector(':scope .section');
 
     if (fragmentSection) {
-      if (fragmentSection.dataset.audience) {
-        block.closest('.section').dataset.audience = fragmentSection.dataset.audience;
+      const audience = fragmentSection.dataset?.audience;
+      if (audience) {
+        if (audience !== document.body.dataset?.device) {
+          fragmentSection.remove();
+          return;
+        }
+        block.closest('.section').dataset.audience = audience;
       }
 
       block.closest('.section').classList.add(...fragmentSection.classList);

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -465,7 +465,7 @@ export function readBlockConfig($block) {
   return config;
 }
 
-function deleteIrrelevantSections(main) {
+function removeIrrelevantSections(main) {
   main.querySelectorAll(':scope > div').forEach((section) => {
     const sectionMeta = section.querySelector('div.section-metadata');
     if (sectionMeta) {
@@ -2145,7 +2145,7 @@ function decoratePictures(main) {
 }
 
 export async function decorateMain(main) {
-  deleteIrrelevantSections(main);
+  removeIrrelevantSections(main);
   await buildAutoBlocks(main);
   splitSections(main);
   decorateSections(main);

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1860,26 +1860,12 @@ async function buildAutoBlocks($main) {
     if (!window.floatingCtasLoaded) {
       const floatingCTAData = await fetchFloatingCta(window.location.pathname);
       const validButtonVersion = ['floating-button', 'multifunction-button', 'bubble-ui-button', 'floating-panel'];
-      let desktopButton;
-      let mobileButton;
-
-      if (floatingCTAData) {
-        const buttonTypes = {
-          desktop: floatingCTAData.desktop,
-          mobile: floatingCTAData.mobile,
-        };
-
-        desktopButton = validButtonVersion.includes(buttonTypes.desktop) ? buildBlock(buttonTypes.desktop, 'desktop') : null;
-        mobileButton = validButtonVersion.includes(buttonTypes.mobile) ? buildBlock(buttonTypes.mobile, 'mobile') : null;
-
-        [desktopButton, mobileButton].forEach((button) => {
-          if (button) {
-            button.classList.add('spreadsheet-powered');
-            if ($lastDiv) {
-              $lastDiv.append(button);
-            }
-          }
-        });
+      const device = document.body.dataset?.device;
+      const blockName = floatingCTAData?.[device];
+      if (validButtonVersion.includes(blockName) && $lastDiv) {
+        const button = buildBlock(blockName, device);
+        button.classList.add('spreadsheet-powered');
+        $lastDiv.append(button);
       }
 
       window.floatingCtasLoaded = true;

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -499,8 +499,6 @@ export function decorateSections($main) {
           section.id = toClassName(meta.anchor);
         } else if (key === 'background') {
           section.style.background = meta.background;
-        } else if (key === 'audience' && meta[key] && meta[key] !== document.body.dataset?.device) {
-          section.remove();
         } else {
           section.dataset[key] = meta[key];
         }
@@ -2353,6 +2351,15 @@ async function loadEager() {
     displayEnv();
     displayOldLinkWarning();
     wordBreakJapanese();
+
+    main
+      .querySelectorAll('div.section')
+      .forEach((section) => {
+        const audience = section.dataset?.audience;
+        if (audience && audience !== document.body.dataset?.device) {
+          section.remove();
+        }
+      });
 
     const lcpBlocks = ['columns', 'hero-animation', 'hero-3d', 'template-list', 'template-x', 'floating-button', 'fullscreen-marquee', 'fullscreen-marquee-desktop', 'collapsible-card', 'search-marquee'];
     const block = document.querySelector('.block');

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -499,6 +499,8 @@ export function decorateSections($main) {
           section.id = toClassName(meta.anchor);
         } else if (key === 'background') {
           section.style.background = meta.background;
+        } else if (key === 'audience' && meta[key] && meta[key] !== document.body.dataset?.device) {
+          section.remove();
         } else {
           section.dataset[key] = meta[key];
         }
@@ -2351,15 +2353,6 @@ async function loadEager() {
     displayEnv();
     displayOldLinkWarning();
     wordBreakJapanese();
-
-    main
-      .querySelectorAll('div.section')
-      .forEach((section) => {
-        const audience = section.dataset?.audience;
-        if (audience && audience !== document.body.dataset?.device) {
-          section.remove();
-        }
-      });
 
     const lcpBlocks = ['columns', 'hero-animation', 'hero-3d', 'template-list', 'template-x', 'floating-button', 'fullscreen-marquee', 'fullscreen-marquee-desktop', 'collapsible-card', 'search-marquee'];
     const block = document.querySelector('.block');

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -2352,14 +2352,19 @@ async function loadEager() {
     displayOldLinkWarning();
     wordBreakJapanese();
 
+    main
+      .querySelectorAll('div.section')
+      .forEach((section) => {
+        const audience = section.dataset?.audience;
+        if (audience && audience !== document.body.dataset?.device) {
+          section.remove();
+        }
+      });
+
     const lcpBlocks = ['columns', 'hero-animation', 'hero-3d', 'template-list', 'template-x', 'floating-button', 'fullscreen-marquee', 'fullscreen-marquee-desktop', 'collapsible-card', 'search-marquee'];
-    const blocks = document.querySelectorAll('.block');
-    const firstVisualBlock = Array.from(blocks).find((b) => {
-      const { audience } = b.closest('.section')?.dataset || {};
-      return audience === document.body.dataset.device;
-    });
-    const hasLCPBlock = (firstVisualBlock && lcpBlocks.includes(firstVisualBlock.getAttribute('data-block-name')));
-    if (hasLCPBlock) await loadBlock(firstVisualBlock, true);
+    const block = document.querySelector('.block');
+    const hasLCPBlock = (block && lcpBlocks.includes(block.getAttribute('data-block-name')));
+    if (hasLCPBlock) await loadBlock(block, true);
 
     document.querySelector('body').classList.add('appear');
 


### PR DESCRIPTION
Resolves: https://jira.corp.adobe.com/browse/MWPW-133990?filter=381833

We should no longer see sections labelled with data-audience=mobile on desktop and data-audience=desktop on mobile.

Note: I attempted updating the decorateSections() to do the removal there, but we will have some mysterious padding that I suspect caused by splitSections(). So I did it the fast way, but in the future we should look into decoupling them and removing sections before even decorating them for performance enhancement.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/templates/banner/gaming?lighthouse=on
- After: https://del-secs-by-device--express--adobecom.hlx.page/express/templates/banner/gaming?lighthouse=on

Another pair of pages to see the difference:
- Before: https://stage--express--adobecom.hlx.page/express/create/chart?lighthouse=on
- After: https://del-secs-by-device--express--adobecom.hlx.page/express/create/chart?lighthouse=on
