### PR TITLE
Marquee CTA FR free-plan wrapping

### DIFF
--- a/express/blocks/marquee/marquee.css
+++ b/express/blocks/marquee/marquee.css
@@ -302,7 +302,6 @@ body.no-desktop-brand-header header {
   }
 
   .marquee .marquee-foreground .content-wrapper {
-    width: 600px;
     max-width: 46%;
   }
 


### PR DESCRIPTION
Resolves: No ticket

FR copy was still wrapping. Removed hard-set max-width and let copy stretch to as far as 46%.

Test URLs:
- Before: https://main--express--adobecom.hlx.page/fr/express/?lighthouse=on
- After: https://marquee-cta-longtext-fix-2--express--adobecom.hlx.page/fr/express/?lighthouse=on
