### PR TITLE
[MWPW-133250] CTA-Carousel: Gen AI followup Elements

### DIFF
--- a/express/blocks/cta-carousel/cta-carousel.css
+++ b/express/blocks/cta-carousel/cta-carousel.css
@@ -37,6 +37,11 @@
     position: relative;
 }
 
+.cta-carousel .card.coming-soon {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
 .cta-carousel .card:first-of-type {
     margin-left: 0;
 }
@@ -60,7 +65,6 @@
 }
 
 .cta-carousel.gen-ai .card .card-sleeve .gen-ai-input-form {
-    position: relative;
     background-color: var(--color-info-accent-light);
     border-radius: 8px;
     box-sizing: border-box;
@@ -80,16 +84,34 @@
     height: 100%;
 }
 
+.cta-carousel.gen-ai .card.gen-ai-action .card-sleeve .gen-ai-input-form .gen-ai-form-wrapper {
+    background: white;
+    padding: 12px;
+    gap: 8px;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    box-sizing: border-box;
+    border-radius: 8px;
+    border: 2px solid var(--color-info-accent);
+}
+
 .cta-carousel.gen-ai .gen-ai-input {
     box-sizing: border-box;
     border-radius: 8px;
-    padding: 16px;
-    border: 2px solid var(--color-info-accent);
+    border: none;
     font-family: var(--body-font-family);
     font-size: var(--body-font-size-m);
     resize: none;
     height: 100%;
     width: 100%;
+}
+
+.cta-carousel.gen-ai .gen-ai-input:active,
+.cta-carousel.gen-ai .gen-ai-input:focus-visible {
+    border: none;
+    outline: none;
 }
 
 .cta-carousel.gen-ai .card .card-sleeve .gen-ai-input-form .gen-ai-input::placeholder {
@@ -99,7 +121,6 @@
 }
 
 .cta-carousel.gen-ai .card .gen-ai-input-form .gen-ai-submit {
-    position: absolute;
     left: 40px;
     bottom: 40px;
     color: var(--color-white);
@@ -115,7 +136,6 @@
 }
 
 .cta-carousel.quick-action .card.gen-ai-action .card-sleeve .gen-ai-input-form .gen-ai-submit {
-    position: absolute;
     left: 56px;
     bottom: 24px;
 }
@@ -158,7 +178,7 @@
     width: max-content;
 }
 
-.cta-carousel.quick-action .card .card-sleeve .links-wrapper a.clickable-overlay {
+.cta-carousel .card .card-sleeve .links-wrapper a.clickable-overlay {
     padding: 0;
     border-radius: 0;
     border: none;
@@ -168,7 +188,7 @@
     width: 100%;
 }
 
-.cta-carousel .card .card-sleeve .links-wrapper a:nth-of-type(1) {
+.cta-carousel .card .card-sleeve .links-wrapper a:nth-of-type(1):not(.clickable-overlay) {
     border: solid 2px var(--color-white);
     background-color: var(--color-white);
     color: var(--body-color);
@@ -267,6 +287,14 @@
     background-color: #DEDEF9;
     color: var(--color-info-accent);
     border-radius: 4px;
+}
+
+.cta-carousel.create .carousel-container .carousel-fader-left a,
+.cta-carousel.create .carousel-container .carousel-fader-right a,
+.cta-carousel.quick-action .carousel-container .carousel-fader-left a,
+.cta-carousel.quick-action .carousel-container .carousel-fader-right a {
+    position: absolute;
+    top: 64px;
 }
 
 @media (min-width: 900px) {

--- a/express/blocks/cta-carousel/cta-carousel.css
+++ b/express/blocks/cta-carousel/cta-carousel.css
@@ -236,7 +236,7 @@
     opacity: 0;
 }
 
-.cta-carousel.gen-ai:not(.quick-action) .card:hover .text-wrapper {
+.cta-carousel.gen-ai:not(.quick-action) .card:not(.gen-ai-action):hover .text-wrapper {
     opacity: 1;
 }
 

--- a/express/blocks/cta-carousel/cta-carousel.css
+++ b/express/blocks/cta-carousel/cta-carousel.css
@@ -48,10 +48,67 @@
     overflow: hidden;
 }
 
+.cta-carousel.quick-action .card.gen-ai-action .card-sleeve {
+    width: 511px;
+    display: flex;
+}
+
+.cta-carousel.quick-action .card.gen-ai-action .card-sleeve .gen-ai-input-form {
+    position: relative;
+    background-color: var(--color-info-accent-light);
+    border-radius: 8px;
+    padding: 10px 16px 10px 40px;
+    margin-left: -24px;
+    width: 287px;
+}
+
+.cta-carousel.quick-action .card.gen-ai-action .card-sleeve .gen-ai-input-form .gen-ai-input {
+    box-sizing: border-box;
+    border-radius: 8px;
+    padding: 10px 16px;
+    border: 2px solid var(--color-info-accent);
+    font-family: var(--body-font-family);
+    font-size: var(--body-font-size-m);
+    resize: none;
+    height: 100%;
+    width: 100%;
+}
+
+.cta-carousel.quick-action .card.gen-ai-action .card-sleeve .gen-ai-input-form .gen-ai-input::placeholder {
+    font-style: italic;
+    font-family: var(--body-font-family);
+    font-size: var(--body-font-size-m);
+}
+
+.cta-carousel.quick-action .card.gen-ai-action .card-sleeve .gen-ai-input-form .gen-ai-submit {
+    position: absolute;
+    left: 56px;
+    bottom: 24px;
+    color: var(--color-white);
+    background-color: var(--color-info-accent);
+    border-style: none;
+    font-family: var(--body-font-family);
+    font-size: var(--body-font-size-s);
+    font-weight: 700;
+    padding: 10px 1.5em 10px 1.5em;
+    border-radius: 22px;
+    cursor: pointer;
+    transition: background-color .2s;
+}
+
+.cta-carousel.quick-action .card.gen-ai-action .card-sleeve .gen-ai-input-form .gen-ai-submit:not(:disabled):hover {
+    background-color: var(--color-info-accent-hover);
+}
+
+.cta-carousel.quick-action .card.gen-ai-action .card-sleeve .gen-ai-input-form .gen-ai-submit:disabled {
+    background-color: var(--color-gray-200);
+    color: var(--color-gray-500);
+}
+
 .cta-carousel .card .card-sleeve .media-wrapper {
     position: relative;
     height: 100%;
-    width: 100%;
+    width: 200px;
 }
 
 .cta-carousel .card .card-sleeve .links-wrapper {
@@ -61,7 +118,7 @@
     justify-content: center;
     top: 0;
     height: 100%;
-    width: 100%;
+    width: 200px;
     background-color: #00000050;
     opacity: 0;
     z-index: 1;
@@ -112,6 +169,7 @@
     display: block;
     height: 100%;
     width: 100%;
+    border-radius: 8px;
 }
 
 .cta-carousel .card .card-sleeve .media-wrapper img.icon {

--- a/express/blocks/cta-carousel/cta-carousel.css
+++ b/express/blocks/cta-carousel/cta-carousel.css
@@ -34,6 +34,7 @@
 
 .cta-carousel .card {
     margin: 0 8px;
+    position: relative;
 }
 
 .cta-carousel .card:first-of-type {
@@ -48,24 +49,43 @@
     overflow: hidden;
 }
 
+.cta-carousel.gen-ai:not(.quick-action) .card .card-sleeve {
+    height: 200px;
+    width: unset;
+}
+
 .cta-carousel.quick-action .card.gen-ai-action .card-sleeve {
     width: 511px;
     display: flex;
 }
 
+.cta-carousel.gen-ai .gen-ai-input-form,
 .cta-carousel.quick-action .card.gen-ai-action .card-sleeve .gen-ai-input-form {
     position: relative;
     background-color: var(--color-info-accent-light);
     border-radius: 8px;
-    padding: 10px 16px 10px 40px;
-    margin-left: -24px;
-    width: 287px;
+    box-sizing: border-box;
+    margin: auto;
 }
 
-.cta-carousel.quick-action .card.gen-ai-action .card-sleeve .gen-ai-input-form .gen-ai-input {
+.cta-carousel.gen-ai .gen-ai-input-form {
+    width: 305px;
+    height: 200px;
+    padding: 24px;
+    margin: 0 16px 0 0;
+}
+
+.cta-carousel.quick-action .card.gen-ai-action .card-sleeve .gen-ai-input-form {
+    margin-left: -24px;
+    width: 335px;
+    padding: 10px 16px 10px 40px;
+    height: 100%;
+}
+
+.cta-carousel .gen-ai-input {
     box-sizing: border-box;
     border-radius: 8px;
-    padding: 10px 16px;
+    padding: 16px;
     border: 2px solid var(--color-info-accent);
     font-family: var(--body-font-family);
     font-size: var(--body-font-size-m);
@@ -78,6 +98,22 @@
     font-style: italic;
     font-family: var(--body-font-family);
     font-size: var(--body-font-size-m);
+}
+
+.cta-carousel.gen-ai .gen-ai-input-form .gen-ai-submit {
+    position: absolute;
+    left: 40px;
+    bottom: 40px;
+    color: var(--color-white);
+    background-color: var(--color-info-accent);
+    border-style: none;
+    font-family: var(--body-font-family);
+    font-size: var(--body-font-size-s);
+    font-weight: 700;
+    padding: 10px 1.5em 10px 1.5em;
+    border-radius: 22px;
+    cursor: pointer;
+    transition: background-color .2s;
 }
 
 .cta-carousel.quick-action .card.gen-ai-action .card-sleeve .gen-ai-input-form .gen-ai-submit {
@@ -96,10 +132,11 @@
     transition: background-color .2s;
 }
 
-.cta-carousel.quick-action .card.gen-ai-action .card-sleeve .gen-ai-input-form .gen-ai-submit:not(:disabled):hover {
+.cta-carousel .gen-ai-input-form .gen-ai-submit:not(:disabled):hover {
     background-color: var(--color-info-accent-hover);
 }
 
+.cta-carousel .gen-ai-input-form .gen-ai-submit:disabled,
 .cta-carousel.quick-action .card.gen-ai-action .card-sleeve .gen-ai-input-form .gen-ai-submit:disabled {
     background-color: var(--color-gray-200);
     color: var(--color-gray-500);
@@ -172,6 +209,22 @@
     border-radius: 8px;
 }
 
+.cta-carousel.gen-ai:not(.quick-action) .card .card-sleeve {
+    width: auto;
+}
+
+.cta-carousel.gen-ai:not(.quick-action) .card .card-sleeve .media-wrapper,
+.cta-carousel.gen-ai:not(.quick-action) .card .card-sleeve .links-wrapper {
+    width: 100%;
+}
+
+.cta-carousel.gen-ai:not(.quick-action) .card .card-sleeve picture,
+.cta-carousel.gen-ai:not(.quick-action) .card .card-sleeve picture img,
+.cta-carousel.gen-ai:not(.quick-action) .card .card-sleeve video {
+    position: static;
+    width: auto;
+}
+
 .cta-carousel .card .card-sleeve .media-wrapper img.icon {
     position: absolute;
     display: block;
@@ -185,6 +238,19 @@
     bottom: 12px;
     left: 12px;
     z-index: 1;
+}
+
+.cta-carousel.gen-ai:not(.quick-action) .cta-carousel-cards .text-wrapper {
+    position: absolute;
+    top: 8px;
+    left: 16px;
+    color: var(--color-white);
+    transition: opacity .2s;
+    opacity: 0;
+}
+
+.cta-carousel.gen-ai:not(.quick-action) .card:hover .text-wrapper {
+    opacity: 1;
 }
 
 .cta-carousel .card .text-wrapper .cta-card-text {

--- a/express/blocks/cta-carousel/cta-carousel.css
+++ b/express/blocks/cta-carousel/cta-carousel.css
@@ -59,8 +59,7 @@
     display: flex;
 }
 
-.cta-carousel.gen-ai .gen-ai-input-form,
-.cta-carousel.quick-action .card.gen-ai-action .card-sleeve .gen-ai-input-form {
+.cta-carousel.gen-ai .card .card-sleeve .gen-ai-input-form {
     position: relative;
     background-color: var(--color-info-accent-light);
     border-radius: 8px;
@@ -72,7 +71,6 @@
     width: 305px;
     height: 200px;
     padding: 24px;
-    margin: 0 16px 0 0;
 }
 
 .cta-carousel.quick-action .card.gen-ai-action .card-sleeve .gen-ai-input-form {
@@ -82,7 +80,7 @@
     height: 100%;
 }
 
-.cta-carousel .gen-ai-input {
+.cta-carousel.gen-ai .gen-ai-input {
     box-sizing: border-box;
     border-radius: 8px;
     padding: 16px;
@@ -94,13 +92,13 @@
     width: 100%;
 }
 
-.cta-carousel.quick-action .card.gen-ai-action .card-sleeve .gen-ai-input-form .gen-ai-input::placeholder {
+.cta-carousel.gen-ai .card .card-sleeve .gen-ai-input-form .gen-ai-input::placeholder {
     font-style: italic;
     font-family: var(--body-font-family);
     font-size: var(--body-font-size-m);
 }
 
-.cta-carousel.gen-ai .gen-ai-input-form .gen-ai-submit {
+.cta-carousel.gen-ai .card .gen-ai-input-form .gen-ai-submit {
     position: absolute;
     left: 40px;
     bottom: 40px;
@@ -120,24 +118,13 @@
     position: absolute;
     left: 56px;
     bottom: 24px;
-    color: var(--color-white);
-    background-color: var(--color-info-accent);
-    border-style: none;
-    font-family: var(--body-font-family);
-    font-size: var(--body-font-size-s);
-    font-weight: 700;
-    padding: 10px 1.5em 10px 1.5em;
-    border-radius: 22px;
-    cursor: pointer;
-    transition: background-color .2s;
 }
 
-.cta-carousel .gen-ai-input-form .gen-ai-submit:not(:disabled):hover {
+.cta-carousel.gen-ai .gen-ai-input-form .gen-ai-submit:not(:disabled):hover {
     background-color: var(--color-info-accent-hover);
 }
 
-.cta-carousel .gen-ai-input-form .gen-ai-submit:disabled,
-.cta-carousel.quick-action .card.gen-ai-action .card-sleeve .gen-ai-input-form .gen-ai-submit:disabled {
+.cta-carousel.gen-ai .card .card-sleeve .gen-ai-input-form .gen-ai-submit:disabled {
     background-color: var(--color-gray-200);
     color: var(--color-gray-500);
 }

--- a/express/blocks/cta-carousel/cta-carousel.js
+++ b/express/blocks/cta-carousel/cta-carousel.js
@@ -106,7 +106,7 @@ function buildGenAIForm(ctaObj) {
   genAIInput.addEventListener('keyup', (e) => {
     if (e.key === 'Enter') {
       e.preventDefault();
-      handleGenAISubmit(genAIForm, ctaObj.ctaLinks[0]);
+      handleGenAISubmit(genAIForm, ctaObj.ctaLinks[0].href);
     } else {
       genAISubmit.disabled = genAIInput.value === '';
     }
@@ -114,7 +114,7 @@ function buildGenAIForm(ctaObj) {
 
   genAIForm.addEventListener('submit', (e) => {
     e.preventDefault();
-    handleGenAISubmit(genAIForm, ctaObj.ctaLinks[0]);
+    handleGenAISubmit(genAIForm, ctaObj.ctaLinks[0].href);
   });
 
   return genAIForm;

--- a/express/blocks/cta-carousel/cta-carousel.js
+++ b/express/blocks/cta-carousel/cta-carousel.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { createTag, transformLinkToAnimation, } from '../../scripts/scripts.js';
+import { createTag, transformLinkToAnimation } from '../../scripts/scripts.js';
 
 import { buildCarousel } from '../shared/carousel.js';
 
@@ -26,9 +26,7 @@ function sanitizeInput(string) {
     '=': '&#x3D;',
   };
 
-  return string.replace(/[&<>"'`=/]/g, (s) => {
-    return charMap[s];
-  });
+  return string.replace(/[&<>"'`=/]/g, (s) => charMap[s]);
 }
 
 function decorateTextWithTag(textSource) {
@@ -87,10 +85,10 @@ function handleGenAISubmit(form, link) {
 
 function buildGenAIForm(ctaObj) {
   const genAIForm = createTag('form', { class: 'gen-ai-input-form' });
+  const formWrapper = createTag('div', { class: 'gen-ai-form-wrapper' });
   const genAIInput = createTag('textarea', {
     class: 'gen-ai-input',
     placeholder: ctaObj.subtext || '',
-    maxlength: 56,
   });
   const genAISubmit = createTag('button', {
     class: 'gen-ai-submit',
@@ -98,7 +96,8 @@ function buildGenAIForm(ctaObj) {
     disabled: true,
   });
 
-  genAIForm.append(genAIInput, genAISubmit);
+  genAIForm.append(formWrapper);
+  formWrapper.append(genAIInput, genAISubmit);
 
   genAISubmit.textContent = ctaObj.ctaLinks[0].textContent;
   genAISubmit.disabled = genAIInput.value === '';
@@ -158,7 +157,7 @@ export async function decorateCards(block, payload) {
         linksWrapper.remove();
       }
 
-      if (block.classList.contains('quick-action') && cta.ctaLinks.length === 1) {
+      if ((block.classList.contains('quick-action') || block.classList.contains('gen-ai')) && cta.ctaLinks.length === 1) {
         cta.ctaLinks[0].textContent = '';
         cta.ctaLinks[0].classList.add('clickable-overlay');
       }
@@ -166,6 +165,8 @@ export async function decorateCards(block, payload) {
       cta.ctaLinks.forEach((a) => {
         linksWrapper.append(a);
       });
+    } else {
+      card.classList.add('coming-soon');
     }
 
     if (cta.text) {
@@ -204,7 +205,7 @@ function constructPayload(block) {
       image: row.querySelector(':scope > div:nth-of-type(1) picture'),
       videoLink: row.querySelector(':scope > div:nth-of-type(1) a'),
       icon: row.querySelector(':scope > div:nth-of-type(1) img.icon'),
-      text: row.querySelector(':scope > div:nth-of-type(2) p:not(.button-container)')?.textContent.trim(),
+      text: row.querySelector(':scope > div:nth-of-type(2) p:not(.button-container), :scope > div:nth-of-type(2) > *:first-of-type')?.textContent.trim(),
       subtext: row.querySelector(':scope > div:nth-of-type(2) p:not(.button-container) em')?.textContent.trim(),
       ctaLinks: row.querySelectorAll(':scope > div:nth-of-type(2) a'),
     };

--- a/express/blocks/cta-carousel/cta-carousel.js
+++ b/express/blocks/cta-carousel/cta-carousel.js
@@ -100,7 +100,7 @@ export async function decorateCards(block, payload) {
         });
 
         card.classList.add('gen-ai-action');
-        genAISubmit.textContent = cta.ctaLinks[0].textContent || placeholders['generate'];
+        genAISubmit.textContent = cta.ctaLinks[0].textContent || placeholders.generate;
         linksWrapper.remove();
 
         const handleGenAISubmit = () => {
@@ -108,7 +108,7 @@ export async function decorateCards(block, payload) {
           const genAILinkTemplate = cta.ctaLinks[0].href || placeholders['gen-ai-link-template'];
           const genAILink = genAILinkTemplate.replace('%7B%7Bprompt-text%7D%7D', genAIInput.value.replaceAll(' ', '+'));
           if (genAILink !== '') window.location.assign(genAILink);
-        }
+        };
 
         genAIInput.addEventListener('keyup', (e) => {
           if (e.key === 'Enter') {
@@ -126,24 +126,6 @@ export async function decorateCards(block, payload) {
 
         genAIForm.append(genAIInput, genAISubmit);
         cardSleeve.append(genAIForm);
-      }
-
-      if (block.classList.contains('gen-ai') && !block.classList.contains('quick-action') {
-        const genAIForm = createTag('form', { class: 'gen-ai-input-form' });
-        const genAIInput = createTag('textarea', {
-          class: 'gen-ai-input',
-          placeholder: placeholders['gen-ai-input-placeholder'],
-          maxlength: 70,
-        });
-        const genAISubmit = createTag('button', {
-          class: 'gen-ai-submit',
-          type: 'submit',
-          disabled: true,
-        });
-
-        card.classList.add('gen-ai-action');
-        genAISubmit.textContent = placeholders['generate'];
-        cards.prepend(genAIForm)
       }
 
       if (block.classList.contains('quick-action') && cta.ctaLinks.length === 1) {
@@ -164,6 +146,45 @@ export async function decorateCards(block, payload) {
       const subtext = createTag('p', { class: 'subtext' });
       subtext.textContent = cta.subtext;
       textWrapper.append(subtext);
+    }
+
+    if (block.classList.contains('gen-ai') && !block.classList.contains('quick-action') && index === 0) {
+      const genAIForm = createTag('form', { class: 'gen-ai-input-form' });
+      const genAIInput = createTag('textarea', {
+        class: 'gen-ai-input',
+        placeholder: placeholders['gen-ai-input-placeholder'],
+        maxlength: 70,
+      });
+      const genAISubmit = createTag('button', {
+        class: 'gen-ai-submit',
+        type: 'submit',
+        disabled: true,
+      });
+
+      const handleGenAISubmit = () => {
+        genAISubmit.disabled = true;
+        const genAILinkTemplate = placeholders['gen-ai-link-template'];
+        const genAILink = genAILinkTemplate.replace('%7B%7Bprompt-text%7D%7D', genAIInput.value.replaceAll(' ', '+'));
+        if (genAILink !== '') window.location.assign(genAILink);
+      };
+
+      genAIInput.addEventListener('keyup', (e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          handleGenAISubmit();
+        } else {
+          genAISubmit.disabled = genAIInput.value === '';
+        }
+      }, { passive: true });
+
+      genAIForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        handleGenAISubmit();
+      });
+
+      genAISubmit.textContent = placeholders.generate;
+      genAIForm.append(genAIInput, genAISubmit);
+      cards.prepend(genAIForm);
     }
 
     cards.append(card);
@@ -208,5 +229,5 @@ export default async function decorate(block) {
 
   decorateHeading(block, payload);
   await decorateCards(block, payload);
-  buildCarousel('.card, .gen-ai-input-form', block, false);
+  buildCarousel('', block.querySelector('.cta-carousel-cards'), false);
 }

--- a/express/blocks/cta-carousel/cta-carousel.js
+++ b/express/blocks/cta-carousel/cta-carousel.js
@@ -91,7 +91,7 @@ export async function decorateCards(block, payload) {
         const genAIInput = createTag('textarea', {
           class: 'gen-ai-input',
           placeholder: placeholders['gen-ai-input-placeholder'],
-          maxlength: 70,
+          maxlength: 56,
         });
         const genAISubmit = createTag('button', {
           class: 'gen-ai-submit',

--- a/express/blocks/cta-carousel/cta-carousel.js
+++ b/express/blocks/cta-carousel/cta-carousel.js
@@ -17,6 +17,23 @@ import {
 
 import { buildCarousel } from '../shared/carousel.js';
 
+function sanitizeInput(string) {
+  const charMap = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+    '/': '&#x2F;',
+    '`': '&#x60;',
+    '=': '&#x3D;',
+  };
+
+  return string.replace(/[&<>"'`=/]/g, (s) => {
+    return charMap[s];
+  });
+}
+
 function decorateTextWithTag(textSource) {
   const text = createTag('p', { class: 'cta-card-text' });
   const tagText = textSource.match(/\[(.*?)]/);
@@ -106,7 +123,7 @@ export async function decorateCards(block, payload) {
         const handleGenAISubmit = () => {
           genAISubmit.disabled = true;
           const genAILinkTemplate = cta.ctaLinks[0].href || placeholders['gen-ai-link-template'];
-          const genAILink = genAILinkTemplate.replace('%7B%7Bprompt-text%7D%7D', genAIInput.value.replaceAll(' ', '+'));
+          const genAILink = genAILinkTemplate.replace('%7B%7Bprompt-text%7D%7D', sanitizeInput(genAIInput.value).replaceAll(' ', '+'));
           if (genAILink !== '') window.location.assign(genAILink);
         };
 
@@ -164,7 +181,7 @@ export async function decorateCards(block, payload) {
       const handleGenAISubmit = () => {
         genAISubmit.disabled = true;
         const genAILinkTemplate = placeholders['gen-ai-link-template'];
-        const genAILink = genAILinkTemplate.replace('%7B%7Bprompt-text%7D%7D', genAIInput.value.replaceAll(' ', '+'));
+        const genAILink = genAILinkTemplate.replace('%7B%7Bprompt-text%7D%7D', sanitizeInput(genAIInput.value).replaceAll(' ', '+'));
         if (genAILink !== '') window.location.assign(genAILink);
       };
 

--- a/express/blocks/cta-carousel/cta-carousel.js
+++ b/express/blocks/cta-carousel/cta-carousel.js
@@ -101,12 +101,12 @@ function buildGenAIForm(ctaObj) {
   genAIForm.append(genAIInput, genAISubmit);
 
   genAISubmit.textContent = ctaObj.ctaLinks[0].textContent;
-  genAISubmit.disabled = genAIInput.value === ''
+  genAISubmit.disabled = genAIInput.value === '';
 
   genAIInput.addEventListener('keyup', (e) => {
     if (e.key === 'Enter') {
       e.preventDefault();
-      handleGenAISubmit(genAIForm, genAISubmit.textContent);
+      handleGenAISubmit(genAIForm, ctaObj.ctaLinks[0]);
     } else {
       genAISubmit.disabled = genAIInput.value === '';
     }
@@ -114,7 +114,7 @@ function buildGenAIForm(ctaObj) {
 
   genAIForm.addEventListener('submit', (e) => {
     e.preventDefault();
-    handleGenAISubmit(genAIForm, genAISubmit.textContent);
+    handleGenAISubmit(genAIForm, ctaObj.ctaLinks[0]);
   });
 
   return genAIForm;


### PR DESCRIPTION
Resolves: [MWPW-133250](https://jira.corp.adobe.com/browse/MWPW-133250)

This follow up feature allows Gen AI frictionless experience to be added to the cta carousel.
The quick-action variant combined with the gen-ai variant will shoe-horn a gen-ai input field into the first card
A gen-ai alone variant will generate the carousel with variable width cards and prepend a stand-alone gen-ai input at the beginning.

Both gen AI inputs will redirect people to the product with a prompt param value replaced with what's in the input, joined by '+'

**Update:** We are not using placeholders anymore as the input fields needs to be more dynamic than 1 per locale.
In the quick-action + gen-ai variant, since the input is appended to the first card, the generate link and the generate text will first be attempted to be fetched from the first card's first link.

**Update 2:**
- Added no-link card turning into coming-soon version (grayed out and non-interactive)
- Added gen-ai form wrapper to make generate button stack and the form scroll above the generate button (same as product)
- Single CTA gen-ai card also has clickable overlay
- remove maxlength in gen-ai input
- Tweaked the carousel button position for create and quick-action variants

In the gen-ai variant in general, any card without any media in the first column will have the mapping as follow:
- The first CTA's text be mapped to the Generate button text
- The first CTA's link be the Gen AI link
- The italic text (sub-text) will become the placeholder text

When previewing, please make sure to toggle to the Generative AI tab using the toggle bar.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/qiyundai/homepage-v3/sandbox?lighthouse=on
- After: https://mwpw-133250-branch--express--adobecom.hlx.page/drafts/qiyundai/homepage-v3/sandbox?lighthouse=on
