### PR TITLE
[MWPW-135859] Template X update for color page use

### DIFF
--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -1,4 +1,4 @@
-.template-x-horizontal {
+.section.template-x-container {
     padding-top: 0;
 }
 

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -164,10 +164,6 @@
     margin: 0 12px 20px 12px;
 }
 
-.template-x-container .template-x-wrapper:not(:has(.toolbar-wrapper)) {
-    padding-top: 60px;
-}
-
 .template-x-wrapper .template-title.with-link > div {
     display: flex;
     flex-direction: column;
@@ -488,8 +484,8 @@
     border-radius: 12px;
     min-height: unset;
     box-sizing: border-box;
-    height: 120%;
-    width: 120%;
+    height: calc(100% + 40px);
+    width: calc(100% + 24px);
 }
 
 .template-x.horizontal .template:not(.placeholder) .template-link,
@@ -2307,6 +2303,10 @@ nav ol.templates-breadcrumbs li:not(:first-child):before {
     .template-x-wrapper .template-title.with-link > div {
         flex-direction: row;
         justify-content: space-between;
+    }
+
+    .template-x-wrapper .template-title.with-link.link-only {
+        justify-content: flex-end;
     }
 
     .template-x-wrapper .template-x:not(.holiday) .template-title.horizontal .view-all-link-wrapper {

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -1,6 +1,6 @@
 /* templates pages spacial styling */
-[class='section section-wrapper template-x-container'],
-[class='section section-wrapper browse-by-category-card-fullwidth-container template-x-container'] {
+div[class='section section-wrapper template-x-container'],
+div[class='section section-wrapper browse-by-category-card-fullwidth-container template-x-container'] {
     padding-top: 0;
 }
 

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -1,4 +1,6 @@
-.section.template-x-container {
+/* templates pages spacial styling */
+[class='section section-wrapper template-x-container'],
+[class='section section-wrapper browse-by-category-card-fullwidth-container template-x-container'] {
     padding-top: 0;
 }
 

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -122,6 +122,10 @@ async function processContentRow(block, props) {
         p.className = 'view-all-link-wrapper';
       }
     });
+
+    if (textWrapper.children.length === 1 && textWrapper.firstElementChild.className === 'button-container') {
+      templateTitle.classList.add('link-only');
+    }
   }
 
   block.prepend(templateTitle);


### PR DESCRIPTION
In this PR, we expand Template X a little bit to support a horizontal use case where the heading and copy are not authored in block and only a link is in the first row.

We also enhanced the block a little by not letting hover effect always expand to 120% which becomes disproportionally large when the ratio difference is big (see the hover effect of the first banner template on the page).

We also removed the 60px padding from the block. I believe it was an over-compensation for a CSS creeping that has been fixed in another place.

Partially Resolves: [MWPW-135859](https://jira.corp.adobe.com/browse/MWPW-135859)

Test URLs:

Before: https://main--express--adobecom.hlx.page/express/colors/red?lighthouse=on
After: https://mwpw-135859--express--adobecom.hlx.page/express/colors/red?lighthouse=on