### PR TITLE
search-terms-log sheet fields update

### DIFF
--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -48,6 +48,7 @@ function logSearch(form, url = '/express/search-terms-log') {
           audience: document.body.dataset.device,
           sourcePath: window.location.pathname,
           previousSearch: params.toString() || 'N/A',
+          sessionId: sessionStorage.getItem('u_scsid'),
         },
       }),
     });

--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -35,6 +35,8 @@ function handlelize(str) {
 function logSearch(form, url = 'https://main--express-website--adobe.hlx.page/express/search-terms-log') {
   if (form) {
     const input = form.querySelector('input');
+    const currentHref = new URL(window.location.href);
+    const params = new URLSearchParams(currentHref.search);
     fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -45,6 +47,7 @@ function logSearch(form, url = 'https://main--express-website--adobe.hlx.page/ex
           timestamp: Date.now(),
           audience: document.body.dataset.device,
           sourcePath: window.location.pathname,
+          previousSearch: params.toString() || 'N/A',
         },
       }),
     });

--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -44,6 +44,7 @@ function logSearch(form, url = 'https://main--express-website--adobe.hlx.page/ex
           locale: getLocale(window.location),
           timestamp: Date.now(),
           audience: document.body.dataset.device,
+          sourcePath: window.location.pathname,
         },
       }),
     });

--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -32,7 +32,7 @@ function handlelize(str) {
     .toLowerCase(); // To lowercase
 }
 
-function logSearch(form, url = 'https://main--express-website--adobe.hlx.page/express/search-terms-log') {
+function logSearch(form, url = '/express/search-terms-log') {
   if (form) {
     const input = form.querySelector('input');
     const currentHref = new URL(window.location.href);


### PR DESCRIPTION
Fix no ticket

**Description:**
- Added a sourcePath attribute for tracking which page this search was launched
- Added a previousSearch attribute to track which search page it's from
- Made fetch url relative (tested and works)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/templates/?lighthouse=on
- After: https://search-term-log-update--express--adobecom.hlx.page/express/templates/?lighthouse=on
