### PR TITLE
Template Content API Filter Unsupported Langs to prepare for GB and IN

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -661,6 +661,7 @@ export function getLanguage(locale) {
     de: 'de-DE',
     it: 'it-IT',
     dk: 'da-DK',
+    gb: 'en-GB',
     es: 'es-ES',
     fi: 'fi-FI',
     jp: 'ja-JP',


### PR DESCRIPTION
No impacts/changes should be visible, as this is mostly preparing for the new locales we plan to support in the future.

Note that based on the authored {{locales}}, we are doing language filtering + language boosting + region boosting, but **NO** region filtering.
When we migrate to Milo or a more advanced locale systems (now we only have locales, but we should be doing region + language), we can uncomment the code and support more flexible configurations of Region + Language.

Another note: we have been authoring **EN**, which is our locale concept that doesn't actually map to a valid Region. We should either use US or ZZ(global). At the moment our code maps EN to ZZ.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/fr/express/templates/flyer?lighthouse=on
- After: https://template-x-lang-region--express--adobecom.hlx.page/fr/express/templates/flyer?lighthouse=on
