### PR TITLE
[MWPW-136430] Sub CTA text with markdown

### DIFF
--- a/express/blocks/marquee/marquee.css
+++ b/express/blocks/marquee/marquee.css
@@ -127,6 +127,7 @@ body.no-desktop-brand-header header {
 .marquee .button-container.button-inline {
   display: inline-block;
   margin-right: 16px;
+  text-align: left;
 }
 
 .marquee .content-wrapper .button-container.free-plan-container {
@@ -287,6 +288,10 @@ body.no-desktop-brand-header header {
     display: flex;
     flex-direction: column;
     justify-content: center;
+  }
+
+  .marquee .button-container.button-inline {
+    text-align: center;
   }
 
   .marquee.short .marquee-foreground {

--- a/express/blocks/marquee/marquee.css
+++ b/express/blocks/marquee/marquee.css
@@ -136,6 +136,10 @@ body.no-desktop-brand-header header {
   flex-wrap: wrap;
 }
 
+.marquee .marquee-foreground .content-wrapper .button-container .cta-sub-text {
+  margin: 0;
+}
+
 .marquee .button-container.button-inline.free-plan-container .free-plan-widget {
   color: var(--body-color);
   background: unset;
@@ -303,7 +307,7 @@ body.no-desktop-brand-header header {
     max-width: 60%;
   }
 
-  .marquee.narrow .marquee-foreground .content-wrapper p {
+  .marquee.narrow .marquee-foreground .content-wrapper > p {
     max-width: 80%;
   }
 

--- a/express/blocks/marquee/marquee.js
+++ b/express/blocks/marquee/marquee.js
@@ -42,11 +42,13 @@ const breakpointConfig = [
 // FIXME: Not fulfilling requirement. Re-think of a way to allow subtext to contain link.
 function handleSubCTAText(buttonContainer) {
   if (buttonContainer.nextElementSibling.tagName === 'BLOCKQUOTE') {
+    const blockQuote = buttonContainer.nextElementSibling;
     const subText = buttonContainer.nextElementSibling.querySelector('p');
     if (subText) {
       subText.classList.add('cta-sub-text');
       buttonContainer.append(subText);
     }
+    blockQuote.remove();
   } else if (buttonContainer.querySelector('a')?.textContent.includes('§')) {
     const button = buttonContainer.querySelector('a');
     const dividedText = button.textContent.split('§');

--- a/express/blocks/marquee/marquee.js
+++ b/express/blocks/marquee/marquee.js
@@ -41,13 +41,19 @@ const breakpointConfig = [
 
 // FIXME: Not fulfilling requirement. Re-think of a way to allow subtext to contain link.
 function handleSubCTAText(buttonContainer) {
-  const button = buttonContainer.querySelector('a');
-  if (button && button.textContent.includes('§')) {
+  if (buttonContainer.nextElementSibling.tagName === 'BLOCKQUOTE') {
+    const subText = buttonContainer.nextElementSibling.querySelector('p');
+    if (subText) {
+      subText.classList.add('cta-sub-text');
+      buttonContainer.append(subText);
+    }
+  } else if (buttonContainer.querySelector('a')?.textContent.includes('§')) {
+    const button = buttonContainer.querySelector('a');
     const dividedText = button.textContent.split('§');
     if (dividedText.length < 2) return;
 
     button.textContent = dividedText[0].trim();
-    const subText = createTag('div', { class: 'cta-sub-text' });
+    const subText = createTag('p', { class: 'cta-sub-text' });
     subText.textContent = dividedText[1]?.trim();
     buttonContainer.append(subText);
   }
@@ -371,8 +377,6 @@ export default async function decorate(block) {
   if (getLocale(window.location) === 'jp') {
     addHeaderSizing(block);
   }
-
-  handleSubCTAText(block);
 
   block.classList.add('appear');
 }

--- a/express/blocks/marquee/marquee.js
+++ b/express/blocks/marquee/marquee.js
@@ -44,7 +44,7 @@ function handleSubCTAText(buttonContainer) {
   if (buttonContainer.nextElementSibling.tagName !== 'BLOCKQUOTE') return;
 
   const blockQuote = buttonContainer.nextElementSibling;
-  const subText = buttonContainer.nextElementSibling.querySelector('p');
+  const subText = blockQuote.querySelector('p');
   if (subText) {
     subText.classList.add('cta-sub-text');
     buttonContainer.append(subText);

--- a/express/blocks/marquee/marquee.js
+++ b/express/blocks/marquee/marquee.js
@@ -49,15 +49,6 @@ function handleSubCTAText(buttonContainer) {
       buttonContainer.append(subText);
     }
     blockQuote.remove();
-  } else if (buttonContainer.querySelector('a')?.textContent.includes('§')) {
-    const button = buttonContainer.querySelector('a');
-    const dividedText = button.textContent.split('§');
-    if (dividedText.length < 2) return;
-
-    button.textContent = dividedText[0].trim();
-    const subText = createTag('p', { class: 'cta-sub-text' });
-    subText.textContent = dividedText[1]?.trim();
-    buttonContainer.append(subText);
   }
 }
 

--- a/express/blocks/marquee/marquee.js
+++ b/express/blocks/marquee/marquee.js
@@ -41,15 +41,15 @@ const breakpointConfig = [
 
 // FIXME: Not fulfilling requirement. Re-think of a way to allow subtext to contain link.
 function handleSubCTAText(buttonContainer) {
-  if (buttonContainer.nextElementSibling.tagName === 'BLOCKQUOTE') {
-    const blockQuote = buttonContainer.nextElementSibling;
-    const subText = buttonContainer.nextElementSibling.querySelector('p');
-    if (subText) {
-      subText.classList.add('cta-sub-text');
-      buttonContainer.append(subText);
-    }
-    blockQuote.remove();
+  if (buttonContainer.nextElementSibling.tagName !== 'BLOCKQUOTE') return;
+
+  const blockQuote = buttonContainer.nextElementSibling;
+  const subText = buttonContainer.nextElementSibling.querySelector('p');
+  if (subText) {
+    subText.classList.add('cta-sub-text');
+    buttonContainer.append(subText);
   }
+  blockQuote.remove();
 }
 
 function getBreakpoint(animations) {


### PR DESCRIPTION
We can now use blockquote (_Quote_ style in word doc) to author a sub CTA text with any type of content. The § method will be deprecated.

Resolves: [MWPW-136430](https://jira.corp.adobe.com/browse/MWPW-136430)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/qiyundai/business?martech=off
- After: https://mwpw-136430--express--adobecom.hlx.page/drafts/qiyundai/business?martech=off