### PR TITLE
Fix tel, mailto and sms links

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1866,16 +1866,18 @@ function decorateLinks(main) {
         url = new URL(a.href);
       }
 
-      // make url relative if needed
-      const relative = url.hostname === window.location.hostname;
-      const urlPath = `${url.pathname}${url.search}${url.hash}`;
-      a.href = relative ? urlPath : `${url.origin}${urlPath}`;
+      const isContactLink = ['tel:', 'mailto:', 'sms:'].includes(url.protocol);
+      const isBranchLink = url.hostname === 'adobesparkpost.app.link';
+      if (!isContactLink) {
+        // make url relative if needed
+        const relative = url.hostname === window.location.hostname;
+        const urlPath = `${url.pathname}${url.search}${url.hash}`;
+        a.href = relative ? urlPath : `${url.origin}${urlPath}`;
 
-      if (!relative
-        && url.hostname !== 'adobesparkpost.app.link'
-        && !['tel:', 'mailto:', 'sms:'].includes(url.protocol)) {
-        // open external links in a new tab
-        a.target = '_blank';
+        if (!relative && !isBranchLink) {
+          // open external links in a new tab
+          a.target = '_blank';
+        }
       }
     } catch (e) {
       // invalid url


### PR DESCRIPTION
This PR fixes the contact links (tel:, mailto:, sms:). Franklin used to regardlessly transform all links to relative and then add _blank to non-contact && non-branch links. Now we exempt contact links from being made relative too.

Resolves: [MWPW-136404](https://jira.corp.adobe.com/browse/MWPW-136404)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/drafts/qiyundai/business?lighthouse=on
- After: https://mwpw-136404-1--express--adobecom.hlx.page/drafts/qiyundai/business?lighthouse=on
