### PR TITLE
[MWPW-134814] Marquee: Wide variant alignment fix

### DIFF
--- a/express/blocks/marquee/marquee.css
+++ b/express/blocks/marquee/marquee.css
@@ -127,6 +127,7 @@ body.no-desktop-brand-header header {
 
 .marquee .button-container.button-inline {
   display: inline-block;
+  margin-right: 16px;
 }
 
 .marquee .content-wrapper .button-container.free-plan-container {
@@ -138,14 +139,11 @@ body.no-desktop-brand-header header {
 .marquee .button-container.button-inline.free-plan-container .free-plan-widget {
   color: var(--body-color);
   background: unset;
-  background-color: unset;
   margin: unset;
 }
 
 .marquee.dark .button-container.button-inline.free-plan-container .free-plan-widget {
   color: var(--color-white);
-  background: unset;
-  background-color: unset;
 }
 
 .marquee .button-container.button-inline.free-plan-container + .button-container.button-inline > a {
@@ -155,9 +153,6 @@ body.no-desktop-brand-header header {
 .marquee.wide .free-plan-widget {
   margin: 0;
   background-color: transparent;
-}
-
-.marquee.wide .free-plan-widget {
   padding-left: 0;
 }
 
@@ -225,7 +220,6 @@ body.no-desktop-brand-header header {
 
   .marquee.wide {
     position: relative;
-    max-width: 1200px;
     margin: 0 auto;
   }
 
@@ -302,8 +296,7 @@ body.no-desktop-brand-header header {
 
   .marquee.wide .marquee-foreground {
     box-sizing: border-box;
-    padding: 32px;
-    margin: 0;
+    padding: 32px 20px;
     min-height: 250px;
   }
 
@@ -373,10 +366,6 @@ body.no-desktop-brand-header header {
 
   .marquee.wide .button-container.free-plan-container.stacked .free-plan-widget {
     padding-left: 0;
-  }
-
-  .marquee p.button-container a.secondary:any-link {
-    margin-left: 15px;
   }
 }
 


### PR DESCRIPTION
The wide variant of Marquee block has the inherited issues from hero-animation-beta block. This PR is to make some small CSS changes so that the wide variant looks better.

Resolves: [MWPW-134814](https://jira.corp.adobe.com/browse/MWPW-134814)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/qiyundai/homepage-v3/marquee?lighthouse=on
- After: https://mwpw-134814--express--adobecom.hlx.page/drafts/qiyundai/homepage-v3/marquee?lighthouse=on
The links contains all the possible variants of the marquee block. The one in question here is the **second to last** one.
