### PR TITLE
Fix marquee with no elements after CTA breaking change

### DIFF
--- a/express/blocks/marquee/marquee.js
+++ b/express/blocks/marquee/marquee.js
@@ -41,15 +41,15 @@ const breakpointConfig = [
 
 // FIXME: Not fulfilling requirement. Re-think of a way to allow subtext to contain link.
 function handleSubCTAText(buttonContainer) {
-  if (buttonContainer.nextElementSibling.tagName !== 'BLOCKQUOTE') return;
+  const elBelowButton = buttonContainer.nextElementSibling;
+  if (!elBelowButton || elBelowButton?.tagName !== 'BLOCKQUOTE') return;
 
-  const blockQuote = buttonContainer.nextElementSibling;
-  const subText = blockQuote.querySelector('p');
+  const subText = elBelowButton.querySelector('p');
   if (subText) {
     subText.classList.add('cta-sub-text');
     buttonContainer.append(subText);
   }
-  blockQuote.remove();
+  elBelowButton.remove();
 }
 
 function getBreakpoint(animations) {

--- a/express/blocks/marquee/marquee.js
+++ b/express/blocks/marquee/marquee.js
@@ -41,15 +41,15 @@ const breakpointConfig = [
 
 // FIXME: Not fulfilling requirement. Re-think of a way to allow subtext to contain link.
 function handleSubCTAText(buttonContainer) {
-  const elBelowButton = buttonContainer.nextElementSibling;
-  if (!elBelowButton || elBelowButton?.tagName !== 'BLOCKQUOTE') return;
+  const elementBelowButton = buttonContainer.nextElementSibling;
+  if (!elementBelowButton || elementBelowButton?.tagName !== 'BLOCKQUOTE') return;
 
-  const subText = elBelowButton.querySelector('p');
+  const subText = elementBelowButton.querySelector('p');
   if (subText) {
     subText.classList.add('cta-sub-text');
     buttonContainer.append(subText);
   }
-  elBelowButton.remove();
+  elementBelowButton.remove();
 }
 
 function getBreakpoint(animations) {

--- a/express/blocks/marquee/marquee.js
+++ b/express/blocks/marquee/marquee.js
@@ -41,15 +41,15 @@ const breakpointConfig = [
 
 // FIXME: Not fulfilling requirement. Re-think of a way to allow subtext to contain link.
 function handleSubCTAText(buttonContainer) {
-  const elementBelowButton = buttonContainer.nextElementSibling;
-  if (!elementBelowButton || elementBelowButton?.tagName !== 'BLOCKQUOTE') return;
+  const elAfterBtn = buttonContainer.nextElementSibling;
+  if (!elAfterBtn || elAfterBtn?.tagName !== 'BLOCKQUOTE') return;
 
-  const subText = elementBelowButton.querySelector('p');
+  const subText = elAfterBtn.querySelector('p');
   if (subText) {
     subText.classList.add('cta-sub-text');
     buttonContainer.append(subText);
   }
-  elementBelowButton.remove();
+  elAfterBtn.remove();
 }
 
 function getBreakpoint(animations) {


### PR DESCRIPTION
The blockquote approach for sub cta text feature left one potential for block breakage open. This PR is to rectify the typeError in handleSubCTAText function

Resolves: [MWPW-136430](https://jira.corp.adobe.com/browse/MWPW-136430)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/qiyundai/template-x/template-x-still?lighthouse=on
- After: https://mwpw-136430--express--adobecom.hlx.page/drafts/qiyundai/template-x/template-x-still?lighthouse=on
