### PR TITLE
Hide Mobile CKG Pills Before Replacment

### DIFF
--- a/express/blocks/link-list/link-list.js
+++ b/express/blocks/link-list/link-list.js
@@ -73,6 +73,6 @@ export default async function decorate($block) {
   }
 
   if (window.location.href.includes('/express/templates/')) {
-    import('../../scripts/ckg-link-list.js');
+    await import('../../scripts/ckg-link-list.js');
   }
 }


### PR DESCRIPTION
On mobile, you shouldn't see 2 Default pills flashing anymore

No ticket was created

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/templates/flyer?lighthouse=on
- After: https://hide-mobile-ckg-defaults--express--adobecom.hlx.page/express/templates/flyer?lighthouse=on
