### PR TITLE
[MWPW-135726] Business Audience Page: Block enhancements

### DIFF
--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -551,6 +551,46 @@ main .collapsible-card-wrapper + .columns-wrapper .columns > div {
   text-align: center;
 }
 
+main .columns .button-container.free-plan-container.stacked .free-plan-widget {
+  margin-top: 0;
+  padding: 16px 0;
+  background-color: transparent;
+}
+
+main .columns.center.button-container.free-plan-container.stacked .free-plan-widget {
+  padding-left: 24px;
+}
+
+main .columns-fullsize-top-container .columns-wrapper {
+  max-width: 1200px;
+}
+
+main .columns.fullsize.top > div {
+  padding: 40px 0;
+}
+
+main .columns.fullsize.top .column {
+  width: auto;
+  padding: 0 20px;
+}
+
+main .columns.fullsize.top .column .columns-iconlist > div {
+  margin-top: 12px;
+}
+
+main .columns.fullsize.top .column .columns-iconlist p {
+  font-size: var(--body-font-size-s);
+  line-height: 18px;
+}
+
+main .columns.fullsize.top .column .columns-iconlist .columns-iconlist-icon img.icon {
+  margin-right: 8px;
+}
+
+main .columns.fullsize.top .column .columns-iconlist .columns-iconlist-description {
+  margin-left: 8px;
+}
+
 /* Japanese font sizing styles */
 :lang(ja) main .columns h2.columns-heading-long {
   font-size: var(--heading-font-size-l);
@@ -614,15 +654,15 @@ main .collapsible-card-wrapper + .columns-wrapper .columns > div {
     padding-right: 32px;
   }
 
-  main .columns .column:first-child:not(.column-picture):not(.hero-animation-overlay):not('.text') {
+  main .columns .column:first-child:not(.column-picture):not(.hero-animation-overlay):not(.text) {
     padding-right: 16px;
   }
 
-  main .columns .column:nth-child(2):not(.column-picture):not(.hero-animation-overlay):not('.text') {
+  main .columns .column:nth-child(2):not(.column-picture):not(.hero-animation-overlay):not(.text) {
     padding-left: 16px;
   }
 
-  main .columns .column:nth-child(2):not(.column-picture):not(.hero-animation-overlay):not('.text') {
+  main .columns .column:nth-child(2):not(.column-picture):not(.hero-animation-overlay):not(.text) {
     padding-left: 16px;
   }
 
@@ -792,16 +832,6 @@ main .collapsible-card-wrapper + .columns-wrapper .columns > div {
   }
 }
 
-main .columns .button-container.free-plan-container.stacked .free-plan-widget {
-  margin-top: 0;
-  padding: 16px 0;
-  background-color: transparent;
-}
-
-main .columns.center.button-container.free-plan-container.stacked .free-plan-widget {
-  padding-left: 24px;
-}
-
 @media (min-width: 1200px) {
   main .columns-container > div,
   main .columns-dark-container > div,
@@ -870,6 +900,10 @@ main .columns.center.button-container.free-plan-container.stacked .free-plan-wid
 
   main .columns.columns.custom-color > div {
     gap: 25px;
+  }
+
+  main .columns.fullsize.top > div {
+    padding: 80px 0;
   }
 
   :lang(ja) main .columns h1{

--- a/express/blocks/marquee/marquee.css
+++ b/express/blocks/marquee/marquee.css
@@ -4,7 +4,7 @@ body.no-desktop-brand-header header {
 }
 
 .marquee-container,
-.marquee-wide-container {
+.marquee-narrow-container {
   padding-top: 0;
 }
 
@@ -38,6 +38,10 @@ body.no-desktop-brand-header header {
   width: 100%;
   max-width: 1440px;
   margin: auto;
+}
+
+.marquee.narrow .marquee-foreground {
+  max-width: 1200px;
 }
 
 .marquee .marquee-foreground > p:first-child img {
@@ -106,17 +110,6 @@ body.no-desktop-brand-header header {
   color: var(--color-white);
 }
 
-.marquee.wide .marquee-background {
-  min-height: unset;
-  max-height: unset;
-}
-
-.marquee.wide video.marquee-background {
-  max-height: 200px;
-  min-height: 200px;
-  object-position: 75% 100%;
-}
-
 .marquee .hero-shadow {
   display: none;
 }
@@ -151,13 +144,13 @@ body.no-desktop-brand-header header {
   margin-left: 0;
 }
 
-.marquee.wide .free-plan-widget {
+.marquee .free-plan-widget {
   margin: 0;
   background-color: transparent;
   padding-left: 0;
 }
 
-.marquee p.button-container a.secondary::before {
+.marquee p.button-container a.video-link::before {
   display: inline-block;
   width: 18px;
   height: 20px;
@@ -219,26 +212,17 @@ body.no-desktop-brand-header header {
     display: block;
   }
 
-  .marquee.wide {
-    position: relative;
-    margin: 0 auto;
-  }
-
-  .marquee.wide.fullwidth {
-    max-width: unset;
-  }
-
-  .marquee.wide h1 {
+  .marquee.short h1 {
     font-size: var(--heading-font-size-l);
   }
 
-  .marquee.wide p {
+  .marquee.short p {
     font-size: var(--body-font-size-m);
     position: relative;
     margin: 12px 0;
   }
 
-  .marquee.wide .marquee-foreground > p:first-child img.icon {
+  .marquee.short .marquee-foreground > p:first-child img.icon {
     height: 30px;
   }
 
@@ -263,7 +247,7 @@ body.no-desktop-brand-header header {
     max-height: unset;
   }
 
-  .marquee.wide video.marquee-background {
+  .marquee.short video.marquee-background {
     position: absolute;
     top: 0;
     left: 0;
@@ -295,7 +279,7 @@ body.no-desktop-brand-header header {
     justify-content: center;
   }
 
-  .marquee.wide .marquee-foreground {
+  .marquee.short .marquee-foreground {
     box-sizing: border-box;
     padding: 32px 20px;
     min-height: 250px;
@@ -303,6 +287,14 @@ body.no-desktop-brand-header header {
 
   .marquee .marquee-foreground .content-wrapper {
     max-width: 46%;
+  }
+
+  .marquee.narrow .marquee-foreground .content-wrapper {
+    max-width: 60%;
+  }
+
+  .marquee.narrow .marquee-foreground .content-wrapper p {
+    max-width: 80%;
   }
 
   .marquee .hero-shadow {
@@ -341,16 +333,16 @@ body.no-desktop-brand-header header {
     filter: invert(100%) sepia(0%) saturate(1%) hue-rotate(172deg) brightness(110%) contrast(101%);
   }
 
-  .marquee.wide .button-container.free-plan-container {
+  .marquee.short .button-container.free-plan-container {
     flex-direction: row;
     align-items: center;
   }
 
-  .marquee.wide .button-container.free-plan-container a.button {
+  .marquee.short .button-container.free-plan-container a.button {
     margin-right: 24px;
   }
 
-  .marquee.wide .button-container.free-plan-container.stacked {
+  .marquee.short .button-container.free-plan-container.stacked {
     flex-direction: column;
     align-items: flex-start;
   }
@@ -359,18 +351,18 @@ body.no-desktop-brand-header header {
     align-items: center;
   }
 
-  .marquee.wide .button-container.free-plan-container .free-plan-widget {
+  .marquee.short .button-container.free-plan-container .free-plan-widget {
     margin-top: 0;
     padding: 16px 24px;
   }
 
-  .marquee.wide .button-container.free-plan-container.stacked .free-plan-widget {
+  .marquee.short .button-container.free-plan-container.stacked .free-plan-widget {
     padding-left: 0;
   }
 }
 
 @media (min-width: 1200px) {
-  .marquee:not(.wide) .marquee-foreground {
+  .marquee .marquee-foreground {
     min-height: 400px;
     padding: 56px 20px;
   }


### PR DESCRIPTION
**Description**
- Marquee block now has narrow and short variants (short changes height and font-size, while narrow limits block width to 1200px)
- I discovered that the columns block comes with a lot of variants, among which the fullsize and top combo isn't currently used and brings the block close enough to the figma. I made small changes to .fullsize.top combo to be 1:1 to the design

Resolves: [MWPW-135726](https://jira.corp.adobe.com/browse/MWPW-135726)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/qiyundai/business?lighthouse=on
- After: https://mwpw-135726--express--adobecom.hlx.page/drafts/qiyundai/business?lighthouse=on
