### PR TITLE
[MWPW-134928] Long text CTA in marquee fix

### DIFF
--- a/express/blocks/marquee/marquee.css
+++ b/express/blocks/marquee/marquee.css
@@ -134,6 +134,7 @@ body.no-desktop-brand-header header {
   display: flex;
   justify-content: left;
   align-items: flex-start;
+  flex-wrap: wrap;
 }
 
 .marquee .button-container.button-inline.free-plan-container .free-plan-widget {
@@ -302,7 +303,7 @@ body.no-desktop-brand-header header {
 
   .marquee .marquee-foreground .content-wrapper {
     width: 600px;
-    max-width: 42%;
+    max-width: 46%;
   }
 
   .marquee .hero-shadow {


### PR DESCRIPTION
Give content more room horizontally and allow free-plan tags to wrap when not enough room.

Resolves: [MWPW-134928](https://jira.corp.adobe.com/browse/MWPW-134928)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/fr/express/?lighthouse=on
- After: https://mwpw-134928--express--adobecom.hlx.page/fr/express/?lighthouse=on
