### PR TITLE
MWPW-135103 add NL sitemap config for templates

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -174,3 +174,8 @@ sitemaps:
         destination: /express/sitemap-seo-templates.xml
         hreflang: zh-Hant
         alternate: /tw/{path}
+      netherlands:
+        source: /nl/express/templates/default/metadata.json?sheet=sitemap
+        destination: /express/sitemap-seo-templates.xml
+        hreflang: nl
+        alternate: /nl/{path}


### PR DESCRIPTION
Adds configuration so that NL sitemap for templates is also generated

Resolves: [MWPW-135103](https://jira.corp.adobe.com/browse/MWPW-135103)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/?lighthouse=on
- After: https://MWPW-135103-nl-sitemap-templates--express--adobecom.hlx.page/express/?lighthouse=on
