### PR TITLE
Content V3 API CDN

### DIFF
--- a/express/blocks/template-x/template-search-api-v3.js
+++ b/express/blocks/template-x/template-search-api-v3.js
@@ -64,7 +64,7 @@ function formatFilterString(filters) {
 async function fetchSearchUrl({
   limit, start, filters, sort, q, collectionId,
 }) {
-  const base = 'https://spark-search.adobe.io/v3/content';
+  const base = 'https://www.adobe.com/express-search-api-v3';
   const collectionIdParam = `collectionId=${collectionId}`;
   const queryType = 'search';
   const queryParam = `&queryType=${queryType}`;


### PR DESCRIPTION
Switch to use the one behind CDN. Then when on acom, there won't be origin crossing and performance could be improved!

Resolves: https://jira.corp.adobe.com/browse/MWPW-133915

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/templates/?lighthouse=on
- After: https://template-x-api-behind-cdn--express--adobecom.hlx.page/express/templates/?lighthouse=on
