### PR TITLE
[MWPW-134875]: fixed sort issue in localized template pages

### DIFF
--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -713,10 +713,15 @@ function closeDrawer(toolBar) {
   }, 500);
 }
 
-async function updateOptionsStatus(block, props, toolBar) {
+function updateOptionsStatus(block, props, toolBar) {
   const wrappers = toolBar.querySelectorAll('.function-wrapper');
-  const placeholders = await fetchPlaceholders();
-  const waysOfSort = JSON.parse(placeholders['template-x-sort']);
+  const waysOfSort = {
+    'Most Relevant': '',
+    'Most Viewed': '&orderBy=-remixCount',
+    'Rare & Original': '&orderBy=remixCount',
+    'Newest to Oldest': '&orderBy=-availabilityDate',
+    'Oldest to Newest': '&orderBy=availabilityDate',
+  };
 
   wrappers.forEach((wrapper) => {
     const currentOption = wrapper.querySelector('.current-option');
@@ -725,13 +730,10 @@ async function updateOptionsStatus(block, props, toolBar) {
     options.forEach((option) => {
       const paramType = wrapper.dataset.param;
       const paramValue = option.dataset.value;
-      const propValue = props[paramType] ? props[paramType] : 'remove';
       const filterValue = props.filters[paramType] ? props.filters[paramType] : 'remove';
-      const sortValue = waysOfSort[props[paramType]] || '';
+      const sortValue = waysOfSort[props[paramType]] || props[paramType];
 
-      if (propValue === paramValue
-        || filterValue === paramValue
-        || sortValue === paramValue) {
+      if (filterValue === paramValue || sortValue === paramValue) {
         if (currentOption) {
           currentOption.textContent = option.textContent;
         }
@@ -785,7 +787,7 @@ function initDrawer(block, props, toolBar) {
     el.addEventListener('click', async () => {
       props.filters = { ...currentFilters };
       closeDrawer(toolBar);
-      await updateOptionsStatus(block, props, toolBar);
+      updateOptionsStatus(block, props, toolBar);
     }, { passive: true });
   });
 
@@ -852,7 +854,7 @@ async function redrawTemplates(block, props, toolBar) {
   await decorateNewTemplates(block, props, { reDrawMasonry: true });
 
   heading.textContent = heading.textContent.replace(`${currentTotal}`, props.total.toLocaleString('en-US'));
-  await updateOptionsStatus(block, props, toolBar);
+  updateOptionsStatus(block, props, toolBar);
   if (block.querySelectorAll('.template').length <= 0) {
     const $viewButtons = toolBar.querySelectorAll('.view-toggle-button');
     $viewButtons.forEach((button) => {
@@ -935,7 +937,7 @@ async function initFilterSort(block, props, toolBar) {
     }
 
     // sync current filter & sorting method with toolbar current options
-    await updateOptionsStatus(block, props, toolBar);
+    updateOptionsStatus(block, props, toolBar);
   }
 }
 


### PR DESCRIPTION
**Description:**
Fixing sort params referencing issue on localized pages. In the past, the waysOfSort uses the localized sort names but the block always uses English version of the sort names. Now we use hardcoded English values. In the KR pages in the preview, the evidence should be that we are seeing the most viewed sorting by default (eye icon) while the before shows a most relevant (up-down arrows icon).

Resolves: [MWPW-134875](https://jira.corp.adobe.com/browse/MWPW-134875)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/kr/express/templates/?lighthouse=on
- After: https://template-x-sort-fix--express--adobecom.hlx.page/kr/express/templates/?lighthouse=on
