### PR TITLE
[Fullscreen Marquee Desktop] Gradient H1 different layout for JP

### DIFF
--- a/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.css
+++ b/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.css
@@ -51,6 +51,12 @@ main .fullscreen-marquee-desktop .fullscreen-marquee-desktop-heading .button-con
   align-items: center;
 }
 
+main .fullscreen-marquee-desktop-heading h1.budoux {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
 main .fullscreen-marquee-desktop-heading h1 em {
   font-style: normal;
   background: linear-gradient(320deg, #7C84F3, #FF4DD2, #FF993B, #FF4DD2, #7C84F3, #FF4DD2, #FF993B);


### PR DESCRIPTION
Treat JP h1 with gradient text differently in CSS due to reserved child tags empty space.

Test URLs:
- Before: https://main--express--adobecom.hlx.page/jp/express/create/video/tiktok?lighthouse=on
- After: https://jp-fullscreen-marquee-fix--express--adobecom.hlx.page/jp/express/create/video/tiktok?lighthouse=on
