### PR TITLE
JP font-size fix for cta-carousel

### DIFF
--- a/express/blocks/cta-carousel/cta-carousel.css
+++ b/express/blocks/cta-carousel/cta-carousel.css
@@ -299,6 +299,11 @@
     top: 64px;
 }
 
+:lang(ja) main .cta-carousel.gen-ai .gen-ai-input,
+:lang(ja) main .cta-carousel.gen-ai .card .card-sleeve .gen-ai-input-form .gen-ai-input::placeholder {
+    font-size: var(--body-font-size-s);
+}
+
 @media (min-width: 900px) {
     .cta-carousel .cta-carousel-heading-section {
         flex-direction: row;


### PR DESCRIPTION
Fixing jp font getting clipped in gen-ai input

Resolves: [MWPW-135853](https://jira.corp.adobe.com/browse/MWPW-135853)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/jp/express/?lighthouse=on
- After: https://mwpw-135853--express--adobecom.hlx.page/jp/express/?lighthouse=on
