### PR TITLE
[MWPW-135326] Updated styling and slide-in behaviour of promo banner

### DIFF
--- a/express/blocks/sticky-promo-bar/sticky-promo-bar.css
+++ b/express/blocks/sticky-promo-bar/sticky-promo-bar.css
@@ -3,7 +3,7 @@ main .sticky-promo-bar {
     left: 0;
     right: 0;
     bottom: 0;
-    transform: translateY(70px);
+    transform: translateY(calc(100% + 24px));
     background-color: var(--color-info-accent);
     color: white;
     padding: 12px 36px 12px 12px;

--- a/express/blocks/sticky-promo-bar/sticky-promo-bar.css
+++ b/express/blocks/sticky-promo-bar/sticky-promo-bar.css
@@ -25,9 +25,11 @@ main .sticky-promo-bar.clone {
 
 body[data-device="mobile"] main .sticky-promo-bar.rounded {
     border-radius: 10px;
-    margin: 11px 24px 16px 24px;
     font-weight: 300;
     padding: 7px 16px 9px;
+    margin: 12px auto;
+    box-sizing: border-box;
+    max-width: 360px;
 }
 
 body[data-device="mobile"] main .sticky-promo-bar.loadinbody {

--- a/express/blocks/sticky-promo-bar/sticky-promo-bar.js
+++ b/express/blocks/sticky-promo-bar/sticky-promo-bar.js
@@ -31,7 +31,7 @@ function initScrollInteraction(block) {
 
   const observer = new IntersectionObserver(intersectionCallback, {
     rootMargin: '0px',
-    threshold: 1.0,
+    threshold: 0,
   });
 
   observer.observe(spotHolder);

--- a/express/blocks/sticky-promo-bar/sticky-promo-bar.js
+++ b/express/blocks/sticky-promo-bar/sticky-promo-bar.js
@@ -14,14 +14,14 @@ import { createTag } from '../../scripts/scripts.js';
 import BlockMediator from '../../scripts/block-mediator.js';
 
 function initScrollInteraction(block) {
-  const spotHolder = block.cloneNode(true);
-  spotHolder.classList.add('clone');
+  const inBodyBanner = block.cloneNode(true);
+  inBodyBanner.classList.add('clone');
   block.classList.add('inbody');
-  block.insertAdjacentElement('afterend', spotHolder);
+  block.insertAdjacentElement('afterend', inBodyBanner);
 
   const intersectionCallback = (entries) => {
     entries.forEach((entry) => {
-      if (!entry.isIntersecting && spotHolder.getBoundingClientRect().top < 0) {
+      if (!entry.isIntersecting && inBodyBanner.getBoundingClientRect().top < 0) {
         block.classList.add('shown');
       } else {
         block.classList.remove('shown');
@@ -34,7 +34,7 @@ function initScrollInteraction(block) {
     threshold: 0,
   });
 
-  observer.observe(spotHolder);
+  observer.observe(inBodyBanner);
 }
 
 export default function decorate(block) {


### PR DESCRIPTION
Resolves: [MWPW-135326](https://jira.corp.adobe.com/browse/MWPW-135326)

Changed threshold for sliding up  promo banner from top to bottom
Made slide down dynamic to size of element:
- Before: https://main--express--adobecom.hlx.page/drafts/casey/firefly-mobile/
- After: https://mwpw-135326-4--express--adobecom.hlx.page/drafts/casey/firefly-mobile/?lighthouse=on

Standardized look of rounded promo banners:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://mwpw-135326-4--express--adobecom.hlx.page/express/?lighthouse=on
