### PR TITLE
Floating Button: Overflow Issue

### DIFF
--- a/express/blocks/shared/floating-cta.css
+++ b/express/blocks/shared/floating-cta.css
@@ -53,7 +53,7 @@ main .floating-button {
     background-color: var(--color-gray-200);
     transition: background-color .3s, padding .3s, margin-bottom 0.6s ease-out, bottom .3s;
     z-index: 2;
-    max-width: 100%;
+    max-width: 100vw;
     pointer-events: auto;
     margin-bottom: 24px;
 }

--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -237,6 +237,7 @@ export async function createFloatingButton($block, audience, data) {
   }
 
   const $heroCTA = document.querySelector('a.button.same-as-floating-button-CTA');
+  console.log($heroCTA);
   if ($heroCTA) {
     const hideButtonWhenIntersecting = new IntersectionObserver((entries) => {
       const $e = entries[0];

--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -237,7 +237,6 @@ export async function createFloatingButton($block, audience, data) {
   }
 
   const $heroCTA = document.querySelector('a.button.same-as-floating-button-CTA');
-  console.log($heroCTA);
   if ($heroCTA) {
     const hideButtonWhenIntersecting = new IntersectionObserver((entries) => {
       const $e = entries[0];


### PR DESCRIPTION
The max-width of the floating button was set to 100% of it's parent, which was wider than the viewport, causing overflow off the screen.

Test URLs:
- Before: https://main--express--adobecom.hlx.page/fr/express/create/post/facebook
- After: https://floating-button-alignment--express--adobecom.hlx.page/fr/express/create/post/facebook
