### PR TITLE
Template-x 2 fallback strategies

### DIFF
--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -32,7 +32,7 @@ import { Masonry } from '../shared/masonry.js';
 
 import { buildCarousel } from '../shared/carousel.js';
 
-import { fetchTemplates, isValidTemplate } from './template-search-api-v3.js';
+import { fetchTemplates, isValidTemplate, fetchTemplatesCategoryCount } from './template-search-api-v3.js';
 import renderTemplate from './template-rendering.js';
 import fetchAllTemplatesMetadata from '../../scripts/all-templates-metadata.js';
 
@@ -1280,14 +1280,9 @@ async function appendCategoryTemplatesCount(block, props) {
     const anchor = li.querySelector('a');
     if (anchor) {
       const countSpan = createTag('span', { class: 'category-list-template-count' });
-      tempProps.filters.tasks = anchor.dataset.tasks;
       // eslint-disable-next-line no-await-in-loop
-      const { response } = await fetchTemplates(tempProps, false);
-      if (!response?.metadata?.totalHits) {
-        countSpan.textContent = '(0)';
-      } else {
-        countSpan.textContent = `(${response.metadata.totalHits.toLocaleString(lang)})`;
-      }
+      const cnt = await fetchTemplatesCategoryCount(props, anchor.dataset.tasks);
+      countSpan.textContent = `(${cnt.toLocaleString(lang)})`;
       anchor.append(countSpan);
     }
   }


### PR DESCRIPTION
Resolves: https://jira.corp.adobe.com/browse/MWPW-134418

Now use 2 queries to satisfy the requirement of using a backup language when localized content is not enough. You should still more localized templates on the branch link.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/jp/express/create/logo/instagram?lighthouse=on
- After: https://template-x-backup-locale--express--adobecom.hlx.page/jp/express/create/logo/instagram?lighthouse=on
Extra urls:
https://stage--express--adobecom.hlx.page/drafts/qiyundai/template-x/online-portfolio?lighthouse=on
https://template-x-backup-locale--express--adobecom.hlx.page/drafts/qiyundai/template-x/online-portfolio?lighthouse=on
