### PR TITLE
MWPW-136462 consider query param when showing sections over showwith

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -507,15 +507,25 @@ export function getMetadata(name) {
 
 export function removeIrrelevantSections(main) {
   main.querySelectorAll(':scope > div').forEach((section) => {
-    const sectionMeta = section.querySelector('div.section-metadata');
-    if (sectionMeta) {
-      const meta = readBlockConfig(sectionMeta);
+    const sectionMetaBlock = section.querySelector('div.section-metadata');
+    if (sectionMetaBlock) {
+      const sectionMeta = readBlockConfig(sectionMetaBlock);
 
-      // section meant for different device or section visibility steered over metadata
-      if ((meta.audience && meta.audience !== document.body.dataset?.device)
-          || (meta.showwith !== undefined && getMetadata(meta.showwith.toLowerCase()) !== 'on')) {
-        section.remove();
+      // section meant for different device
+      let sectionRemove = !!(sectionMeta.audience
+        && sectionMeta.audience !== document.body.dataset?.device);
+
+      // section visibility steered over metadata
+      if (!sectionRemove && sectionMeta.showwith !== undefined) {
+        let showWithSearchParam = null;
+        if (!['www.adobe.com'].includes(window.location.hostname)) {
+          const urlParams = new URLSearchParams(window.location.search);
+          showWithSearchParam = urlParams.get(`showwith${sectionMeta.showwith.toLowerCase()}`)
+            || urlParams.get(`showwith${sectionMeta.showwith}`);
+        }
+        sectionRemove = showWithSearchParam !== null ? showWithSearchParam !== 'on' : getMetadata(sectionMeta.showwith.toLowerCase()) !== 'on';
       }
+      if (sectionRemove) section.remove();
     }
   });
 }


### PR DESCRIPTION
Allows for the visibility of sections that are steered with the showwith section metadata and metadata to also be steered over a query param instead of using the metadata.
This will work everywhere except on prod. 

Resolves: [MWPW-136462](https://jira.corp.adobe.com/browse/MWPW-136462)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/docs/library/kitchen-sink/section-metadata/show-with-example-usage?lighthouse=on&showwithacefeature=on
- After: https://mwpw-136462-show-with-param--express--adobecom.hlx.page/docs/library/kitchen-sink/section-metadata/show-with-example-usage?martech=on&showwithacefeature=on
