### PR TITLE
MWPW-135859 | Update XML sitemap path to align with a.com and add UK locale setting

### DIFF
--- a/express/sitemap.index.xml
+++ b/express/sitemap.index.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
-    <loc>https://www.adobe.com/express/sitemap.index.xml</loc>
+    <loc>https://www.adobe.com/express/sitemap.xml</loc>
   </sitemap>
   <sitemap>
     <loc>https://www.adobe.com/de/express/sitemap.xml</loc>

--- a/express/sitemap.xml
+++ b/express/sitemap.xml
@@ -52,57 +52,57 @@
     <loc>https://www.adobe.com/in/express/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/blog.sitemap.xml</loc>
+    <loc>https://www.adobe.com/express/blog.sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/jp/blog.sitemap.xml</loc>
+    <loc>https://www.adobe.com/jp/express/blog.sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/uk/blog.sitemap.xml</loc>
+    <loc>https://www.adobe.com/uk/express/blog.sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/de/blog.sitemap.xml</loc>
+    <loc>https://www.adobe.com/de/express/blog.sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/fr/blog.sitemap.xml</loc>
+    <loc>https://www.adobe.com/fr/express/blog.sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/es/blog.sitemap.xml</loc>
+    <loc>https://www.adobe.com/es/express/blog.sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/br/blog.sitemap.xml</loc>
+    <loc>https://www.adobe.com/br/express/blog.sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/it/blog.sitemap.xml</loc>
+    <loc>https://www.adobe.com/it/express/blog.sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/templates.sitemap.xml</loc>
+    <loc>https://www.adobe.com/express/templates.sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/br/templates.sitemap.xml</loc>
+    <loc>https://www.adobe.com/br/express/templates.sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/fr/templates.sitemap.xml</loc>
+    <loc>https://www.adobe.com/fr/express/templates.sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/de/templates.sitemap.xml</loc>
+    <loc>https://www.adobe.com/de/express/templates.sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/it/templates.sitemap.xml</loc>
+    <loc>https://www.adobe.com/it/express/templates.sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/jp/templates.sitemap.xml</loc>
+    <loc>https://www.adobe.com/jp/express/templates.sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/kr/templates.sitemap.xml</loc>
+    <loc>https://www.adobe.com/kr/express/templates.sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/es/templates.sitemap.xml</loc>
+    <loc>https://www.adobe.com/es/express/templates.sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/tw/templates.sitemap.xml</loc>
+    <loc>https://www.adobe.com/tw/express/templates.sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/nl/templates.sitemap.xml</loc>
+    <loc>https://www.adobe.com/nl/express/templates.sitemap.xml</loc>
   </sitemap>
 </sitemapindex>

--- a/express/sitemap.xml
+++ b/express/sitemap.xml
@@ -1,42 +1,108 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
-    <loc>https://www.adobe.com/express/sitemap-us.xml</loc>
+    <loc>https://www.adobe.com/express/sitemap.index.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/express/sitemap-de.xml</loc>
+    <loc>https://www.adobe.com/de/express/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/express/sitemap-es.xml</loc>
+    <loc>https://www.adobe.com/es/express/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/express/sitemap-fr.xml</loc>
+    <loc>https://www.adobe.com/fr/express/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/express/sitemap-it.xml</loc>
+    <loc>https://www.adobe.com/it/express/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/express/sitemap-jp.xml</loc>
+    <loc>https://www.adobe.com/jp/express/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/express/sitemap-kr.xml</loc>
+    <loc>https://www.adobe.com/kr/express/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/express/sitemap-nl.xml</loc>
+    <loc>https://www.adobe.com/nl/express/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/express/sitemap-br.xml</loc>
+    <loc>https://www.adobe.com/br/express/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/express/sitemap-tw.xml</loc>
+    <loc>https://www.adobe.com/tw/express/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/express/sitemap-other.xml</loc>
+    <loc>https://www.adobe.com/cn/express/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/express/sitemap-blog.xml</loc>
+    <loc>https://www.adobe.com/dk/express/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/express/sitemap-seo-templates.xml</loc>
+    <loc>https://www.adobe.com/fi/express/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/no/express/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/se/express/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/uk/express/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/in/express/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/blog.sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/jp/blog.sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/uk/blog.sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/de/blog.sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/fr/blog.sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/es/blog.sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/br/blog.sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/it/blog.sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/templates.sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/br/templates.sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/fr/templates.sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/de/templates.sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/it/templates.sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/jp/templates.sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/kr/templates.sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/es/templates.sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/tw/templates.sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/nl/templates.sitemap.xml</loc>
   </sitemap>
 </sitemapindex>

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -7,82 +7,87 @@ sitemaps:
     languages:
       default:
         source: /express/query-index.json
-        destination: /express/sitemap-us.xml
+        destination: /express/sitemap.index.xml
         hreflang: en
         alternate: /{path}
+      unitedkingdom:
+        source: /uk/express/query-index.json
+        destination: /uk/express/sitemap.xml
+        hreflang: en-GB
+        alternate: /uk/{path}
       germany:
         source: /de/express/query-index.json
-        destination: /express/sitemap-de.xml
+        destination: /de/express/sitemap.xml
         hreflang: de
         alternate: /de/{path}
       spain:
         source: /es/express/query-index.json
-        destination: /express/sitemap-es.xml
+        destination: /es/express/sitemap.xml
         hreflang: es
         alternate: /es/{path}
       france:
         source: /fr/express/query-index.json
-        destination: /express/sitemap-fr.xml
+        destination: /fr/express/sitemap.xml
         hreflang: fr
         alternate: /fr/{path}
       italy:
         source: /it/express/query-index.json
-        destination: /express/sitemap-it.xml
+        destination: /it/express/sitemap.xml
         hreflang: it
         alternate: /it/{path}
       japan:
         source: /jp/express/query-index.json
-        destination: /express/sitemap-jp.xml
+        destination: /jp/express/sitemap.xml
         hreflang: ja
         alternate: /jp/{path}
       korea:
         source: /kr/express/query-index.json
-        destination: /express/sitemap-kr.xml
+        destination: /kr/express/sitemap.xml
         hreflang: ko
         alternate: /kr/{path}
       netherlands:
         source: /nl/express/query-index.json
-        destination: /express/sitemap-nl.xml
+        destination: /nl/express/sitemap.xml
         hreflang: nl
         alternate: /nl/{path}
       brasil:
         source: /br/express/query-index.json
-        destination: /express/sitemap-br.xml
+        destination: /br/express/sitemap.xml
         hreflang: pt
         alternate: /br/{path}
       taiwan:
         source: /tw/express/query-index.json
-        destination: /express/sitemap-tw.xml
+        destination: /tw/express/sitemap.xml
         hreflang: zh-Hant
         alternate: /tw/{path}
       china:
         source: /cn/express/query-index.json
-        destination: /express/sitemap-other.xml
+        destination: /cn/express/sitemap.xml
         hreflang: zh-Hans
         alternate: /cn/{path}
       denmark:
         source: /dk/express/query-index.json
-        destination: /express/sitemap-other.xml
+        destination: /dk/express/sitemap.xml
         hreflang: da
         alternate: /dk/{path}
       finland:
         source: /fi/express/query-index.json
-        destination: /express/sitemap-other.xml
+        destination: /fi/express/sitemap.xml
         hreflang: fi
         alternate: /fi/{path}
       norway:
         source: /no/express/query-index.json
-        destination: /express/sitemap-other.xml
+        destination: /no/express/sitemap.xml
         hreflang: nb
         alternate: /no/{path}
       sweden:
         source: /se/express/query-index.json
-        destination: /express/sitemap-other.xml
+        destination: /se/express/sitemap.xml
         hreflang: sv
         alternate: /se/{path}
       india:
         source: /in/express/query-index.json
-        destination: /express/sitemap-other.xml
+        destination: /in/express/sitemap.xml
         hreflang: en-IN
         alternate: /in/{path}
 
@@ -92,37 +97,42 @@ sitemaps:
     languages:
       default:
         source: /express/learn/blog/query-index.json
-        destination: /express/sitemap-blog.xml
+        destination: /express/blog.sitemap.xml
         hreflang: en
         alternate: /{path}
       japan:
         source: /jp/express/learn/blog/query-index.json
-        destination: /express/sitemap-blog.xml
+        destination: /jp/express/blog.sitemap.xml
         hreflang: ja
         alternate: /jp/{path}
+      unitedkingdom:
+        source: /uk/express/learn/blog/query-index.json
+        destination: /uk/express/blog.sitemap.xml
+        hreflang: en-GB
+        alternate: /uk/{path}
       germany:
         source: /de/express/learn/blog/query-index.json
-        destination: /express/sitemap-blog.xml
+        destination: /de/express/blog.sitemap.xml
         hreflang: de
         alternate: /de/{path}
       france:
         source: /fr/express/learn/blog/query-index.json
-        destination: /express/sitemap-blog.xml
+        destination: /fr/express/blog.sitemap.xml
         hreflang: fr
         alternate: /fr/{path}
       spain:
         source: /es/express/learn/blog/query-index.json
-        destination: /express/sitemap-blog.xml
+        destination: /es/express/blog.sitemap.xml
         hreflang: es
         alternate: /es/{path}
       brazil:
         source: /br/express/learn/blog/query-index.json
-        destination: /express/sitemap-blog.xml
+        destination: /br/express/blog.sitemap.xml
         hreflang: pt
         alternate: /br/{path}
       it:
         source: /it/express/learn/blog/query-index.json
-        destination: /express/sitemap-blog.xml
+        destination: /it/express/blog.sitemap.xml
         hreflang: it
         alternate: /it/{path}
 
@@ -131,51 +141,51 @@ sitemaps:
     languages:
       default:
         source: /express/templates/default/metadata.json?sheet=sitemap
-        destination: /express/sitemap-seo-templates.xml
+        destination: /express/templates.sitemap.xml
         hreflang: en
         alternate: /{path}
       brasil:
         source: /br/express/templates/default/metadata.json?sheet=sitemap
-        destination: /express/sitemap-seo-templates.xml
+        destination: /br/express/templates.sitemap.xml
         hreflang: pt
         alternate: /br/{path}
       france:
         source: /fr/express/templates/default/metadata.json?sheet=sitemap
-        destination: /express/sitemap-seo-templates.xml
+        destination: /fr/express/templates.sitemap.xml
         hreflang: fr
         alternate: /fr/{path}
       germany:
         source: /de/express/templates/default/metadata.json?sheet=sitemap
-        destination: /express/sitemap-seo-templates.xml
+        destination: /de/express/templates.sitemap.xml
         hreflang: de
         alternate: /de/{path}
       italy:
         source: /it/express/templates/default/metadata.json?sheet=sitemap
-        destination: /express/sitemap-seo-templates.xml
+        destination: /it/express/templates.sitemap.xml
         hreflang: it
         alternate: /it/{path}
       japan:
         source: /jp/express/templates/default/metadata.json?sheet=sitemap
-        destination: /express/sitemap-seo-templates.xml
+        destination: /jp/express/templates.sitemap.xml
         hreflang: ja
         alternate: /jp/{path}
       korea:
         source: /kr/express/templates/default/metadata.json?sheet=sitemap
-        destination: /express/sitemap-seo-templates.xml
+        destination: /kr/express/templates.sitemap.xml
         hreflang: ko
         alternate: /kr/{path}
       spain:
         source: /es/express/templates/default/metadata.json?sheet=sitemap
-        destination: /express/sitemap-seo-templates.xml
+        destination: /es/express/templates.sitemap.xml
         hreflang: es
         alternate: /es/{path}
       taiwan:
         source: /tw/express/templates/default/metadata.json?sheet=sitemap
-        destination: /express/sitemap-seo-templates.xml
+        destination: /tw/express/templates.sitemap.xml
         hreflang: zh-Hant
         alternate: /tw/{path}
       netherlands:
         source: /nl/express/templates/default/metadata.json?sheet=sitemap
-        destination: /express/sitemap-seo-templates.xml
+        destination: /nl/express/templates.sitemap.xml
         hreflang: nl
         alternate: /nl/{path}

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -7,7 +7,7 @@ sitemaps:
     languages:
       default:
         source: /express/query-index.json
-        destination: /express/sitemap.index.xml
+        destination: /express/sitemap.xml
         hreflang: en
         alternate: /{path}
       unitedkingdom:


### PR DESCRIPTION
Update XML sitemap path to align with a.com and add UK locale setting

Resolves: https://jira.corp.adobe.com/browse/MWPW-135859 and 
https://jira.corp.adobe.com/browse/MWPW-135682

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/?lighthouse=on
- After: https://MWPW-135859--express--adobecom.hlx.page/express/?lighthouse=on
