### PR TITLE
Send Unhandled Client-Side Errors to Lana

### DIFF
--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -1542,6 +1542,7 @@ async function buildTemplateList(block, props, type = []) {
 
     await decorateTemplates(block, props);
   } else {
+    window.lana.log(`failed to load templates with props: ${JSON.stringify(props)}`, { tags: 'templates-api' });
     // fixme: better error message.
     block.innerHTML = 'Oops. Our templates delivery got stolen. Please try refresh the page.';
   }

--- a/express/scripts/block-mediator.js
+++ b/express/scripts/block-mediator.js
@@ -53,7 +53,7 @@ const BlockMediator = (() => {
    * @returns {function(): void} unsubscribe func
    * @example
    * const unsubscribe = mediator.subscribe('storeName', ({ oldValue, newValue }) => {
-   *  console.log(`storeName value from ${oldValue} to ${newValue}`);
+   *  reactToNewValue(newValue, oldValue);
    * });
    * @notes
    * 1. It doesn't filter duplicate events

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -926,16 +926,14 @@ export async function loadBlock(block, eager = false) {
               await mod.default(block, blockName, document, eager);
             }
           } catch (err) {
-            // eslint-disable-next-line no-console
-            console.log(`failed to load module for ${blockName}`, err);
+            window.lana.log(`failed to load module for ${blockName}: ${err}`, { s: 10, tags: 'module' });
           }
           resolve();
         })();
       });
       await Promise.all([cssLoaded, decorationComplete]);
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.log(`failed to load block ${blockName}`, err);
+      window.lana.log(`failed to load block ${blockName}: ${err}`, { s: 10, tags: 'block' });
     }
     block.setAttribute('data-block-status', 'loaded');
   }


### PR DESCRIPTION
Added lana error logging on blocking loading/decorating. (sample rate 10%)
Added lana error logging on templates-api failing. (sample rate 1%)
We can see how it goes for now. Later, we should standardize and finalize the tagging and sampling rate approaches, before we can start launching auto-CSO.

Resolves: https://jira.corp.adobe.com/browse/MWPW-135754

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/?lighthouse=on
- After: https://lana-handlers--express--adobecom.hlx.page/express/?lighthouse=on
