### PR TITLE
[PUF block]: Annual Price Discount Percentage Toggle Highlight Removal

### DIFF
--- a/express/blocks/puf/puf.css
+++ b/express/blocks/puf/puf.css
@@ -119,12 +119,8 @@ main .block.puf .puf-card .puf-card-top .puf-card-plans > div span {
   color: var(--color-gray-800);
 }
 
-main .block.puf .puf-card .puf-card-top .puf-card-plans > div.strong {
-  -webkit-text-stroke-width: 0.6px;
-  -webkit-text-stroke-color: var(--color-info-accent);
-}
-
 main .block.puf .puf-card .puf-card-top .puf-card-plans > div.strong span {
+  -webkit-text-stroke-width: 0.6px;
   -webkit-text-stroke-color: var(--color-gray-800);
 }
 
@@ -482,7 +478,7 @@ main .block.puf .puf-card .puf-card-banner {
   }
 
   main .block.puf .carousel-container.slide-2-selected .carousel-fader-left {
-    left: 0.7rem;    
+    left: 0.7rem;
     opacity: 1;
     pointer-events: auto;
   }


### PR DESCRIPTION
**Description**
The annual pricing discount percentage should not be bolded when toggled, while the word annual should.

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER) Pending

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/pricing?lighthouse=on
- After: https://puf-percentage-no-highlight--express--adobecom.hlx.page/express/pricing?lighthouse=on
