### PR TITLE
Enable Selection of Martech, GNAV, targetTesting=off

### DIFF
--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -297,7 +297,7 @@ async function loadFEDS() {
   loadScript(`${prefix}/etc.clientlibs/globalnav/clientlibs/base/feds.js`).id = 'feds-script';
 }
 
-if (!window.hlx || (!window.hlx.lighthouse && window.hlx.gnav)) {
+if (!window.hlx || window.hlx.gnav) {
   loadIMS();
   loadFEDS();
   loadGoogleYOLO();

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -297,7 +297,7 @@ async function loadFEDS() {
   loadScript(`${prefix}/etc.clientlibs/globalnav/clientlibs/base/feds.js`).id = 'feds-script';
 }
 
-if (!window.hlx || !window.hlx.lighthouse) {
+if (!window.hlx || !(window.hlx.lighthouse || window.hlx.nognav)) {
   loadIMS();
   loadFEDS();
   loadGoogleYOLO();

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -297,7 +297,7 @@ async function loadFEDS() {
   loadScript(`${prefix}/etc.clientlibs/globalnav/clientlibs/base/feds.js`).id = 'feds-script';
 }
 
-if (!window.hlx || !(window.hlx.lighthouse || window.hlx.nognav)) {
+if (!window.hlx || (!window.hlx.lighthouse && window.hlx.gnav)) {
   loadIMS();
   loadFEDS();
   loadGoogleYOLO();

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -2185,7 +2185,7 @@ async function loadEager(main) {
 
     removeIrrelevantSections(main);
   }
-  if (!window.hlx.lighthouse && !window.hlx.notesting) await decorateTesting();
+  if (!window.hlx.lighthouse && window.hlx.testing) await decorateTesting();
 
   // for backward compatibility
   // TODO: remove the href check after we tag content with sheet-powered
@@ -2217,7 +2217,7 @@ async function loadEager(main) {
 
     document.querySelector('body').classList.add('appear');
 
-    if (!window.hlx.lighthouse && !window.hlx.notesting) {
+    if (!window.hlx.lighthouse && window.hlx.testing) {
       const target = checkTesting();
       if (useAlloy) {
         document.querySelector('body').classList.add('personalization-container');
@@ -2267,7 +2267,7 @@ async function loadLazy(main) {
   resolveFragments();
   removeMetadata();
   addFavIcon('/express/icons/cc-express.svg');
-  if (!window.hlx.lighthouse && !window.hlx.nomartech) loadMartech();
+  if (!window.hlx.lighthouse && window.hlx.martech) loadMartech();
   const tkID = TK_IDS[getLocale(window.location)];
   if (tkID) {
     const { default: loadFonts } = await import('./fonts.js');
@@ -2285,9 +2285,9 @@ async function loadLazy(main) {
 async function decoratePage() {
   window.hlx = window.hlx || {};
   const params = new URLSearchParams(window.location.search);
-  window.hlx.nomartech = params.get('martech') === 'off';
-  window.hlx.nognav = params.get('gnav') === 'off';
-  window.hlx.notesting = params.get('testing') === 'off';
+  window.hlx.martech = params.get('martech') !== 'off';
+  window.hlx.gnav = params.get('gnav') !== 'off';
+  window.hlx.testing = params.get('testing') !== 'off';
   window.hlx.lighthouse = params.get('lighthouse') === 'on';
   window.hlx.init = true;
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -2185,7 +2185,7 @@ async function loadEager(main) {
 
     removeIrrelevantSections(main);
   }
-  if (!window.hlx.lighthouse && window.hlx.testing) await decorateTesting();
+  if (window.hlx.testing) await decorateTesting();
 
   // for backward compatibility
   // TODO: remove the href check after we tag content with sheet-powered
@@ -2217,7 +2217,7 @@ async function loadEager(main) {
 
     document.querySelector('body').classList.add('appear');
 
-    if (!window.hlx.lighthouse && window.hlx.testing) {
+    if (window.hlx.testing) {
       const target = checkTesting();
       if (useAlloy) {
         document.querySelector('body').classList.add('personalization-container');
@@ -2267,7 +2267,7 @@ async function loadLazy(main) {
   resolveFragments();
   removeMetadata();
   addFavIcon('/express/icons/cc-express.svg');
-  if (!window.hlx.lighthouse && window.hlx.martech) loadMartech();
+  if (window.hlx.martech) loadMartech();
   const tkID = TK_IDS[getLocale(window.location)];
   if (tkID) {
     const { default: loadFonts } = await import('./fonts.js');
@@ -2285,10 +2285,10 @@ async function loadLazy(main) {
 async function decoratePage() {
   window.hlx = window.hlx || {};
   const params = new URLSearchParams(window.location.search);
-  window.hlx.martech = params.get('martech') !== 'off';
-  window.hlx.gnav = params.get('gnav') !== 'off';
-  window.hlx.testing = params.get('testing') !== 'off';
-  window.hlx.lighthouse = params.get('lighthouse') === 'on';
+  ['martech', 'gnav', 'testing'].forEach((p) => {
+    window.hlx[p] = params.get('lighthouse') !== 'on' && params.get(p) !== 'off';
+  });
+
   window.hlx.init = true;
 
   const main = document.querySelector('main');

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -2185,7 +2185,7 @@ async function loadEager(main) {
 
     removeIrrelevantSections(main);
   }
-  if (!window.hlx.lighthouse) await decorateTesting();
+  if (!window.hlx.lighthouse && !window.hlx.notesting) await decorateTesting();
 
   // for backward compatibility
   // TODO: remove the href check after we tag content with sheet-powered
@@ -2217,7 +2217,7 @@ async function loadEager(main) {
 
     document.querySelector('body').classList.add('appear');
 
-    if (!window.hlx.lighthouse) {
+    if (!window.hlx.lighthouse && !window.hlx.notesting) {
       const target = checkTesting();
       if (useAlloy) {
         document.querySelector('body').classList.add('personalization-container');
@@ -2267,7 +2267,7 @@ async function loadLazy(main) {
   resolveFragments();
   removeMetadata();
   addFavIcon('/express/icons/cc-express.svg');
-  if (!window.hlx.lighthouse) loadMartech();
+  if (!window.hlx.lighthouse && !window.hlx.nomartech) loadMartech();
   const tkID = TK_IDS[getLocale(window.location)];
   if (tkID) {
     const { default: loadFonts } = await import('./fonts.js');
@@ -2284,7 +2284,11 @@ async function loadLazy(main) {
  */
 async function decoratePage() {
   window.hlx = window.hlx || {};
-  window.hlx.lighthouse = new URLSearchParams(window.location.search).get('lighthouse') === 'on';
+  const params = new URLSearchParams(window.location.search);
+  window.hlx.nomartech = params.get('martech') === 'off';
+  window.hlx.nognav = params.get('gnav') === 'off';
+  window.hlx.notesting = params.get('testing') === 'off';
+  window.hlx.lighthouse = params.get('lighthouse') === 'on';
   window.hlx.init = true;
 
   const main = document.querySelector('main');


### PR DESCRIPTION
Instead of only using ?lighthosue=on, we can now use ?martech=off&gnav=off and so on to more flexibly control what to turn on/off

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/?gnav=off
- After: https://test-performance-flags--express--adobecom.hlx.page/express/?gnav=off
