### PR TITLE
Carousel arrow not loading fix

### DIFF
--- a/express/blocks/cta-carousel/cta-carousel.js
+++ b/express/blocks/cta-carousel/cta-carousel.js
@@ -235,5 +235,6 @@ export default async function decorate(block) {
   decorateHeading(block, payload);
   await decorateCards(block, payload);
   buildCarousel('', block.querySelector('.cta-carousel-cards'), false);
+  block.dispatchEvent(new CustomEvent('carouselloaded'));
   document.dispatchEvent(new CustomEvent('linkspopulated', { detail: block.querySelectorAll('.links-wrapper a') }));
 }

--- a/express/blocks/cta-carousel/cta-carousel.js
+++ b/express/blocks/cta-carousel/cta-carousel.js
@@ -235,6 +235,5 @@ export default async function decorate(block) {
   decorateHeading(block, payload);
   await decorateCards(block, payload);
   buildCarousel('', block.querySelector('.cta-carousel-cards'), false);
-  block.dispatchEvent(new CustomEvent('carouselloaded'));
   document.dispatchEvent(new CustomEvent('linkspopulated', { detail: block.querySelectorAll('.links-wrapper a') }));
 }

--- a/express/blocks/toggle-bar/toggle-bar.js
+++ b/express/blocks/toggle-bar/toggle-bar.js
@@ -41,6 +41,16 @@ function decorateButton(block, toggle) {
   toggle.parentNode.replaceChild(button, toggle);
 }
 
+function awakeNestedCarousels(section) {
+  const carousels = section.querySelectorAll('.carousel-container');
+
+  if (carousels.length === 0) return;
+
+  Array.from(carousels).forEach((c) => {
+    c.closest('.block')?.dispatchEvent(new CustomEvent('carouselloaded'));
+  });
+}
+
 function initButton(block, sections, index, props) {
   const enclosingMain = block.closest('main');
 
@@ -60,6 +70,7 @@ function initButton(block, sections, index, props) {
           if (buttons[index].dataset.text === section.dataset.toggle.toLowerCase()) {
             section.style.display = 'block';
             props.activeSection = section;
+            awakeNestedCarousels(section);
           } else {
             section.style.display = 'none';
           }


### PR DESCRIPTION
**Description:**
Added a dispatch of carouselloaded event in cta carousel for trigger carousel arrows loading after each toggle bar toggle. To test, check if the carousel arrow buttons for scrolling appears after toggling using the toggle bar block.

Resolves: no ticket

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/?lighthouse=on
- After: https://carousel-arrow-not-loading-fix--express--adobecom.hlx.page/express/?lighthouse=on
