### PR TITLE
Template x & Template List CSS Fix

### DIFF
--- a/express/blocks/template-list/template-list.css
+++ b/express/blocks/template-list/template-list.css
@@ -85,21 +85,6 @@ main .template-list.fullwidth > .masonry-col {
   max-width: 175px;
 }
 
-main .template-list.fullwidth.sm-view > .masonry-col {
-  max-width: 170px;
-  text-align: center;
-}
-
-main .template-list.fullwidth.md-view > .masonry-col {
-  max-width: 258.5px;
-  text-align: center;
-}
-
-main .template-list.fullwidth.lg-view > .masonry-col {
-  max-width: 352px;
-  text-align: center;
-}
-
 main .template-list .template-title {
   margin: 0 12px 20px 12px;
 }
@@ -612,12 +597,12 @@ main .template-list.fullwidth.lg-view > .masonry-col {
 }
 
 main .template-list.fullwidth.md-view > .masonry-col {
-  max-width: 165.5px;
+  max-width: 144px;
   text-align: center;
 }
 
 main .template-list.fullwidth.sm-view > .masonry-col {
-  max-width: 106.33px;
+  max-width: 101px;
   text-align: center;
 }
 
@@ -2028,7 +2013,7 @@ main .template-list-fullwidth-apipowered-container nav ol.templates-breadcrumbs 
   }
 
   main .template-list.fullwidth.lg-view > .masonry-col {
-    max-width: 328px;
+    max-width: 320px;
     text-align: center;
   }
 
@@ -2166,7 +2151,7 @@ main .template-list-fullwidth-apipowered-container nav ol.templates-breadcrumbs 
   }
 
   main .template-list.fullwidth.md-view > .masonry-col {
-    max-width: 258.5px;
+    max-width: 240px;
     text-align: center;
   }
 
@@ -2398,7 +2383,7 @@ main .template-list-fullwidth-apipowered-container nav ol.templates-breadcrumbs 
   }
 
   main .template-list.fullwidth.md-view > .masonry-col {
-    max-width: 250px;
+    max-width: 233px;
   }
 
   main .section.template-list-horizontal-container > div {

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -151,8 +151,8 @@
     padding: 0;
 }
 
-.template-x.with-categories-list .template-x.fullwidth {
-    width: 100%;
+.template-x.with-categories-list .template-x-inner-wrapper {
+    min-height: 700px;
 }
 
 .template-x.fullwidth.lg-view > .template-x-inner-wrapper > .masonry-col {

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -879,11 +879,6 @@ main .block.template-list[data-block-status='initialized']>div {
   display: none;
 }
 
-main .template-list.sixcols,
-main .template-x.sixcols .template-x-inner-wrapper {
-  min-height: 700px;
-}
-
 main .columns.columns-marquee {
   min-height: 650px;
 }


### PR DESCRIPTION
Describe your specific features or fixes

Resolves: No ticket reported
Fixing:
- template blocks level CSS appearing in styles.css
- limiting min-height rule scope to category-list template-x only
- tweaking template-list CSS after masonry change

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/fr/express/create/background/zoom?lighthouse=on
- After: https://template-x-mh-fix--express--adobecom.hlx.page/fr/express/create/background/zoom?lighthouse=on
