### PR TITLE
fixing pricing CTA stg->prod issue

### DIFF
--- a/express/blocks/pricing-summary/pricing-summary.js
+++ b/express/blocks/pricing-summary/pricing-summary.js
@@ -11,7 +11,7 @@
  */
 
 import { createTag } from '../../scripts/scripts.js';
-import { getOffer } from '../../scripts/utils/pricing.js';
+import { getOffer, buildUrl } from '../../scripts/utils/pricing.js';
 
 async function fetchPlan(planUrl) {
   if (!window.pricingPlans) {
@@ -96,6 +96,8 @@ function handlePrice(column) {
 
   fetchPlan(price?.href).then((response) => {
     priceText.innerHTML = response.formatted;
+    const planCTA = column.querySelector(':scope > .button-container:last-of-type a.button');
+    if (planCTA) planCTA.href = buildUrl(response.url, response.country, response.language);
   });
 
   priceContainer?.remove();

--- a/express/blocks/puf/puf.js
+++ b/express/blocks/puf/puf.js
@@ -12,78 +12,11 @@
 import {
   addPublishDependencies,
   createTag,
-  getHelixEnv,
   // eslint-disable-next-line import/no-unresolved
 } from '../../scripts/scripts.js';
-import { getOffer } from '../../scripts/utils/pricing.js';
+import { getOffer, buildUrl } from '../../scripts/utils/pricing.js';
 
 import { buildCarousel } from '../shared/carousel.js';
-
-function replaceUrlParam(url, paramName, paramValue) {
-  const params = url.searchParams;
-  params.set(paramName, paramValue);
-  url.search = params.toString();
-  return url;
-}
-
-function buildUrl(optionUrl, country, language) {
-  const currentUrl = new URL(window.location.href);
-  let planUrl = new URL(optionUrl);
-
-  if (!planUrl.hostname.includes('commerce')) {
-    return planUrl.href;
-  }
-  planUrl = replaceUrlParam(planUrl, 'co', country);
-  planUrl = replaceUrlParam(planUrl, 'lang', language);
-  let rUrl = planUrl.searchParams.get('rUrl');
-  if (currentUrl.searchParams.has('host')) {
-    const hostParam = currentUrl.searchParams.get('host');
-    if (hostParam === 'express.adobe.com') {
-      planUrl.hostname = 'commerce.adobe.com';
-      if (rUrl) rUrl = rUrl.replace('express.adobe.com', hostParam);
-    } else if (hostParam.includes('qa.adobeprojectm.com')) {
-      planUrl.hostname = 'commerce.adobe.com';
-      if (rUrl) rUrl = rUrl.replace('express.adobe.com', hostParam);
-    } else if (hostParam.includes('.adobeprojectm.com')) {
-      planUrl.hostname = 'commerce-stg.adobe.com';
-      if (rUrl) rUrl = rUrl.replace('adminconsole.adobe.com', 'stage.adminconsole.adobe.com');
-      if (rUrl) rUrl = rUrl.replace('express.adobe.com', hostParam);
-    }
-  }
-
-  const env = getHelixEnv();
-  if (env && env.commerce && planUrl.hostname.includes('commerce')) planUrl.hostname = env.commerce;
-  if (env && env.spark && rUrl) {
-    const url = new URL(rUrl);
-    url.hostname = env.spark;
-    rUrl = url.toString();
-  }
-
-  if (rUrl) {
-    rUrl = new URL(rUrl);
-
-    if (currentUrl.searchParams.has('touchpointName')) {
-      rUrl = replaceUrlParam(rUrl, 'touchpointName', currentUrl.searchParams.get('touchpointName'));
-    }
-    if (currentUrl.searchParams.has('destinationUrl')) {
-      rUrl = replaceUrlParam(rUrl, 'destinationUrl', currentUrl.searchParams.get('destinationUrl'));
-    }
-    if (currentUrl.searchParams.has('srcUrl')) {
-      rUrl = replaceUrlParam(rUrl, 'srcUrl', currentUrl.searchParams.get('srcUrl'));
-    }
-  }
-
-  if (currentUrl.searchParams.has('code')) {
-    planUrl.searchParams.set('code', currentUrl.searchParams.get('code'));
-  }
-
-  if (currentUrl.searchParams.get('rUrl')) {
-    rUrl = currentUrl.searchParams.get('rUrl');
-  }
-
-  if (rUrl) planUrl.searchParams.set('rUrl', rUrl.toString());
-  return planUrl.href;
-}
 
 function pushPricingAnalytics(adobeEventName, sparkEventName, plan) {
   const url = new URL(window.location.href);

--- a/express/scripts/utils/pricing.js
+++ b/express/scripts/utils/pricing.js
@@ -9,7 +9,79 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { getLocale, getLanguage, getCookie } from '../scripts.js';
+import {
+  getLocale,
+  getLanguage,
+  getCookie,
+  getHelixEnv,
+} from '../scripts.js';
+
+function replaceUrlParam(url, paramName, paramValue) {
+  const params = url.searchParams;
+  params.set(paramName, paramValue);
+  url.search = params.toString();
+  return url;
+}
+
+export function buildUrl(optionUrl, country, language) {
+  const currentUrl = new URL(window.location.href);
+  let planUrl = new URL(optionUrl);
+
+  if (!planUrl.hostname.includes('commerce')) {
+    return planUrl.href;
+  }
+  planUrl = replaceUrlParam(planUrl, 'co', country);
+  planUrl = replaceUrlParam(planUrl, 'lang', language);
+  let rUrl = planUrl.searchParams.get('rUrl');
+  if (currentUrl.searchParams.has('host')) {
+    const hostParam = currentUrl.searchParams.get('host');
+    const { host } = new URL(hostParam);
+    if (host === 'express.adobe.com') {
+      planUrl.hostname = 'commerce.adobe.com';
+      if (rUrl) rUrl = rUrl.replace('express.adobe.com', hostParam);
+    } else if (host === 'qa.adobeprojectm.com') {
+      planUrl.hostname = 'commerce.adobe.com';
+      if (rUrl) rUrl = rUrl.replace('express.adobe.com', hostParam);
+    } else if (host.endsWith('.adobeprojectm.com')) {
+      planUrl.hostname = 'commerce-stg.adobe.com';
+      if (rUrl) rUrl = rUrl.replace('adminconsole.adobe.com', 'stage.adminconsole.adobe.com');
+      if (rUrl) rUrl = rUrl.replace('express.adobe.com', hostParam);
+    }
+  }
+
+  const env = getHelixEnv();
+  if (env && env.commerce && planUrl.hostname.includes('commerce')) planUrl.hostname = env.commerce;
+  if (env && env.spark && rUrl) {
+    const url = new URL(rUrl);
+    url.hostname = env.spark;
+    rUrl = url.toString();
+  }
+
+  if (rUrl) {
+    rUrl = new URL(rUrl);
+
+    if (currentUrl.searchParams.has('touchpointName')) {
+      rUrl = replaceUrlParam(rUrl, 'touchpointName', currentUrl.searchParams.get('touchpointName'));
+    }
+    if (currentUrl.searchParams.has('destinationUrl')) {
+      rUrl = replaceUrlParam(rUrl, 'destinationUrl', currentUrl.searchParams.get('destinationUrl'));
+    }
+    if (currentUrl.searchParams.has('srcUrl')) {
+      rUrl = replaceUrlParam(rUrl, 'srcUrl', currentUrl.searchParams.get('srcUrl'));
+    }
+  }
+
+  if (currentUrl.searchParams.has('code')) {
+    planUrl.searchParams.set('code', currentUrl.searchParams.get('code'));
+  }
+
+  if (currentUrl.searchParams.get('rUrl')) {
+    rUrl = currentUrl.searchParams.get('rUrl');
+  }
+
+  if (rUrl) planUrl.searchParams.set('rUrl', rUrl.toString());
+  return planUrl.href;
+}
 
 function getCurrencyDisplay(currency) {
   if (currency === 'JPY') {


### PR DESCRIPTION
Pricing Summary shouldn't be using the link in the {{pricing}} directly. Instead, we'll be using the same buildUrl method from puf block. You can verify that the Start 30-day free trial CTA is correct now by seeing the pricing summary page with overridden helix-env having commerce link instead of commerce-stg link.
![image](https://github.com/adobecom/express/assets/57737624/f80b096b-c24e-4842-b46c-50130ad0c4c5)

Test URLs:

Before: https://main--express--adobecom.hlx.page/express/?lighthouse=on&helix-env=prod
After: https://pricing-summary-link-fix--express--adobecom.hlx.page/express/?lighthouse=on&helix-env=prod
