### PR TITLE
Fix TemplateX Search Flash MWPW-134490

### DIFF
--- a/express/scripts/content-replace.js
+++ b/express/scripts/content-replace.js
@@ -166,7 +166,11 @@ await (async function updateMetadataForTemplates() {
   if (head) {
     const replacements = await getReplacementsFromSearch();
     if (!replacements) return;
-    head.innerHTML = replaceBladesInStr(head.innerHTML, replacements);
+    const title = head.getElementsByTagName('title')[0];
+    title.innerText = replaceBladesInStr(title.innerText, replacements);
+    [...head.getElementsByTagName('meta')].forEach((meta) => {
+      meta.setAttribute('content', replaceBladesInStr(meta.getAttribute('content'), replacements));
+    });
   }
 }());
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -2161,7 +2161,6 @@ function decoratePictures(main) {
 }
 
 export async function decorateMain(main) {
-  removeIrrelevantSections(main);
   await buildAutoBlocks(main);
   splitSections(main);
   decorateSections(main);
@@ -2357,6 +2356,8 @@ async function loadEager(main) {
     langSplits.pop();
     const htmlLang = langSplits.join('-');
     document.documentElement.setAttribute('lang', htmlLang);
+
+    removeIrrelevantSections(main);
   }
   if (!window.hlx.lighthouse) await decorateTesting();
 


### PR DESCRIPTION
In the before link, you should be able to see a flash of raw content that should go away in the after link. To make it obvious, add a breakpoint to line 171 of content-replace.js in the Before link and see the raw content. To verify the fix, add a breakpoint to line 175 in the After link and see the page stays blank.

https://jira.corp.adobe.com/browse/MWPW-134490

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/templates/search?lighthouse=on&tasks=flyer&tasksx=flyer&phformat=2:3&topics=hello%20worl&q=hello%20worl
- After: https://fix-template-search-flash--express--adobecom.hlx.page/express/templates/search?lighthouse=on&tasks=flyer&tasksx=flyer&phformat=2:3&topics=hello%20worl&q=hello%20worl
