### PR TITLE
Mwpw 135637 delay gdpr popup

### DIFF
--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -292,6 +292,7 @@ async function loadFEDS() {
     prefix = 'https://www.adobe.com';
   }
   loadScript(`${prefix}/etc.clientlibs/globalnav/clientlibs/base/feds.js`).id = 'feds-script';
+  // delay gdpr popup so it is not LCP for mobile
   setTimeout(() => {
     window.fedsConfig.privacy = {
       otDomainId: '7a5eb705-95ed-4cc4-a11d-0cc5760e93db',

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -292,7 +292,6 @@ async function loadFEDS() {
     prefix = 'https://www.adobe.com';
   }
   loadScript(`${prefix}/etc.clientlibs/globalnav/clientlibs/base/feds.js`).id = 'feds-script';
-  // delay gdpr popup so it is not LCP for mobile
   setTimeout(() => {
     window.fedsConfig.privacy = {
       otDomainId: '7a5eb705-95ed-4cc4-a11d-0cc5760e93db',

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -223,10 +223,6 @@ async function loadFEDS() {
         window.location.href = sparkLoginUrl;
       },
     },
-    privacy: {
-      otDomainId: '7a5eb705-95ed-4cc4-a11d-0cc5760e93db',
-      footerLinkSelector: '[data-feds-action="open-adchoices-modal"]',
-    },
     jarvis: getMetadata('enable-chat') === 'yes'
       ? {
         surfaceName: 'AdobeExpressEducation',
@@ -296,6 +292,19 @@ async function loadFEDS() {
     prefix = 'https://www.adobe.com';
   }
   loadScript(`${prefix}/etc.clientlibs/globalnav/clientlibs/base/feds.js`).id = 'feds-script';
+  setTimeout(() => {
+    window.fedsConfig.privacy = {
+      otDomainId: '7a5eb705-95ed-4cc4-a11d-0cc5760e93db',
+    };
+    loadScript('https://www.adobe.com/etc.clientlibs/globalnav/clientlibs/base/privacy-standalone.js');
+  }, 3500);
+  const footer = document.querySelector('footer');
+  footer?.addEventListener('click', (event) => {
+    if (event.target.closest('a[data-feds-action="open-adchoices-modal"]')) {
+      event.preventDefault();
+      window.adobePrivacy?.showPreferenceCenter();
+    }
+  });
 }
 
 if (!window.hlx || !window.hlx.lighthouse) {


### PR DESCRIPTION
Delays the GDPR popup, which appears in European countries. To test this you'll probably need to join the hamburg or london vpn. 
You should expect to see the popup being LCP on mobile on the main branch and it not being LCP for this branch. 

Resolves: [mwpw-135637](https://jira.corp.adobe.com/browse/mwpw-135637)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://mwpw-135637-delay-gdpr-popup--express--adobecom.hlx.page/express/
