### PR TITLE
Templates API: Region Replaced EN with ZZ

### DIFF
--- a/express/blocks/template-x/template-search-api-v3.js
+++ b/express/blocks/template-x/template-search-api-v3.js
@@ -95,7 +95,8 @@ async function fetchSearchUrl({
   if (langs.length > 0) {
     [prefLang] = langs;
     headers['x-express-pref-lang'] = getLanguage(prefLang);
-    headers['x-express-ims-region-code'] = prefLang.toUpperCase();
+    // TODO: maintaining a more thorough mapping when we add UK and IN, or update getLanguage()
+    headers['x-express-ims-region-code'] = prefLang === 'en' ? 'ZZ' : prefLang.toUpperCase();
   }
   const res = await memoizedFetch(url, { headers });
   if (!res) return res;


### PR DESCRIPTION
You should see no visual difference, except that in the Network tab we are using x-express-ims-region-code: ZZ instead of EN. No impact at the moment but this is to comply with a breaking change going to be deployed this Friday. Without this, all our Global templates will become US-centered templates.

Resolves: https://jira.corp.adobe.com/browse/MWPW-136088

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/templates/flyer?lighthouse=on
- After: https:/global-templates-for-en--express--adobecom.hlx.page/express/templates/flyer?lighthouse=on
