### PR TITLE
[MWPW 135726] Enabled Video Modal in Columns Block

### DIFF
--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -65,22 +65,22 @@ main .columns .button-container a {
   margin: 0;
 }
 
-main .columns:not(.highlight) .button-container a {
+main .columns:not(.highlight) .column-video .button-container a {
   border-radius: 24px;
   padding: 8px 20px;
 }
 
-main .columns:not(.highlight) .button-container a,
-main .columns:not(.highlight) .button-container a:hover,
-main .columns:not(.highlight) .button-container a:active,
-main .columns:not(.highlight) .button-container a:focus {
+main .columns:not(.highlight) .column-video .button-container a:hover,
+main .columns:not(.highlight) .column-video .button-container a:active,
+main .columns:not(.highlight) .column-video .button-container a,
+main .columns:not(.highlight) .column-video .button-container a:focus {
   background-color: transparent;
   border-color: var(--color-black);
   color: var(--color-black);
   box-shadow: none;
 }
 
-main .columns:not(.highlight) .button-container a:before {
+main .columns:not(.highlight) .column-video .button-container a:before {
   display: inline-block;
   width: 18px;
   height: 20px;

--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -65,6 +65,32 @@ main .columns .button-container a {
   margin: 0;
 }
 
+main .columns:not(.highlight) .button-container a {
+  border-radius: 24px;
+  padding: 8px 20px;
+}
+
+main .columns:not(.highlight) .button-container a,
+main .columns:not(.highlight) .button-container a:hover,
+main .columns:not(.highlight) .button-container a:active,
+main .columns:not(.highlight) .button-container a:focus {
+  background-color: transparent;
+  border-color: var(--color-black);
+  color: var(--color-black);
+  box-shadow: none;
+}
+
+main .columns:not(.highlight) .button-container a:before {
+  display: inline-block;
+  width: 18px;
+  height: 20px;
+  margin-right: 16px;
+  vertical-align: sub;
+  top: 1px;
+  position: relative;
+  content: url(/express/icons/play.svg);
+}
+
 main .columns .column-picture {
   margin: 15px 0;
 }
@@ -306,7 +332,7 @@ main .columns.highlight.width-2-columns .column-picture {
   order: -1
 }
 
-main .columns-video {
+main .columns.highlight .columns-video {
   cursor: pointer;
 }
 
@@ -325,7 +351,7 @@ main .columns-video .column-picture .column-video-overlay {
   height: 100%;
 }
 
-main .columns-video:hover .column-picture .column-video-overlay {
+main .columns.highlight .columns-video:hover .column-picture .column-video-overlay {
   background-image: linear-gradient(#ffffff00, #90909025, #000000a0);
 }
 

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -27,7 +27,7 @@ import {
   isVideoLink,
 } from '../shared/video.js';
 
-function transformToVideoColumn($cell, $a) {
+function transformToVideoColumn($cell, $a, block) {
   const $parent = $cell.parentElement;
   const title = $a.textContent.trim();
   // gather video urls from all links in cell
@@ -45,7 +45,7 @@ function transformToVideoColumn($cell, $a) {
 
   setTimeout(() => {
     const $sibling = $parent.querySelector('.column-picture');
-    if ($sibling) {
+    if ($sibling && block.classList.contains('highlight')) {
       const $videoOverlay = createTag('div', { class: 'column-video-overlay' });
       const $videoOverlayIcon = getIconElement('play', 44);
       $videoOverlay.append($videoOverlayIcon);
@@ -53,11 +53,11 @@ function transformToVideoColumn($cell, $a) {
     }
   }, 1);
 
-  $parent.addEventListener('click', () => {
+  const modalActivator = block.classList.contains('highlight') ? $parent : $a;
+  modalActivator.addEventListener('click', () => {
     displayVideoModal(vidUrls, title, true);
   });
-
-  $parent.addEventListener('keyup', ({ key }) => {
+  modalActivator.addEventListener('keyup', ({ key }) => {
     if (key === 'Enter') {
       displayVideoModal(vidUrls, title);
     }
@@ -175,8 +175,8 @@ export default function decorate($block) {
       // this probably needs to be tighter and possibly earlier
       const $a = $cell.querySelector('a');
       if ($a) {
-        if (isVideoLink($a.href) && $row.parentElement.classList.contains('highlight')) {
-          transformToVideoColumn($cell, $a);
+        if (isVideoLink($a.href)) {
+          transformToVideoColumn($cell, $a, $block);
 
           $a.addEventListener('click', (e) => {
             e.preventDefault();

--- a/express/blocks/shared/video.js
+++ b/express/blocks/shared/video.js
@@ -181,7 +181,6 @@ export function isVideoLink(url) {
 }
 
 export function hideVideoModal(push) {
-  const body = document.querySelector('body');
   const $overlay = document.querySelector('main .video-overlay');
   if ($overlay) {
     $overlay.remove();
@@ -191,17 +190,16 @@ export function hideVideoModal(push) {
     // create new history entry
     window.history.pushState({}, docTitle, window.location.href.split('#')[0]);
   }
-  body.classList.remove('no-scroll');
+  document.body.classList.remove('no-scroll');
 }
 
 export function displayVideoModal(url = [], title, push) {
-  const body = document.querySelector('body');
   let vidUrls = typeof url === 'string' ? [url] : url;
   const [primaryUrl] = vidUrls;
   const canPlayInline = vidUrls
     .some((src) => src && isVideoLink(src));
 
-  body.classList.add('no-scroll');
+  document.body.classList.add('no-scroll');
   if (canPlayInline) {
     const $overlay = createTag('div', { class: 'video-overlay' });
     const $video = createTag('div', { class: 'video-overlay-video', id: 'video-overlay-video' });

--- a/express/blocks/shared/video.js
+++ b/express/blocks/shared/video.js
@@ -181,6 +181,7 @@ export function isVideoLink(url) {
 }
 
 export function hideVideoModal(push) {
+  const body = document.querySelector('body');
   const $overlay = document.querySelector('main .video-overlay');
   if ($overlay) {
     $overlay.remove();
@@ -190,13 +191,17 @@ export function hideVideoModal(push) {
     // create new history entry
     window.history.pushState({}, docTitle, window.location.href.split('#')[0]);
   }
+  body.classList.remove('no-scroll');
 }
 
 export function displayVideoModal(url = [], title, push) {
+  const body = document.querySelector('body');
   let vidUrls = typeof url === 'string' ? [url] : url;
   const [primaryUrl] = vidUrls;
   const canPlayInline = vidUrls
     .some((src) => src && isVideoLink(src));
+
+  body.classList.add('no-scroll');
   if (canPlayInline) {
     const $overlay = createTag('div', { class: 'video-overlay' });
     const $video = createTag('div', { class: 'video-overlay-video', id: 'video-overlay-video' });

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -102,6 +102,11 @@ body {
   padding: 0;
 }
 
+body.no-scroll {
+  overflow-y: hidden;
+  touch-action: none;
+}
+
 /* gnav */
 
 body > header {
@@ -532,6 +537,10 @@ main .section:last-of-type>.default-content-wrapper {
 
   main p {
     font-size: var(--body-font-size-l);
+  }
+
+  body.no-scroll[data-device="desktop"] {
+    padding-right: 15px;
   }
 }
 


### PR DESCRIPTION
Enabled the use of modals in the columns block, which can be expanded to all blocks when we feel necessary.
Can be tested by clicking on the "Play Video" buttons.

Resolves: [MWPW-135726](https://jira.corp.adobe.com/browse/MWPW-135726)

Test URLs:

Before: https://main--express--adobecom.hlx.page/drafts/casey/embedded-youtube
After: https://mwpw-135726-video-modal-2--express--adobecom.hlx.page/drafts/casey/embedded-youtube?lighthouse=on