### PR TITLE
PUF Free Plan Link Update

### DIFF
--- a/express/blocks/puf/puf.js
+++ b/express/blocks/puf/puf.js
@@ -137,8 +137,9 @@ async function fetchPlan(planUrl) {
     plan.symbol = '$';
 
     // TODO: Remove '/sp/ once confirmed with stakeholders
-    const { host } = planUrl.includes('adobe.com') ? new URL(planUrl) : '';
-    if (host.includes('express.adobe.com') || planUrl.includes('/sp/')) {
+    const allowedHosts = ['new.express.adobe.com', 'express.adobe.com'];
+    const { host } = new URL(planUrl);
+    if (allowedHosts.includes(host) || planUrl.includes('/sp/')) {
       plan.offerId = 'FREE0';
       plan.frequency = 'monthly';
       plan.name = 'Free';

--- a/express/blocks/puf/puf.js
+++ b/express/blocks/puf/puf.js
@@ -137,7 +137,8 @@ async function fetchPlan(planUrl) {
     plan.symbol = '$';
 
     // TODO: Remove '/sp/ once confirmed with stakeholders
-    if (new URL(planUrl).host.includes('express.adobe.com') || planUrl.includes('/sp/')) {
+    const { host } = planUrl.includes('adobe.com') ? new URL(planUrl) : '';
+    if (host.includes('express.adobe.com') || planUrl.includes('/sp/')) {
       plan.offerId = 'FREE0';
       plan.frequency = 'monthly';
       plan.name = 'Free';

--- a/express/blocks/puf/puf.js
+++ b/express/blocks/puf/puf.js
@@ -136,7 +136,8 @@ async function fetchPlan(planUrl) {
     plan.currency = 'US';
     plan.symbol = '$';
 
-    if (planUrl.includes('/sp/')) {
+    // TODO: Remove '/sp/ once confirmed with stakeholders
+    if (new URL(planUrl).host.includes('express.adobe.com') || planUrl.includes('/sp/')) {
       plan.offerId = 'FREE0';
       plan.frequency = 'monthly';
       plan.name = 'Free';


### PR DESCRIPTION
The 'fetchPlan' function was checking for '/sp' in the URL, but the new free plan link is 'https://new.express.adobe.com/'. I have left in the original check for '/sp' but that can be removed if there is no longer a need for it.

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/pricing
- After:  https://puf-free-button-fix--express--adobecom.hlx.page/express/pricing?lighthouse=on
