### PR TITLE
Autocomplete only for EFGJ

### DIFF
--- a/express/scripts/autocomplete-api-v3.js
+++ b/express/scripts/autocomplete-api-v3.js
@@ -16,10 +16,11 @@ import { memoize, throttle, debounce } from './utils.js';
 const url = 'https://adobesearch-atc.adobe.io/uss/v3/autocomplete';
 const experienceId = 'default-templates-autocomplete-v1';
 const scopeEntities = ['HzTemplate'];
+const wlLocales = ['en-US', 'fr-FR', 'de-DE', 'ja-JP'];
 const emptyRes = { queryResults: [{ items: [] }] };
 
 async function fetchAPI({ limit = 5, textQuery, locale = 'en-US' }) {
-  if (!textQuery) {
+  if (!textQuery || !wlLocales.includes(locale)) {
     return [];
   }
 


### PR DESCRIPTION
This is to sync with our current live PROD so that autocomplete API is not called on non-efgj locales. You should see no network request when you type in the search bar in the after link.

No ticket was created

Test URLs:

Before: https://stage--express--adobecom.hlx.page/tw/express/templates/?lighthouse=on
After: https://ac-only-to-efgj--express--adobecom.hlx.page/tw/express/templates/?lighthouse=on