### PR TITLE
Mwpw 136608 template pages uk

### DIFF
--- a/express/sitemap-index.xml
+++ b/express/sitemap-index.xml
@@ -105,4 +105,7 @@
   <sitemap>
     <loc>https://www.adobe.com/nl/express/templates/sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/uk/express/templates/sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>

--- a/express/sitemap-index.xml
+++ b/express/sitemap-index.xml
@@ -103,9 +103,9 @@
     <loc>https://www.adobe.com/tw/express/templates/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/nl/express/templates/sitemap.xml</loc>
+    <loc>https://www.adobe.com/uk/express/templates/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/uk/express/templates/sitemap.xml</loc>
+    <loc>https://www.adobe.com/nl/express/templates/sitemap.xml</loc>
   </sitemap>
 </sitemapindex>

--- a/fstab.yaml
+++ b/fstab.yaml
@@ -13,6 +13,7 @@ folders:
   /kr/express/templates/: /kr/express/templates/default
   /nl/express/templates/: /nl/express/templates/default
   /tw/express/templates/: /tw/express/templates/default
+  /uk/express/templates/: /uk/express/templates/default
   /express/colors/: /express/colors/default
   /br/express/colors/: /br/express/colors/default
   /cn/express/colors/: /cn/express/colors/default

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -179,6 +179,11 @@ sitemaps:
         destination: /es/express/templates/sitemap.xml
         hreflang: es
         alternate: /es/{path}
+      unitedkingdom:
+        source: /uk/express/templates/default/metadata.json?sheet=sitemap
+        destination: /uk/express/templates/sitemap.xml
+        hreflang: en-GB
+        alternate: /uk/{path}
       taiwan:
         source: /tw/express/templates/default/metadata.json?sheet=sitemap
         destination: /tw/express/templates/sitemap.xml

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -179,16 +179,16 @@ sitemaps:
         destination: /es/express/templates/sitemap.xml
         hreflang: es
         alternate: /es/{path}
-      unitedkingdom:
-        source: /uk/express/templates/default/metadata.json?sheet=sitemap
-        destination: /uk/express/templates/sitemap.xml
-        hreflang: en-GB
-        alternate: /uk/{path}
       taiwan:
         source: /tw/express/templates/default/metadata.json?sheet=sitemap
         destination: /tw/express/templates/sitemap.xml
         hreflang: zh-Hant
         alternate: /tw/{path}
+      unitedkingdom:
+        source: /uk/express/templates/default/metadata.json?sheet=sitemap
+        destination: /uk/express/templates/sitemap.xml
+        hreflang: en-GB
+        alternate: /uk/{path}
       netherlands:
         source: /nl/express/templates/default/metadata.json?sheet=sitemap
         destination: /nl/express/templates/sitemap.xml


### PR DESCRIPTION
Activates uk template pages 
The changes to the fstab are unfortunately not in effect until this is merged to main. 

Resolves: [MWPW-136608](https://jira.corp.adobe.com/browse/MWPW-136608)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/?lighthouse=on
- After: https://MWPW-136608-template-pages-uk--express--adobecom.hlx.page/express/?lighthouse=on
