### PR TITLE
Search marquee dropdown keyboard interactions

### DIFF
--- a/express/blocks/search-marquee/search-marquee.css
+++ b/express/blocks/search-marquee/search-marquee.css
@@ -53,12 +53,19 @@ main .search-marquee .search-dropdown-container .trends-container .from-scratch-
     margin-bottom: 16px;
 }
 
-main .search-marquee .search-dropdown-container .trends-container ul,
+main .search-marquee .search-dropdown-container .trends-container ul {
+    padding-left: 0;
+    list-style: none;
+    max-height: 216px;
+    overflow: auto;
+}
+
 main .search-marquee .search-dropdown-container .suggestions-container ul {
     padding-left: 0;
     list-style: none;
     max-height: 216px;
     overflow: auto;
+    margin: 0 0 16px -8px;
 }
 
 main .search-marquee .search-dropdown-container .trends-container .trends-wrapper li,
@@ -68,10 +75,15 @@ main .search-marquee .search-dropdown-container .suggestions-container li {
 
 main .search-marquee .search-dropdown-container .suggestions-container li {
     cursor: pointer;
+    margin: 0 8px 0 0;
+    padding: 8px;
 }
 
-main .search-marquee .search-dropdown-container .suggestions-container li:hover {
-    color: var(--color-info-accent);
+main .search-marquee .search-dropdown-container .suggestions-container li:hover,
+main .search-marquee .search-dropdown-container .suggestions-container li:focus-visible {
+    background: var(--color-gray-200);
+    outline: none;
+    border-radius: 8px;
 }
 
 main .search-marquee .search-dropdown-container .trends-container .trends-wrapper li a {

--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -56,6 +56,12 @@ function wordExistsInString(word, inputString) {
   return regexPattern.test(inputString);
 }
 
+function cycleThroughSuggestions(block, targetIndex = 0) {
+  const suggestions = block.querySelectorAll('.suggestions-list li');
+  if (targetIndex >= suggestions.length || targetIndex < 0) return;
+  if (suggestions.length > 0) suggestions[targetIndex].focus();
+}
+
 function initSearchFunction(block) {
   const searchBarWrapper = block.querySelector('.search-bar-wrapper');
 
@@ -101,6 +107,13 @@ function initSearchFunction(block) {
       suggestionsContainer.classList.add('hidden');
     }
   }, { passive: true });
+
+  searchBar.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowDown' || e.keyCode === 40) {
+      e.preventDefault();
+      cycleThroughSuggestions(block);
+    }
+  });
 
   document.addEventListener('click', (e) => {
     const { target } = e;
@@ -199,7 +212,7 @@ function initSearchFunction(block) {
     suggestionsList.innerHTML = '';
     const searchBarVal = searchBar.value.toLowerCase();
     if (suggestions && !(suggestions.length <= 1 && suggestions[0]?.query === searchBarVal)) {
-      suggestions.forEach((item) => {
+      suggestions.forEach((item, index) => {
         const li = createTag('li', { tabindex: 0 });
         const valRegEx = new RegExp(searchBar.value, 'i');
         li.innerHTML = item.query.replace(valRegEx, `<b>${searchBarVal}</b>`);
@@ -210,6 +223,20 @@ function initSearchFunction(block) {
         li.addEventListener('keydown', async (e) => {
           if (e.key === 'Enter' || e.keyCode === 13) {
             await handleSubmitInteraction(item);
+          }
+        });
+
+        li.addEventListener('keydown', (e) => {
+          if (e.key === 'ArrowDown' || e.keyCode === 40) {
+            e.preventDefault();
+            cycleThroughSuggestions(block, index + 1);
+          }
+        });
+
+        li.addEventListener('keydown', (e) => {
+          if (e.key === 'ArrowUp' || e.keyCode === 38) {
+            e.preventDefault();
+            cycleThroughSuggestions(block, index - 1);
           }
         });
 

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -809,12 +809,19 @@ main .template-x .search-dropdown-container .trends-container .from-scratch-link
     margin-bottom: 16px;
 }
 
-main .template-x .search-dropdown-container .trends-container ul,
+main .template-x .search-dropdown-container .trends-container ul {
+    padding-left: 0;
+    list-style: none;
+    max-height: 216px;
+    overflow: auto;
+}
+
 main .template-x .search-dropdown-container .suggestions-container ul {
     padding-left: 0;
     list-style: none;
     max-height: 216px;
     overflow: auto;
+    margin: 0 0 16px -8px;
 }
 
 main .template-x .search-dropdown-container .trends-container .trends-wrapper li,
@@ -824,10 +831,15 @@ main .template-x .search-dropdown-container .suggestions-container li {
 
 main .template-x .search-dropdown-container .suggestions-container li {
     cursor: pointer;
+    margin: 0 8px 0 0;
+    padding: 8px;
 }
 
-main .template-x .search-dropdown-container .suggestions-container li:hover {
-    color: var(--color-info-accent);
+main .template-x .search-dropdown-container .suggestions-container li:hover,
+main .template-x .search-dropdown-container .suggestions-container li:focus-visible {
+    background: var(--color-gray-200);
+    outline: none;
+    border-radius: 8px;
 }
 
 main .template-x .search-dropdown-container .trends-container .trends-wrapper li a {

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -1316,6 +1316,12 @@ async function decorateBreadcrumbs(block) {
   if (breadcrumbs) block.prepend(breadcrumbs);
 }
 
+function cycleThroughSuggestions(block, targetIndex = 0) {
+  const suggestions = block.querySelectorAll('.suggestions-list li');
+  if (targetIndex >= suggestions.length || targetIndex < 0) return;
+  if (suggestions.length > 0) suggestions[targetIndex].focus();
+}
+
 function importSearchBar(block, blockMediator) {
   blockMediator.subscribe('stickySearchBar', (e) => {
     const parent = block.querySelector('.api-templates-toolbar .wrapper-content-search');
@@ -1354,6 +1360,13 @@ function importSearchBar(block, blockMediator) {
             suggestionsContainer.classList.add('hidden');
           }
         }, { passive: true });
+
+        searchBar.addEventListener('keydown', (event) => {
+          if (event.key === 'ArrowDown' || event.keyCode === 40) {
+            event.preventDefault();
+            cycleThroughSuggestions(block);
+          }
+        });
 
         document.addEventListener('click', (event) => {
           const { target } = event;
@@ -1425,7 +1438,7 @@ function importSearchBar(block, blockMediator) {
           suggestionsList.innerHTML = '';
           const searchBarVal = searchBar.value.toLowerCase();
           if (suggestions && !(suggestions.length <= 1 && suggestions[0]?.query === searchBarVal)) {
-            suggestions.forEach((item) => {
+            suggestions.forEach((item, index) => {
               const li = createTag('li', { tabindex: 0 });
               const valRegEx = new RegExp(searchBar.value, 'i');
               li.innerHTML = item.query.replace(valRegEx, `<b>${searchBarVal}</b>`);
@@ -1433,6 +1446,20 @@ function importSearchBar(block, blockMediator) {
                 if (item.query === searchBar.value) return;
                 searchBar.value = item.query;
                 searchBar.dispatchEvent(new Event('input'));
+              });
+
+              li.addEventListener('keydown', (event) => {
+                if (event.key === 'ArrowDown' || event.keyCode === 40) {
+                  event.preventDefault();
+                  cycleThroughSuggestions(block, index + 1);
+                }
+              });
+
+              li.addEventListener('keydown', (event) => {
+                if (event.key === 'ArrowUp' || event.keyCode === 38) {
+                  event.preventDefault();
+                  cycleThroughSuggestions(block, index - 1);
+                }
               });
 
               suggestionsList.append(li);


### PR DESCRIPTION
**Description**
It's been flagged a few times that the keyboard interactions of the search dropdown on our template pages is different from the in product. In this PR, we've added arrow keys cycling through the auto complete suggestions. Same interaction is added to the template x imported version through Block Mediator

Resolves: [MWPW-135131](https://jira.corp.adobe.com/browse/MWPW-135131)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/templates/?lighthouse=on
- After: https://search-marquee-dropdown--express--adobecom.hlx.page/express/templates/?lighthouse=on
