### PR TITLE
MWPW-136496 | Adding en-GB mapping for uk context for analytics prop4

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -659,6 +659,7 @@ export function getLanguage(locale) {
     us: 'en-US',
     fr: 'fr-FR',
     in: 'en-IN',
+    uk: 'en-GB',
     de: 'de-DE',
     it: 'it-IT',
     dk: 'da-DK',


### PR DESCRIPTION
Adding en-GB mapping for uk context for analytics prop4

Resolves: MWPW-136496

Test URLs:
- Before: https://main--express--adobecom.hlx.page/in/express/pricing?lighthouse=on
- After: https://MWPW-136496--express--adobecom.hlx.page/in/express/pricing?lighthouse=on
