### PR TITLE
hide ckg default when mismatch

### DIFF
--- a/express/scripts/ckg-link-list.js
+++ b/express/scripts/ckg-link-list.js
@@ -66,13 +66,14 @@ function matchCKGResult(ckgData, pageData) {
   return sameLocale && ckgMatch && taskMatch;
 }
 
+const defaultRegex = /\/express\/templates\/default/;
 function replaceLinkPill(linkPill, data) {
   const clone = linkPill.cloneNode(true);
   if (data) {
     clone.innerHTML = clone.innerHTML.replace('/express/templates/default', data.url);
     clone.innerHTML = clone.innerHTML.replaceAll('Default', data.altShortTitle || data['short-title']);
   }
-  if (clone.innerHTML.contains('/express/templates/default')) {
+  if (defaultRegex.test(clone.innerHTML)) {
     return null;
   }
   return clone;

--- a/express/scripts/ckg-link-list.js
+++ b/express/scripts/ckg-link-list.js
@@ -68,10 +68,9 @@ function matchCKGResult(ckgData, pageData) {
 
 function replaceLinkPill(linkPill, data) {
   const clone = linkPill.cloneNode(true);
-  if (data) {
-    clone.innerHTML = clone.innerHTML.replace('/express/templates/default', data.url);
-    clone.innerHTML = clone.innerHTML.replaceAll('Default', data.altShortTitle || data['short-title']);
-  }
+  if (!data) return null;
+  clone.innerHTML = clone.innerHTML.replace('/express/templates/default', data.url);
+  clone.innerHTML = clone.innerHTML.replaceAll('Default', data.altShortTitle || data['short-title']);
   return clone;
 }
 
@@ -177,7 +176,7 @@ async function updateLinkList(container, linkPill, list) {
       linkListData.forEach((d) => {
         const templatePageData = templatePages.find((p) => p.live === 'Y' && p.shortTitle === d.childSibling);
         const clone = replaceLinkPill(linkPill, templatePageData);
-        container.append(clone);
+        if (clone) container.append(clone);
       });
     }
   }

--- a/express/scripts/ckg-link-list.js
+++ b/express/scripts/ckg-link-list.js
@@ -68,9 +68,13 @@ function matchCKGResult(ckgData, pageData) {
 
 function replaceLinkPill(linkPill, data) {
   const clone = linkPill.cloneNode(true);
-  if (!data) return null;
-  clone.innerHTML = clone.innerHTML.replace('/express/templates/default', data.url);
-  clone.innerHTML = clone.innerHTML.replaceAll('Default', data.altShortTitle || data['short-title']);
+  if (data) {
+    clone.innerHTML = clone.innerHTML.replace('/express/templates/default', data.url);
+    clone.innerHTML = clone.innerHTML.replaceAll('Default', data.altShortTitle || data['short-title']);
+  }
+  if (clone.innerHTML.contains('/express/templates/default')) {
+    return null;
+  }
   return clone;
 }
 
@@ -92,7 +96,7 @@ async function updateSEOLinkList(container, linkPill, list) {
 
       if (templatePageData) {
         const clone = replaceLinkPill(linkPill, templatePageData);
-        container.append(clone);
+        if (clone) container.append(clone);
       }
     });
   }
@@ -152,7 +156,7 @@ async function updateLinkList(container, linkPill, list) {
 
       if (templatePageData) {
         const clone = replaceLinkPill(linkPill, templatePageData);
-        pageLinks.push(clone);
+        if (clone) pageLinks.push(clone);
       }
     });
 


### PR DESCRIPTION
We should stop seeing Default CKG Pills even when ckgid and pages don't match.

Hot Fix!

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/templates/meme?lighthouse=on
- After: https://hide-ckg-default--express--adobecom.hlx.page/express/templates/meme?lighthouse=on

You can check that CKG Pills on other pages are still functioning: https://hide-ckg-default--express--adobecom.hlx.page/express/templates/flyer?lighthouse=on
