### PR TITLE
removing fragment from splitSections to fix RR padding pollution

### DIFF
--- a/express/blocks/quick-action-card/quick-action-card.js
+++ b/express/blocks/quick-action-card/quick-action-card.js
@@ -130,7 +130,6 @@ async function buildBlockFromFragment($block) {
   }
 
   await fixIcons(newBlock);
-  console.log(newBlock);
   return newBlock;
 }
 

--- a/express/blocks/quick-action-card/quick-action-card.js
+++ b/express/blocks/quick-action-card/quick-action-card.js
@@ -130,7 +130,7 @@ async function buildBlockFromFragment($block) {
   }
 
   await fixIcons(newBlock);
-
+  console.log(newBlock);
   return newBlock;
 }
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1743,7 +1743,7 @@ function splitSections($main) {
   const multipleColumns = $main.querySelectorAll('.columns.fullsize-center').length > 1;
   $main.querySelectorAll(':scope > div > div').forEach(($block) => {
     const hasAppStoreBlocks = ['yes', 'true', 'on'].includes(getMetadata('show-standard-app-store-blocks').toLowerCase());
-    const blocksToSplit = ['template-list', 'layouts', 'banner', 'faq', 'promotion', 'fragment', 'app-store-highlight', 'app-store-blade', 'plans-comparison'];
+    const blocksToSplit = ['template-list', 'layouts', 'banner', 'faq', 'promotion', 'app-store-highlight', 'app-store-blade', 'plans-comparison'];
     // work around for splitting columns and sixcols template list
     // add metadata condition to minimize impact on other use cases
     if (hasAppStoreBlocks && !multipleColumns) {

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -507,7 +507,6 @@ function removeIrrelevantSections(main) {
  * @param {Element} $main The container element
  */
 function decorateSections($main) {
-  let noAudienceFound = false;
   $main.querySelectorAll(':scope > div').forEach((section) => {
     const wrappers = [];
     let defaultContent = false;
@@ -541,12 +540,6 @@ function decorateSections($main) {
         }
       });
       sectionMeta.parentNode.remove();
-    }
-
-    if (section.dataset.audience && !noAudienceFound) {
-      section.style.paddingTop = '0';
-    } else {
-      noAudienceFound = true;
     }
   });
 }


### PR DESCRIPTION
**Description**
We've discovered that the Relevant Rows fragment creates an empty section during splitSections. It's unclear why we'd ever need split sections for fragment but removing it from the list fixes the issue and causes no visible harm so far. Worth having more eyes on this for regression QA.

Resolves: [MWPW-135481](https://jira.corp.adobe.com/browse/MWPW-135481)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/create/facebook-story?lighthouse=on
- After: https://fix-rr-padding-pollution--express--adobecom.hlx.page/express/create/facebook-story?lighthouse=on
