### PR TITLE
PUF Free Plan Link Update-2: Branch Links Added

### DIFF
--- a/express/blocks/puf/puf.js
+++ b/express/blocks/puf/puf.js
@@ -137,7 +137,7 @@ async function fetchPlan(planUrl) {
     plan.symbol = '$';
 
     // TODO: Remove '/sp/ once confirmed with stakeholders
-    const allowedHosts = ['new.express.adobe.com', 'express.adobe.com'];
+    const allowedHosts = ['new.express.adobe.com', 'express.adobe.com', 'adobesparkpost.app.link'];
     const { host } = new URL(planUrl);
     if (allowedHosts.includes(host) || planUrl.includes('/sp/')) {
       plan.offerId = 'FREE0';


### PR DESCRIPTION
Follow-up to https://github.com/adobecom/express/pull/179, I have added branch links to the whitelist of free plan links, as per Pankaj's request.

Test URLs:
- Before: https://main--express--adobecom.hlx.page/de/express/pricing
- After: https://puf-free-button-fix-2--express--adobecom.hlx.page/de/express/pricing?lighthouse=on
