### PR TITLE
content-search undo replacing space

### DIFF
--- a/express/blocks/template-x/template-search-api-v3.js
+++ b/express/blocks/template-x/template-search-api-v3.js
@@ -42,8 +42,8 @@ function formatFilterString(filters) {
     str += `&filters=behaviors==${animated.toLowerCase() === 'false' ? 'still' : 'animated'}`;
   }
   if (behaviors) {
-    extractFilterTerms(behaviors).forEach((b) => {
-      str += `&filters=behaviors==${b}`;
+    extractFilterTerms(behaviors).forEach((behavior) => {
+      str += `&filters=behaviors==${behavior.split(',').map((b) => b.trim()).join(',')}`;
     });
   }
   extractFilterTerms(tasks).forEach((task) => {

--- a/express/blocks/template-x/template-search-api-v3.js
+++ b/express/blocks/template-x/template-search-api-v3.js
@@ -17,7 +17,7 @@ function extractFilterTerms(input) {
     return [];
   }
   return input
-    .split(' AND ')
+    .split('AND')
     .map((t) => t
       .trim()
       .toLowerCase());
@@ -46,11 +46,11 @@ function formatFilterString(filters) {
       str += `&filters=behaviors==${b}`;
     });
   }
-  extractFilterTerms(tasks).forEach((t) => {
-    str += `&filters=pages.task.name==${t}`;
+  extractFilterTerms(tasks).forEach((task) => {
+    str += `&filters=pages.task.name==${task.split(',').map((t) => t.trim()).join(',')}`;
   });
-  extractFilterTerms(topics).forEach((t) => {
-    str += `&filters=topics==${t}`;
+  extractFilterTerms(topics).forEach((topic) => {
+    str += `&filters=topics==${topic.split(',').map((t) => t.trim()).join(',')}`;
   });
   // locale needs backward compatibility with old api
   if (locales) {

--- a/express/blocks/template-x/template-search-api-v3.js
+++ b/express/blocks/template-x/template-search-api-v3.js
@@ -19,7 +19,7 @@ function extractFilterTerms(input) {
   return input
     .split(' AND ')
     .map((t) => t
-      .replaceAll(' ', '')
+      .trim()
       .toLowerCase());
 }
 function extractLangs(locales) {


### PR DESCRIPTION
It appears that content team is replacing their tagging methods, one of them being that a space between word in a topic query is now valid, and many dash separated topics have changed, like "video-memory" -> "video memory". Therefore, we will undo the code that converts authored space into "-", and give the authors full control of what goes into the queries.

No ticket

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/create/create/video/photo?lighthouse=on
- After: https://template-x-search-keep-dashes--express--adobecom.hlx.page/express/create/video/photo?lighthouse=on
