### PR TITLE
[MWPW-134688] Create Page LCP Fix + Promotion Block After loadBlocks

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -2209,6 +2209,7 @@ async function loadEager(main) {
     wordBreakJapanese();
 
     const lcpBlocks = ['columns', 'hero-animation', 'hero-3d', 'template-list', 'template-x', 'floating-button', 'fullscreen-marquee', 'fullscreen-marquee-desktop', 'collapsible-card', 'search-marquee'];
+    if (getMetadata('show-relevant-rows') === 'yes') lcpBlocks.push('fragment');
     const block = document.querySelector('.block');
     const hasLCPBlock = (block && lcpBlocks.includes(block.getAttribute('data-block-name')));
     if (hasLCPBlock) await loadBlock(block, true);
@@ -2259,11 +2260,10 @@ async function loadLazy(main) {
   // post LCP actions go here
   sampleRUM('lcp');
 
-  loadBlocks(main);
+  loadBlocks(main).then(() => addPromotion());
   loadCSS('/express/styles/lazy-styles.css');
   scrollToHash();
   resolveFragments();
-  addPromotion();
   removeMetadata();
   addFavIcon('/express/icons/cc-express.svg');
   if (!window.hlx.lighthouse) loadMartech();


### PR DESCRIPTION
Description:
added fragment to LCP blocks for pages with show-relevant-rows metadata
added .then before addPromotion to always load after loadBlocks

Resolves: [MWPW-134688](https://jira.corp.adobe.com/browse/MWPW-134688)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/create/flyer/party?lighthouse=on
- After: https://mwpw-134688--express--adobecom.hlx.page/express/create/flyer/party?lighthouse=on
