### PR TITLE
Fix TemplateX Static Icons Shows Up Before Image Loaded

### DIFF
--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -349,14 +349,13 @@ function renderStillWrapper(template) {
   const isFree = template.licensingCategory === 'free';
 
   const freeTag = createTag('span', { class: 'free-tag' });
-
+  freeTag.append('Free');
+  const premiumIcon = getIconElement('premium');
   img.onload = (e) => {
     if (e.eventPhase >= Event.AT_TARGET) {
       if (isFree) {
-        freeTag.append('Free');
         imgWrapper.append(freeTag);
       } else {
-        const premiumIcon = getIconElement('premium');
         imgWrapper.append(premiumIcon);
       }
     }

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -325,10 +325,28 @@ function renderHoverWrapper(template, placeholders, props) {
   return btnContainer;
 }
 
-function getFreeSpanTag() {
-  const t = createTag('span', { class: 'free-tag' });
-  t.append('Free');
-  return t;
+function getStillWrapperIcons(template) {
+  let planIcon = null;
+  if (template.licensingCategory === 'free') {
+    planIcon = createTag('span', { class: 'free-tag' });
+    planIcon.append('Free');
+  } else {
+    planIcon = getIconElement('premium');
+  }
+  let videoIcon = '';
+  if (!containsVideo(template.pages) && template.pages.length > 1) {
+    videoIcon = getIconElement('multipage-static-badge');
+  }
+
+  if (containsVideo(template.pages) && template.pages.length === 1) {
+    videoIcon = getIconElement('video-badge');
+  }
+
+  if (containsVideo(template.pages) && template.pages.length > 1) {
+    videoIcon = getIconElement('multipage-video-badge');
+  }
+  if (videoIcon) videoIcon.classList.add('media-type-icon');
+  return { planIcon, videoIcon };
 }
 
 function renderStillWrapper(template) {
@@ -352,30 +370,13 @@ function renderStillWrapper(template) {
   });
   imgWrapper.append(img);
 
-  const tag = template.licensingCategory === 'free' ? getFreeSpanTag() : getIconElement('premium');
+  const { planIcon, videoIcon } = getStillWrapperIcons(template);
   img.onload = (e) => {
     if (e.eventPhase >= Event.AT_TARGET) {
-      imgWrapper.append(tag);
+      imgWrapper.append(planIcon);
+      imgWrapper.append(videoIcon);
     }
   };
-
-  let videoIcon = '';
-  if (containsVideo(template.pages) && template.pages.length === 1) {
-    videoIcon = getIconElement('video-badge');
-  }
-
-  if (!containsVideo(template.pages) && template.pages.length > 1) {
-    videoIcon = getIconElement('multipage-static-badge');
-  }
-
-  if (containsVideo(template.pages) && template.pages.length > 1) {
-    videoIcon = getIconElement('multipage-video-badge');
-  }
-
-  if (videoIcon) {
-    videoIcon.classList.add('media-type-icon');
-    imgWrapper.append(videoIcon);
-  }
 
   stillWrapper.append(imgWrapper);
   return stillWrapper;

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -325,6 +325,12 @@ function renderHoverWrapper(template, placeholders, props) {
   return btnContainer;
 }
 
+function getFreeSpanTag() {
+  const t = createTag('span', { class: 'free-tag' });
+  t.append('Free');
+  return t;
+}
+
 function renderStillWrapper(template) {
   const stillWrapper = createTag('div', { class: 'still-wrapper' });
 
@@ -345,11 +351,6 @@ function renderStillWrapper(template) {
     alt: templateTitle,
   });
   imgWrapper.append(img);
-  const getFreeSpanTag = () => {
-    const t = createTag('span', { class: 'free-tag' });
-    t.append('Free');
-    return t;
-  };
 
   const tag = template.licensingCategory === 'free' ? getFreeSpanTag() : getIconElement('premium');
   img.onload = (e) => {

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -351,7 +351,7 @@ function renderStillWrapper(template) {
   const freeTag = createTag('span', { class: 'free-tag' });
 
   img.onload = (e) => {
-    if (e.eventPhase >= 2) {
+    if (e.eventPhase >= Event.AT_TARGET) {
       if (isFree) {
         freeTag.append('Free');
         imgWrapper.append(freeTag);

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -350,13 +350,17 @@ function renderStillWrapper(template) {
 
   const freeTag = createTag('span', { class: 'free-tag' });
 
-  if (isFree) {
-    freeTag.append('Free');
-    imgWrapper.append(freeTag);
-  } else {
-    const premiumIcon = getIconElement('premium');
-    imgWrapper.append(premiumIcon);
-  }
+  img.onload = (e) => {
+    if (e.eventPhase >= 2) {
+      if (isFree) {
+        freeTag.append('Free');
+        imgWrapper.append(freeTag);
+      } else {
+        const premiumIcon = getIconElement('premium');
+        imgWrapper.append(premiumIcon);
+      }
+    }
+  };
 
   let videoIcon = '';
   if (containsVideo(template.pages) && template.pages.length === 1) {

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -345,19 +345,16 @@ function renderStillWrapper(template) {
     alt: templateTitle,
   });
   imgWrapper.append(img);
+  const getFreeSpanTag = () => {
+    const t = createTag('span', { class: 'free-tag' });
+    t.append('Free');
+    return t;
+  };
 
-  const isFree = template.licensingCategory === 'free';
-
-  const freeTag = createTag('span', { class: 'free-tag' });
-  freeTag.append('Free');
-  const premiumIcon = getIconElement('premium');
+  const tag = template.licensingCategory === 'free' ? getFreeSpanTag() : getIconElement('premium');
   img.onload = (e) => {
     if (e.eventPhase >= Event.AT_TARGET) {
-      if (isFree) {
-        imgWrapper.append(freeTag);
-      } else {
-        imgWrapper.append(premiumIcon);
-      }
+      imgWrapper.append(tag);
     }
   };
 


### PR DESCRIPTION
Free tag and premium icons should not show up before images are loaded now. To see how it was in the before branch, use the toolbar to change filter/sort and see how they showed up before images

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/templates/flyer?lighthouse=on
- After: https://template-x-hide-icons-until-image-loaded--express--adobecom.hlx.page/express/templates/flyer?lighthouse=on
