### PR TITLE
[HOTFIX] Category list hover fix

### DIFF
--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -2493,7 +2493,7 @@ nav ol.templates-breadcrumbs li:not(:first-child):before {
         opacity: 1;
         z-index: -1;
         position: absolute;
-        height: 100%;
+        height: calc(100% - 120px);
         width: 100%;
         transition: opacity 0.2s;
         background: linear-gradient(90deg, #fff 50%, #ffffff9B 88%, #ffffff00 100%);


### PR DESCRIPTION
Fix no ticket. I noticed a small overlap of the category gradient over the SEO Nav block. This is a quick CSS fix to it.

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/templates/flyer?lighthouse=on
- After: https://category-list-hover-fix--express--adobecom.hlx.page/express/templates/flyer?lighthouse=on
