### PR TITLE
adjust h2 font-size for short marquee

### DIFF
--- a/express/blocks/marquee/marquee.css
+++ b/express/blocks/marquee/marquee.css
@@ -223,7 +223,7 @@ body.no-desktop-brand-header header {
   }
 
   .marquee.short h2 {
-    font-size: var(--heading-font-size-m);
+    font-size: var(--heading-font-size-s);
   }
 
   .marquee.short p {

--- a/express/blocks/marquee/marquee.css
+++ b/express/blocks/marquee/marquee.css
@@ -222,6 +222,10 @@ body.no-desktop-brand-header header {
     font-size: var(--heading-font-size-l);
   }
 
+  .marquee.short h2 {
+    font-size: var(--heading-font-size-m);
+  }
+
   .marquee.short p {
     font-size: var(--body-font-size-m);
     position: relative;

--- a/express/blocks/marquee/marquee.js
+++ b/express/blocks/marquee/marquee.js
@@ -372,7 +372,5 @@ export default async function decorate(block) {
     addHeaderSizing(block);
   }
 
-  handleSubCTAText(block);
-
   block.classList.add('appear');
 }


### PR DESCRIPTION
Quick fix for marquee short variant h2 sizing being the same as h1
Also removed a redundant call of a function for sub-cta text

Resolves: [MWPW-135726](https://jira.corp.adobe.com/browse/MWPW-135726)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/qiyundai/business?lighthouse=on
- After: https://mwpw-135726-2--express--adobecom.hlx.page/drafts/qiyundai/business?lighthouse=on
