### PR TITLE
[Urgent] New Required Localization Header for Content API

### DIFF
--- a/express/blocks/template-x/template-search-api-v3.js
+++ b/express/blocks/template-x/template-search-api-v3.js
@@ -95,7 +95,7 @@ async function fetchSearchUrl({
   if (langs.length > 0) {
     [prefLang] = langs;
     headers['x-express-pref-lang'] = getLanguage(prefLang);
-    headers['x-express-ims-region-code'] = prefLang;
+    headers['x-express-ims-region-code'] = prefLang.toUpperCase();
   }
   const res = await memoizedFetch(url, { headers });
   if (!res) return res;

--- a/express/blocks/template-x/template-search-api-v3.js
+++ b/express/blocks/template-x/template-search-api-v3.js
@@ -91,13 +91,18 @@ async function fetchSearchUrl({
   const headers = {};
 
   const langs = extractLangs(filters.locales);
-  if (langs.length > 0) headers['x-express-pref-lang'] = getLanguage(langs[0]);
+  let prefLang;
+  if (langs.length > 0) {
+    [prefLang] = langs;
+    headers['x-express-pref-lang'] = getLanguage(prefLang);
+    headers['x-express-ims-region-code'] = prefLang;
+  }
   const res = await memoizedFetch(url, { headers });
   if (!res) return res;
   if (langs.length > 1) {
     res.items = [
-      ...res.items.filter(({ language }) => language === getLanguage(langs[0])),
-      ...res.items.filter(({ language }) => language !== getLanguage(langs[0]))];
+      ...res.items.filter(({ language }) => language === getLanguage(prefLang)),
+      ...res.items.filter(({ language }) => language !== getLanguage(prefLang))];
   }
   return res;
 }


### PR DESCRIPTION
We should see localized templates on the after url but not on the before url.
This is needed because of a unplanned latest change in the API that requires a new header to be used

Test URLs:
- Before: https://main--express--adobecom.hlx.page/fr/express/templates/?lighthouse=on
- After: https://hot-localize-content-api--express--adobecom.hlx.page/fr/express/templates/?lighthouse=on
