### PR TITLE
[MWPW-136492] Enable Locale-Specific Subtitles on Embedded Vimeo

### DIFF
--- a/express/blocks/shared/video.js
+++ b/express/blocks/shared/video.js
@@ -20,30 +20,12 @@ const locale = getLocale(window.location);
 
 const getSubtitleLanguage = (location) => {
   const langs = {
-    us: 'en-us',
     fr: 'fr',
-    in: 'en',
     de: 'de',
-    it: 'it',
-    dk: 'da',
-    gb: 'en-gb',
-    es: 'es',
-    fi: 'fi',
     jp: 'ja',
-    kr: 'ko',
-    no: 'nb',
-    nl: 'nl',
-    br: 'pt',
-    se: 'sv',
-    th: 'th',
-    tw: 'zh-tw',
-    cn: 'zh-cn',
   };
-  let language = langs[location];
-  if (!language) language = 'en';
-
-  return language;
-}
+  return langs[location] || 'en';
+};
 
 export async function fetchVideoAnalytics() {
   if (!window.videoAnalytics) {
@@ -286,9 +268,7 @@ export function displayVideoModal(url = [], title, push) {
       vidType = 'vimeo';
       const vid = new URL(primaryUrl).pathname.split('/')[1];
       const language = getSubtitleLanguage(locale);
-      console.log(language);
       vidUrls = [`https://player.vimeo.com/video/${vid}?app_id=122963&autoplay=1&texttrack=${language}`];
-      console.log(vidUrls);
     } else if (primaryUrl.includes('/media_')) {
       vidType = 'html5';
       const { hash } = new URL(vidUrls[0]);

--- a/express/blocks/shared/video.js
+++ b/express/blocks/shared/video.js
@@ -258,7 +258,8 @@ export function displayVideoModal(url = [], title, push) {
     } else if (primaryUrl.includes('vimeo')) {
       vidType = 'vimeo';
       const vid = new URL(primaryUrl).pathname.split('/')[1];
-      vidUrls = [`https://player.vimeo.com/video/${vid}?app_id=122963&autoplay=1&texttrack=${locale}`];
+      const language = locale === 'us' ? 'en' : locale
+      vidUrls = [`https://player.vimeo.com/video/${vid}?app_id=122963&autoplay=1&texttrack=${language}`];
     } else if (primaryUrl.includes('/media_')) {
       vidType = 'html5';
       const { hash } = new URL(vidUrls[0]);

--- a/express/blocks/shared/video.js
+++ b/express/blocks/shared/video.js
@@ -16,6 +16,7 @@ import {
 } from '../../scripts/scripts.js';
 
 const docTitle = document.title;
+const locale = getLocale(window.location);
 
 export async function fetchVideoAnalytics() {
   if (!window.videoAnalytics) {
@@ -68,7 +69,6 @@ async function fetchVideoPromotions() {
   if (!window.videoPromotions) {
     window.videoPromotions = {};
     try {
-      const locale = getLocale(window.location);
       const urlPrefix = locale === 'us' ? '' : `/${locale}`;
       const resp = await fetch(`${urlPrefix}/express/video-promotions.json`);
       const json = await resp.json();
@@ -258,7 +258,7 @@ export function displayVideoModal(url = [], title, push) {
     } else if (primaryUrl.includes('vimeo')) {
       vidType = 'vimeo';
       const vid = new URL(primaryUrl).pathname.split('/')[1];
-      vidUrls = [`https://player.vimeo.com/video/${vid}?app_id=122963&autoplay=1`];
+      vidUrls = [`https://player.vimeo.com/video/${vid}?app_id=122963&autoplay=1&texttrack=${locale}`];
     } else if (primaryUrl.includes('/media_')) {
       vidType = 'html5';
       const { hash } = new URL(vidUrls[0]);

--- a/express/blocks/shared/video.js
+++ b/express/blocks/shared/video.js
@@ -18,6 +18,33 @@ import {
 const docTitle = document.title;
 const locale = getLocale(window.location);
 
+const getSubtitleLanguage = (location) => {
+  const langs = {
+    us: 'en-us',
+    fr: 'fr',
+    in: 'en',
+    de: 'de',
+    it: 'it',
+    dk: 'da',
+    gb: 'en-gb',
+    es: 'es',
+    fi: 'fi',
+    jp: 'ja',
+    kr: 'ko',
+    no: 'nb',
+    nl: 'nl',
+    br: 'pt',
+    se: 'sv',
+    th: 'th',
+    tw: 'zh-tw',
+    cn: 'zh-cn',
+  };
+  let language = langs[location];
+  if (!language) language = 'en';
+
+  return language;
+}
+
 export async function fetchVideoAnalytics() {
   if (!window.videoAnalytics) {
     window.videoAnalytics = [];
@@ -258,8 +285,10 @@ export function displayVideoModal(url = [], title, push) {
     } else if (primaryUrl.includes('vimeo')) {
       vidType = 'vimeo';
       const vid = new URL(primaryUrl).pathname.split('/')[1];
-      const language = locale === 'us' ? 'en' : locale
+      const language = getSubtitleLanguage(locale);
+      console.log(language);
       vidUrls = [`https://player.vimeo.com/video/${vid}?app_id=122963&autoplay=1&texttrack=${language}`];
+      console.log(vidUrls);
     } else if (primaryUrl.includes('/media_')) {
       vidType = 'html5';
       const { hash } = new URL(vidUrls[0]);

--- a/express/blocks/shared/video.js
+++ b/express/blocks/shared/video.js
@@ -16,15 +16,14 @@ import {
 } from '../../scripts/scripts.js';
 
 const docTitle = document.title;
-const locale = getLocale(window.location);
 
-const getSubtitleLanguage = (location) => {
+const getAvailableVimeoSubLang = () => {
   const langs = {
     fr: 'fr',
     de: 'de',
     jp: 'ja',
   };
-  return langs[location] || 'en';
+  return langs[getLocale(window.location)] || 'en';
 };
 
 export async function fetchVideoAnalytics() {
@@ -78,6 +77,7 @@ async function fetchVideoPromotions() {
   if (!window.videoPromotions) {
     window.videoPromotions = {};
     try {
+      const locale = getLocale(window.location);
       const urlPrefix = locale === 'us' ? '' : `/${locale}`;
       const resp = await fetch(`${urlPrefix}/express/video-promotions.json`);
       const json = await resp.json();
@@ -267,7 +267,7 @@ export function displayVideoModal(url = [], title, push) {
     } else if (primaryUrl.includes('vimeo')) {
       vidType = 'vimeo';
       const vid = new URL(primaryUrl).pathname.split('/')[1];
-      const language = getSubtitleLanguage(locale);
+      const language = getAvailableVimeoSubLang();
       vidUrls = [`https://player.vimeo.com/video/${vid}?app_id=122963&autoplay=1&texttrack=${language}`];
     } else if (primaryUrl.includes('/media_')) {
       vidType = 'html5';


### PR DESCRIPTION
Sets the subtitles of embedded Vimeo videos based on the user's locale. This is only enabled for English, Japanese, French and German.

Testing: Click on one of the "Play Video" buttons, the stage link will not have any subtitles chosen by default, whereas the branch link will have French.

Resolves: [MWPW-136492](https://jira.corp.adobe.com/browse/MWPW-136492)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/fr/drafts/embed-video-subtitles
- After: https://mwpw-135726-embed--express--adobecom.hlx.page/fr/drafts/embed-video-subtitles
