### PR TITLE
MWPW-135640 hide footer until all sections have loaded

### DIFF
--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -295,7 +295,7 @@ async function loadFEDS() {
       otDomainId: '7a5eb705-95ed-4cc4-a11d-0cc5760e93db',
     };
     loadScript('https://www.adobe.com/etc.clientlibs/globalnav/clientlibs/base/privacy-standalone.js');
-  }, 5200);
+  }, 6000);
   const footer = document.querySelector('footer');
   footer?.addEventListener('click', (event) => {
     if (event.target.closest('a[data-feds-action="open-adchoices-modal"]')) {
@@ -312,7 +312,7 @@ if (!window.hlx || window.hlx.gnav) {
     import('./google-yolo.js').then((mod) => {
       mod.default();
     });
-  }, 5200);
+  }, 4000);
 }
 /* Core Web Vitals RUM collection */
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -786,6 +786,7 @@ function decorateHeaderAndFooter() {
     footer.innerHTML = `
       <div id="feds-footer"></div>
     `;
+    footer.setAttribute('data-status', 'loading');
   } else footer.remove();
 }
 
@@ -2333,6 +2334,8 @@ async function loadArea(area = document) {
     delete section.el.dataset.status;
     delete section.el.dataset.idx;
   }
+  const footer = document.querySelector('footer');
+  delete footer.dataset.status;
 
   loadLazy(main);
 

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -117,6 +117,10 @@ body > header {
   background-color: #FFF;
 }
 
+body>footer[data-status='loading']{
+  visibility:hidden;
+}
+
 body.no-brand-header > header,
 body.no-desktop-brand-header > header {
   height: auto;


### PR DESCRIPTION
I another brilliant idea to lower CLS. The footer often causes CLS when it appears, but I can't load it separately like in milo. But what if we hid it so that it appearing doesn't matter?!
This is working for me :)

Resolves: [MWPW-135640](https://jira.corp.adobe.com/browse/MWPW-135640)

Test URLs:
Before: https://main--express--adobecom.hlx.page/express/?martech=off
After: https://mwpw-135640-footer-perf--express--adobecom.hlx.page/express/?martech=off
