### PR TITLE
Template X Explicitly Wait for Content Replace

### DIFF
--- a/express/scripts/content-replace.js
+++ b/express/scripts/content-replace.js
@@ -90,7 +90,7 @@ function replaceBladesInStr(str, replacements) {
 // for backwards compatibility
 // TODO: remove this func after all content is updated
 // legacy json -> metadata & dom blades
-await (async function updateLegacyContent() {
+async function updateLegacyContent() {
   const searchMarquee = document.querySelector('.search-marquee');
   if (searchMarquee) {
     // not legacy
@@ -155,10 +155,10 @@ await (async function updateLegacyContent() {
       templateList.innerHTML = templateList.innerHTML.replaceAll('default-create-link-text', data.createText || '');
     }
   }
-}());
+}
 
 // searchbar -> metadata blades
-await (async function updateMetadataForTemplates() {
+async function updateMetadataForTemplates() {
   if (!['yes', 'true', 'on', 'Y'].includes(getMetadata('template-search-page'))) {
     return;
   }
@@ -172,10 +172,10 @@ await (async function updateMetadataForTemplates() {
       meta.setAttribute('content', replaceBladesInStr(meta.getAttribute('content'), replacements));
     });
   }
-}());
+}
 
 // metadata -> dom blades
-(function autoUpdatePage() {
+function autoUpdatePage() {
   const wl = ['{{heading_placeholder}}', '{{type}}', '{{quantity}}'];
   // FIXME: deprecate wl
   const main = document.querySelector('main');
@@ -187,10 +187,10 @@ await (async function updateMetadataForTemplates() {
     }
     return match;
   });
-}());
+}
 
 // cleanup remaining dom blades
-(async function updateNonBladeContent() {
+async function updateNonBladeContent() {
   const heroAnimation = document.querySelector('.hero-animation.wide');
   const templateList = document.querySelector('.template-list.fullwidth.apipowered');
   const templateX = document.querySelector('.template-x');
@@ -230,9 +230,9 @@ await (async function updateMetadataForTemplates() {
   if (browseByCat && !['yes', 'true', 'on', 'Y'].includes(getMetadata('show-browse-by-category'))) {
     browseByCat.remove();
   }
-}());
+}
 
-(function validatePage() {
+function validatePage() {
   const env = getHelixEnv();
   const title = document.querySelector('title');
   if ((env && env.name !== 'stage') && getMetadata('live') === 'N') {
@@ -246,4 +246,12 @@ await (async function updateMetadataForTemplates() {
   if (env && env.name !== 'stage' && window.location.pathname.endsWith('/express/templates/default')) {
     window.location.replace('/404');
   }
-}());
+}
+
+export default async function replaceContent() {
+  await updateLegacyContent();
+  await updateMetadataForTemplates();
+  autoUpdatePage();
+  await updateNonBladeContent();
+  validatePage();
+}

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -2190,7 +2190,8 @@ async function loadEager(main) {
   // for backward compatibility
   // TODO: remove the href check after we tag content with sheet-powered
   if (getMetadata('sheet-powered') === 'Y' || window.location.href.includes('/express/templates/')) {
-    await import('./content-replace.js');
+    const { default: replaceContent } = await import('./content-replace.js');
+    await replaceContent();
   }
 
   if (getMetadata('template-search-page') === 'Y') {


### PR DESCRIPTION
The loading order should now be more predictable and deterministic. Namely, content-replace will have finished when every block starts decorating itself one by one.

No ticket was created.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/templates/?lighthouse=on
- After: https://await-content-replace--express--adobecom.hlx.page/express/templates/?lighthouse=on
