### PR TITLE
Pricing summary link fix

### DIFF
--- a/express/blocks/pricing-summary/pricing-summary.js
+++ b/express/blocks/pricing-summary/pricing-summary.js
@@ -162,7 +162,7 @@ function handlePrice(column) {
 
   fetchPlan(price?.href).then((response) => {
     priceText.innerHTML = response.formatted;
-    const planCTA = column.querySelector('button-container .button');
+    const planCTA = column.querySelector('.button-container button');
     if (planCTA) planCTA.href = buildUrl(response.url, response.country, response.language);
   });
 

--- a/express/blocks/pricing-summary/pricing-summary.js
+++ b/express/blocks/pricing-summary/pricing-summary.js
@@ -10,74 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import { createTag, getHelixEnv } from '../../scripts/scripts.js';
-import { getOffer } from '../../scripts/utils/pricing.js';
-
-function replaceUrlParam(url, paramName, paramValue) {
-  const params = url.searchParams;
-  params.set(paramName, paramValue);
-  url.search = params.toString();
-  return url;
-}
-
-function buildUrl(optionUrl, country, language) {
-  const currentUrl = new URL(window.location.href);
-  let planUrl = new URL(optionUrl);
-
-  if (!planUrl.hostname.includes('commerce')) {
-    return planUrl.href;
-  }
-  planUrl = replaceUrlParam(planUrl, 'co', country);
-  planUrl = replaceUrlParam(planUrl, 'lang', language);
-  let rUrl = planUrl.searchParams.get('rUrl');
-  if (currentUrl.searchParams.has('host')) {
-    const hostParam = currentUrl.searchParams.get('host');
-    if (hostParam === 'express.adobe.com') {
-      planUrl.hostname = 'commerce.adobe.com';
-      if (rUrl) rUrl = rUrl.replace('express.adobe.com', hostParam);
-    } else if (hostParam.includes('qa.adobeprojectm.com')) {
-      planUrl.hostname = 'commerce.adobe.com';
-      if (rUrl) rUrl = rUrl.replace('express.adobe.com', hostParam);
-    } else if (hostParam.includes('.adobeprojectm.com')) {
-      planUrl.hostname = 'commerce-stg.adobe.com';
-      if (rUrl) rUrl = rUrl.replace('adminconsole.adobe.com', 'stage.adminconsole.adobe.com');
-      if (rUrl) rUrl = rUrl.replace('express.adobe.com', hostParam);
-    }
-  }
-
-  const env = getHelixEnv();
-  if (env && env.commerce && planUrl.hostname.includes('commerce')) planUrl.hostname = env.commerce;
-  if (env && env.spark && rUrl) {
-    const url = new URL(rUrl);
-    url.hostname = env.spark;
-    rUrl = url.toString();
-  }
-
-  if (rUrl) {
-    rUrl = new URL(rUrl);
-
-    if (currentUrl.searchParams.has('touchpointName')) {
-      rUrl = replaceUrlParam(rUrl, 'touchpointName', currentUrl.searchParams.get('touchpointName'));
-    }
-    if (currentUrl.searchParams.has('destinationUrl')) {
-      rUrl = replaceUrlParam(rUrl, 'destinationUrl', currentUrl.searchParams.get('destinationUrl'));
-    }
-    if (currentUrl.searchParams.has('srcUrl')) {
-      rUrl = replaceUrlParam(rUrl, 'srcUrl', currentUrl.searchParams.get('srcUrl'));
-    }
-  }
-
-  if (currentUrl.searchParams.has('code')) {
-    planUrl.searchParams.set('code', currentUrl.searchParams.get('code'));
-  }
-
-  if (currentUrl.searchParams.get('rUrl')) {
-    rUrl = currentUrl.searchParams.get('rUrl');
-  }
-
-  if (rUrl) planUrl.searchParams.set('rUrl', rUrl.toString());
-  return planUrl.href;
-}
+import { createTag } from '../../scripts/scripts.js';
+import { getOffer, buildUrl } from '../../scripts/utils/pricing.js';
 
 async function fetchPlan(planUrl) {
   if (!window.pricingPlans) {

--- a/express/blocks/pricing-summary/pricing-summary.js
+++ b/express/blocks/pricing-summary/pricing-summary.js
@@ -162,7 +162,7 @@ function handlePrice(column) {
 
   fetchPlan(price?.href).then((response) => {
     priceText.innerHTML = response.formatted;
-    const planCTA = column.querySelector('.button-container button');
+    const planCTA = column.querySelector(':scope > .button-container:last-of-type a.button');
     if (planCTA) planCTA.href = buildUrl(response.url, response.country, response.language);
   });
 

--- a/express/blocks/pricing-summary/pricing-summary.js
+++ b/express/blocks/pricing-summary/pricing-summary.js
@@ -10,8 +10,74 @@
  * governing permissions and limitations under the License.
  */
 
-import { createTag } from '../../scripts/scripts.js';
+import { createTag, getHelixEnv } from '../../scripts/scripts.js';
 import { getOffer } from '../../scripts/utils/pricing.js';
+
+function replaceUrlParam(url, paramName, paramValue) {
+  const params = url.searchParams;
+  params.set(paramName, paramValue);
+  url.search = params.toString();
+  return url;
+}
+
+function buildUrl(optionUrl, country, language) {
+  const currentUrl = new URL(window.location.href);
+  let planUrl = new URL(optionUrl);
+
+  if (!planUrl.hostname.includes('commerce')) {
+    return planUrl.href;
+  }
+  planUrl = replaceUrlParam(planUrl, 'co', country);
+  planUrl = replaceUrlParam(planUrl, 'lang', language);
+  let rUrl = planUrl.searchParams.get('rUrl');
+  if (currentUrl.searchParams.has('host')) {
+    const hostParam = currentUrl.searchParams.get('host');
+    if (hostParam === 'express.adobe.com') {
+      planUrl.hostname = 'commerce.adobe.com';
+      if (rUrl) rUrl = rUrl.replace('express.adobe.com', hostParam);
+    } else if (hostParam.includes('qa.adobeprojectm.com')) {
+      planUrl.hostname = 'commerce.adobe.com';
+      if (rUrl) rUrl = rUrl.replace('express.adobe.com', hostParam);
+    } else if (hostParam.includes('.adobeprojectm.com')) {
+      planUrl.hostname = 'commerce-stg.adobe.com';
+      if (rUrl) rUrl = rUrl.replace('adminconsole.adobe.com', 'stage.adminconsole.adobe.com');
+      if (rUrl) rUrl = rUrl.replace('express.adobe.com', hostParam);
+    }
+  }
+
+  const env = getHelixEnv();
+  if (env && env.commerce && planUrl.hostname.includes('commerce')) planUrl.hostname = env.commerce;
+  if (env && env.spark && rUrl) {
+    const url = new URL(rUrl);
+    url.hostname = env.spark;
+    rUrl = url.toString();
+  }
+
+  if (rUrl) {
+    rUrl = new URL(rUrl);
+
+    if (currentUrl.searchParams.has('touchpointName')) {
+      rUrl = replaceUrlParam(rUrl, 'touchpointName', currentUrl.searchParams.get('touchpointName'));
+    }
+    if (currentUrl.searchParams.has('destinationUrl')) {
+      rUrl = replaceUrlParam(rUrl, 'destinationUrl', currentUrl.searchParams.get('destinationUrl'));
+    }
+    if (currentUrl.searchParams.has('srcUrl')) {
+      rUrl = replaceUrlParam(rUrl, 'srcUrl', currentUrl.searchParams.get('srcUrl'));
+    }
+  }
+
+  if (currentUrl.searchParams.has('code')) {
+    planUrl.searchParams.set('code', currentUrl.searchParams.get('code'));
+  }
+
+  if (currentUrl.searchParams.get('rUrl')) {
+    rUrl = currentUrl.searchParams.get('rUrl');
+  }
+
+  if (rUrl) planUrl.searchParams.set('rUrl', rUrl.toString());
+  return planUrl.href;
+}
 
 async function fetchPlan(planUrl) {
   if (!window.pricingPlans) {
@@ -96,6 +162,8 @@ function handlePrice(column) {
 
   fetchPlan(price?.href).then((response) => {
     priceText.innerHTML = response.formatted;
+    const planCTA = column.querySelector('button-container .button');
+    if (planCTA) planCTA.href = buildUrl(response.url, response.country, response.language);
   });
 
   priceContainer?.remove();

--- a/express/blocks/puf/puf.js
+++ b/express/blocks/puf/puf.js
@@ -12,78 +12,11 @@
 import {
   addPublishDependencies,
   createTag,
-  getHelixEnv,
   // eslint-disable-next-line import/no-unresolved
 } from '../../scripts/scripts.js';
-import { getOffer } from '../../scripts/utils/pricing.js';
+import { getOffer, buildUrl } from '../../scripts/utils/pricing.js';
 
 import { buildCarousel } from '../shared/carousel.js';
-
-function replaceUrlParam(url, paramName, paramValue) {
-  const params = url.searchParams;
-  params.set(paramName, paramValue);
-  url.search = params.toString();
-  return url;
-}
-
-function buildUrl(optionUrl, country, language) {
-  const currentUrl = new URL(window.location.href);
-  let planUrl = new URL(optionUrl);
-
-  if (!planUrl.hostname.includes('commerce')) {
-    return planUrl.href;
-  }
-  planUrl = replaceUrlParam(planUrl, 'co', country);
-  planUrl = replaceUrlParam(planUrl, 'lang', language);
-  let rUrl = planUrl.searchParams.get('rUrl');
-  if (currentUrl.searchParams.has('host')) {
-    const hostParam = currentUrl.searchParams.get('host');
-    if (hostParam === 'express.adobe.com') {
-      planUrl.hostname = 'commerce.adobe.com';
-      if (rUrl) rUrl = rUrl.replace('express.adobe.com', hostParam);
-    } else if (hostParam.includes('qa.adobeprojectm.com')) {
-      planUrl.hostname = 'commerce.adobe.com';
-      if (rUrl) rUrl = rUrl.replace('express.adobe.com', hostParam);
-    } else if (hostParam.includes('.adobeprojectm.com')) {
-      planUrl.hostname = 'commerce-stg.adobe.com';
-      if (rUrl) rUrl = rUrl.replace('adminconsole.adobe.com', 'stage.adminconsole.adobe.com');
-      if (rUrl) rUrl = rUrl.replace('express.adobe.com', hostParam);
-    }
-  }
-
-  const env = getHelixEnv();
-  if (env && env.commerce && planUrl.hostname.includes('commerce')) planUrl.hostname = env.commerce;
-  if (env && env.spark && rUrl) {
-    const url = new URL(rUrl);
-    url.hostname = env.spark;
-    rUrl = url.toString();
-  }
-
-  if (rUrl) {
-    rUrl = new URL(rUrl);
-
-    if (currentUrl.searchParams.has('touchpointName')) {
-      rUrl = replaceUrlParam(rUrl, 'touchpointName', currentUrl.searchParams.get('touchpointName'));
-    }
-    if (currentUrl.searchParams.has('destinationUrl')) {
-      rUrl = replaceUrlParam(rUrl, 'destinationUrl', currentUrl.searchParams.get('destinationUrl'));
-    }
-    if (currentUrl.searchParams.has('srcUrl')) {
-      rUrl = replaceUrlParam(rUrl, 'srcUrl', currentUrl.searchParams.get('srcUrl'));
-    }
-  }
-
-  if (currentUrl.searchParams.has('code')) {
-    planUrl.searchParams.set('code', currentUrl.searchParams.get('code'));
-  }
-
-  if (currentUrl.searchParams.get('rUrl')) {
-    rUrl = currentUrl.searchParams.get('rUrl');
-  }
-
-  if (rUrl) planUrl.searchParams.set('rUrl', rUrl.toString());
-  return planUrl.href;
-}
 
 function pushPricingAnalytics(adobeEventName, sparkEventName, plan) {
   const url = new URL(window.location.href);

--- a/express/blocks/search-marquee/search-marquee.css
+++ b/express/blocks/search-marquee/search-marquee.css
@@ -53,12 +53,19 @@ main .search-marquee .search-dropdown-container .trends-container .from-scratch-
     margin-bottom: 16px;
 }
 
-main .search-marquee .search-dropdown-container .trends-container ul,
+main .search-marquee .search-dropdown-container .trends-container ul {
+    padding-left: 0;
+    list-style: none;
+    max-height: 216px;
+    overflow: auto;
+}
+
 main .search-marquee .search-dropdown-container .suggestions-container ul {
     padding-left: 0;
     list-style: none;
     max-height: 216px;
     overflow: auto;
+    margin: 0 0 16px -8px;
 }
 
 main .search-marquee .search-dropdown-container .trends-container .trends-wrapper li,
@@ -68,10 +75,15 @@ main .search-marquee .search-dropdown-container .suggestions-container li {
 
 main .search-marquee .search-dropdown-container .suggestions-container li {
     cursor: pointer;
+    margin: 0 8px 0 0;
+    padding: 8px;
 }
 
-main .search-marquee .search-dropdown-container .suggestions-container li:hover {
-    color: var(--color-info-accent);
+main .search-marquee .search-dropdown-container .suggestions-container li:hover,
+main .search-marquee .search-dropdown-container .suggestions-container li:focus-visible {
+    background: var(--color-gray-200);
+    outline: none;
+    border-radius: 8px;
 }
 
 main .search-marquee .search-dropdown-container .trends-container .trends-wrapper li a {

--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -56,6 +56,12 @@ function wordExistsInString(word, inputString) {
   return regexPattern.test(inputString);
 }
 
+function cycleThroughSuggestions(block, targetIndex = 0) {
+  const suggestions = block.querySelectorAll('.suggestions-list li');
+  if (targetIndex >= suggestions.length || targetIndex < 0) return;
+  if (suggestions.length > 0) suggestions[targetIndex].focus();
+}
+
 function initSearchFunction(block) {
   const searchBarWrapper = block.querySelector('.search-bar-wrapper');
 
@@ -101,6 +107,13 @@ function initSearchFunction(block) {
       suggestionsContainer.classList.add('hidden');
     }
   }, { passive: true });
+
+  searchBar.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowDown' || e.keyCode === 40) {
+      e.preventDefault();
+      cycleThroughSuggestions(block);
+    }
+  });
 
   document.addEventListener('click', (e) => {
     const { target } = e;
@@ -199,7 +212,7 @@ function initSearchFunction(block) {
     suggestionsList.innerHTML = '';
     const searchBarVal = searchBar.value.toLowerCase();
     if (suggestions && !(suggestions.length <= 1 && suggestions[0]?.query === searchBarVal)) {
-      suggestions.forEach((item) => {
+      suggestions.forEach((item, index) => {
         const li = createTag('li', { tabindex: 0 });
         const valRegEx = new RegExp(searchBar.value, 'i');
         li.innerHTML = item.query.replace(valRegEx, `<b>${searchBarVal}</b>`);
@@ -210,6 +223,20 @@ function initSearchFunction(block) {
         li.addEventListener('keydown', async (e) => {
           if (e.key === 'Enter' || e.keyCode === 13) {
             await handleSubmitInteraction(item);
+          }
+        });
+
+        li.addEventListener('keydown', (e) => {
+          if (e.key === 'ArrowDown' || e.keyCode === 40) {
+            e.preventDefault();
+            cycleThroughSuggestions(block, index + 1);
+          }
+        });
+
+        li.addEventListener('keydown', (e) => {
+          if (e.key === 'ArrowUp' || e.keyCode === 38) {
+            e.preventDefault();
+            cycleThroughSuggestions(block, index - 1);
           }
         });
 

--- a/express/blocks/template-x/template-search-api-v3.js
+++ b/express/blocks/template-x/template-search-api-v3.js
@@ -95,7 +95,7 @@ async function fetchSearchUrl({
   if (langs.length > 0) {
     [prefLang] = langs;
     headers['x-express-pref-lang'] = getLanguage(prefLang);
-    headers['x-express-ims-region-code'] = prefLang;
+    headers['x-express-ims-region-code'] = prefLang.toUpperCase();
   }
   const res = await memoizedFetch(url, { headers });
   if (!res) return res;

--- a/express/blocks/template-x/template-search-api-v3.js
+++ b/express/blocks/template-x/template-search-api-v3.js
@@ -91,13 +91,18 @@ async function fetchSearchUrl({
   const headers = {};
 
   const langs = extractLangs(filters.locales);
-  if (langs.length > 0) headers['x-express-pref-lang'] = getLanguage(langs[0]);
+  let prefLang;
+  if (langs.length > 0) {
+    [prefLang] = langs;
+    headers['x-express-pref-lang'] = getLanguage(prefLang);
+    headers['x-express-ims-region-code'] = prefLang;
+  }
   const res = await memoizedFetch(url, { headers });
   if (!res) return res;
   if (langs.length > 1) {
     res.items = [
-      ...res.items.filter(({ language }) => language === getLanguage(langs[0])),
-      ...res.items.filter(({ language }) => language !== getLanguage(langs[0]))];
+      ...res.items.filter(({ language }) => language === getLanguage(prefLang)),
+      ...res.items.filter(({ language }) => language !== getLanguage(prefLang))];
   }
   return res;
 }

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -809,12 +809,19 @@ main .template-x .search-dropdown-container .trends-container .from-scratch-link
     margin-bottom: 16px;
 }
 
-main .template-x .search-dropdown-container .trends-container ul,
+main .template-x .search-dropdown-container .trends-container ul {
+    padding-left: 0;
+    list-style: none;
+    max-height: 216px;
+    overflow: auto;
+}
+
 main .template-x .search-dropdown-container .suggestions-container ul {
     padding-left: 0;
     list-style: none;
     max-height: 216px;
     overflow: auto;
+    margin: 0 0 16px -8px;
 }
 
 main .template-x .search-dropdown-container .trends-container .trends-wrapper li,
@@ -824,10 +831,15 @@ main .template-x .search-dropdown-container .suggestions-container li {
 
 main .template-x .search-dropdown-container .suggestions-container li {
     cursor: pointer;
+    margin: 0 8px 0 0;
+    padding: 8px;
 }
 
-main .template-x .search-dropdown-container .suggestions-container li:hover {
-    color: var(--color-info-accent);
+main .template-x .search-dropdown-container .suggestions-container li:hover,
+main .template-x .search-dropdown-container .suggestions-container li:focus-visible {
+    background: var(--color-gray-200);
+    outline: none;
+    border-radius: 8px;
 }
 
 main .template-x .search-dropdown-container .trends-container .trends-wrapper li a {

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -1316,6 +1316,12 @@ async function decorateBreadcrumbs(block) {
   if (breadcrumbs) block.prepend(breadcrumbs);
 }
 
+function cycleThroughSuggestions(block, targetIndex = 0) {
+  const suggestions = block.querySelectorAll('.suggestions-list li');
+  if (targetIndex >= suggestions.length || targetIndex < 0) return;
+  if (suggestions.length > 0) suggestions[targetIndex].focus();
+}
+
 function importSearchBar(block, blockMediator) {
   blockMediator.subscribe('stickySearchBar', (e) => {
     const parent = block.querySelector('.api-templates-toolbar .wrapper-content-search');
@@ -1354,6 +1360,13 @@ function importSearchBar(block, blockMediator) {
             suggestionsContainer.classList.add('hidden');
           }
         }, { passive: true });
+
+        searchBar.addEventListener('keydown', (event) => {
+          if (event.key === 'ArrowDown' || event.keyCode === 40) {
+            event.preventDefault();
+            cycleThroughSuggestions(block);
+          }
+        });
 
         document.addEventListener('click', (event) => {
           const { target } = event;
@@ -1425,7 +1438,7 @@ function importSearchBar(block, blockMediator) {
           suggestionsList.innerHTML = '';
           const searchBarVal = searchBar.value.toLowerCase();
           if (suggestions && !(suggestions.length <= 1 && suggestions[0]?.query === searchBarVal)) {
-            suggestions.forEach((item) => {
+            suggestions.forEach((item, index) => {
               const li = createTag('li', { tabindex: 0 });
               const valRegEx = new RegExp(searchBar.value, 'i');
               li.innerHTML = item.query.replace(valRegEx, `<b>${searchBarVal}</b>`);
@@ -1433,6 +1446,20 @@ function importSearchBar(block, blockMediator) {
                 if (item.query === searchBar.value) return;
                 searchBar.value = item.query;
                 searchBar.dispatchEvent(new Event('input'));
+              });
+
+              li.addEventListener('keydown', (event) => {
+                if (event.key === 'ArrowDown' || event.keyCode === 40) {
+                  event.preventDefault();
+                  cycleThroughSuggestions(block, index + 1);
+                }
+              });
+
+              li.addEventListener('keydown', (event) => {
+                if (event.key === 'ArrowUp' || event.keyCode === 38) {
+                  event.preventDefault();
+                  cycleThroughSuggestions(block, index - 1);
+                }
               });
 
               suggestionsList.append(li);

--- a/express/scripts/utils/pricing.js
+++ b/express/scripts/utils/pricing.js
@@ -9,7 +9,79 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { getLocale, getLanguage, getCookie } from '../scripts.js';
+import {
+  getLocale,
+  getLanguage,
+  getCookie,
+  getHelixEnv,
+} from '../scripts.js';
+
+function replaceUrlParam(url, paramName, paramValue) {
+  const params = url.searchParams;
+  params.set(paramName, paramValue);
+  url.search = params.toString();
+  return url;
+}
+
+export function buildUrl(optionUrl, country, language) {
+  const currentUrl = new URL(window.location.href);
+  let planUrl = new URL(optionUrl);
+
+  if (!planUrl.hostname.includes('commerce')) {
+    return planUrl.href;
+  }
+  planUrl = replaceUrlParam(planUrl, 'co', country);
+  planUrl = replaceUrlParam(planUrl, 'lang', language);
+  let rUrl = planUrl.searchParams.get('rUrl');
+  if (currentUrl.searchParams.has('host')) {
+    const hostParam = currentUrl.searchParams.get('host');
+    const { host } = new URL(hostParam);
+    if (host === 'express.adobe.com') {
+      planUrl.hostname = 'commerce.adobe.com';
+      if (rUrl) rUrl = rUrl.replace('express.adobe.com', hostParam);
+    } else if (host === 'qa.adobeprojectm.com') {
+      planUrl.hostname = 'commerce.adobe.com';
+      if (rUrl) rUrl = rUrl.replace('express.adobe.com', hostParam);
+    } else if (host.endsWith('.adobeprojectm.com')) {
+      planUrl.hostname = 'commerce-stg.adobe.com';
+      if (rUrl) rUrl = rUrl.replace('adminconsole.adobe.com', 'stage.adminconsole.adobe.com');
+      if (rUrl) rUrl = rUrl.replace('express.adobe.com', hostParam);
+    }
+  }
+
+  const env = getHelixEnv();
+  if (env && env.commerce && planUrl.hostname.includes('commerce')) planUrl.hostname = env.commerce;
+  if (env && env.spark && rUrl) {
+    const url = new URL(rUrl);
+    url.hostname = env.spark;
+    rUrl = url.toString();
+  }
+
+  if (rUrl) {
+    rUrl = new URL(rUrl);
+
+    if (currentUrl.searchParams.has('touchpointName')) {
+      rUrl = replaceUrlParam(rUrl, 'touchpointName', currentUrl.searchParams.get('touchpointName'));
+    }
+    if (currentUrl.searchParams.has('destinationUrl')) {
+      rUrl = replaceUrlParam(rUrl, 'destinationUrl', currentUrl.searchParams.get('destinationUrl'));
+    }
+    if (currentUrl.searchParams.has('srcUrl')) {
+      rUrl = replaceUrlParam(rUrl, 'srcUrl', currentUrl.searchParams.get('srcUrl'));
+    }
+  }
+
+  if (currentUrl.searchParams.has('code')) {
+    planUrl.searchParams.set('code', currentUrl.searchParams.get('code'));
+  }
+
+  if (currentUrl.searchParams.get('rUrl')) {
+    rUrl = currentUrl.searchParams.get('rUrl');
+  }
+
+  if (rUrl) planUrl.searchParams.set('rUrl', rUrl.toString());
+  return planUrl.href;
+}
 
 function getCurrencyDisplay(currency) {
   if (currency === 'JPY') {


### PR DESCRIPTION
Pricing Summary shouldn't be using the link in the {{pricing}} directly. Instead, we'll be using the same buildUrl method from puf block. You can verify that the Start 30-day free trial CTA is correct now by seeing the pricing summary page with overridden helix-env having commerce link instead of commerce-stg link.

![Screen Shot 2023-08-16 at 6 15 35 AM](https://github.com/adobecom/express/assets/57737624/e8cee854-fd3d-41d2-b00c-0780a1495218)

Resolves: [MWPW-NUMBER Pending](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/?lighthouse=on&helix-env=prod
- After: https://pricing-summary-link-fix--express--adobecom.hlx.page/express/?lighthouse=on&helix-env=prod
