### PR TITLE
MWPW-129069 Template-List Remove API-Returned Bad Templates

### DIFF
--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -214,7 +214,7 @@ async function processResponse(props) {
   }
 
   if (templateFetched) {
-    return templateFetched.map((template) => {
+    return templateFetched.filter((template) => !!template.branchURL).map((template) => {
       const $template = createTag('div');
       const imgWrapper = createTag('div');
 


### PR DESCRIPTION
The content-api-v2 sometimes returns templates without branchURL, resulting in the word undefined bleeding into the pages. This code change will filter out such bad templates and make sure only templates having a branchURL gets rendered. Opening these urls and click **Load More** 3 times, and do a search in Elements panel of your Dev tool, you should see that the old branch contains undefined for some templates but it's gone in the new feature branch

Resolves: https://jira.corp.adobe.com/browse/MWPW-129069

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/templates/certificate/award?lighthouse=on
- After: https://filter-template-list-bad-templates--express--adobecom.hlx.page/express/templates/certificate/award?lighthouse=on
