### PR TITLE
improve block handling logging

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -926,14 +926,14 @@ export async function loadBlock(block, eager = false) {
               await mod.default(block, blockName, document, eager);
             }
           } catch (err) {
-            window.lana.log(`failed to load module for ${blockName}: ${err}`, { s: 10, tags: 'module' });
+            window.lana.log(`failed to load module for ${blockName}: ${err.message}\nError Stack:${err.stack}`, { sampleRate: 1, tags: 'module' });
           }
           resolve();
         })();
       });
       await Promise.all([cssLoaded, decorationComplete]);
     } catch (err) {
-      window.lana.log(`failed to load block ${blockName}: ${err}`, { s: 10, tags: 'block' });
+      window.lana.log(`failed to load block ${blockName}: ${err.message}\nError Stack:${err.stack}`, { sampleRate: 1, tags: 'block' });
     }
     block.setAttribute('data-block-status', 'loaded');
   }


### PR DESCRIPTION
Sampling Rate for Block error back to 1%, since the number of errors out there exceeded my expectations.
Added stack traces to logs. Note that different browsers implement error.stack differently, so expect seeing inconsistent messages in the index.

Resolves: https://jira.corp.adobe.com/browse/MWPW-135754?filter=381833

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/?lighthouse=on
- After: https://lana-handlers--express--adobecom.hlx.page/express/?lighthouse=on
