### PR TITLE
[MWPW-136569] CTA Carousel: added upload gen AI input

### DIFF
--- a/express/blocks/cta-carousel/cta-carousel.css
+++ b/express/blocks/cta-carousel/cta-carousel.css
@@ -73,7 +73,7 @@
     margin: auto;
     width: 305px;
     height: 200px;
-    padding: 24px;
+    padding: 20px;
 }
 
 .cta-carousel.quick-action .card.gen-ai-action .card-sleeve .gen-ai-input-form {
@@ -108,6 +108,7 @@
 }
 
 .cta-carousel.gen-ai .gen-ai-upload-inner-wrapper {
+    border: dashed 2px var(--color-info-accent);
     height: 100%;
     background-color: var(--color-white);
     border-radius: 8px;
@@ -115,7 +116,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 16px;
+    gap: 12px;
 }
 
 .cta-carousel.gen-ai .gen-ai-upload-inner-wrapper .icon {
@@ -124,10 +125,9 @@
 }
 
 .cta-carousel.gen-ai .gen-ai-upload-inner-wrapper .gen-ai-upload-btn {
-    padding: 6px 16px;
+    font-size: var(--body-font-size-s);
+    font-weight: var(--body-font-weight);
     color: var(--color-black);
-    background-color: var(--color-gray-200);
-    border-radius: 16px;
 }
 
 .cta-carousel.gen-ai .gen-ai-input:active,

--- a/express/blocks/cta-carousel/cta-carousel.css
+++ b/express/blocks/cta-carousel/cta-carousel.css
@@ -64,14 +64,13 @@
     display: flex;
 }
 
-.cta-carousel.gen-ai .card .card-sleeve .gen-ai-input-form {
+.cta-carousel.gen-ai .card .card-sleeve .gen-ai-input-form,
+.cta-carousel.gen-ai .card .card-sleeve .gen-ai-upload {
+    display: block;
     background-color: var(--color-info-accent-light);
     border-radius: 8px;
     box-sizing: border-box;
     margin: auto;
-}
-
-.cta-carousel.gen-ai .gen-ai-input-form {
     width: 305px;
     height: 200px;
     padding: 24px;
@@ -106,6 +105,29 @@
     resize: none;
     height: 100%;
     width: 100%;
+}
+
+.cta-carousel.gen-ai .gen-ai-upload-inner-wrapper {
+    height: 100%;
+    background-color: var(--color-white);
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+}
+
+.cta-carousel.gen-ai .gen-ai-upload-inner-wrapper .icon {
+    height: 44px;
+    width: 44px;
+}
+
+.cta-carousel.gen-ai .gen-ai-upload-inner-wrapper .gen-ai-upload-btn {
+    padding: 6px 16px;
+    color: var(--color-black);
+    background-color: var(--color-gray-200);
+    border-radius: 16px;
 }
 
 .cta-carousel.gen-ai .gen-ai-input:active,

--- a/express/blocks/cta-carousel/cta-carousel.css
+++ b/express/blocks/cta-carousel/cta-carousel.css
@@ -331,9 +331,4 @@
         flex-direction: row;
         align-items: flex-end;
     }
-
-    .cta-carousel .carousel-container .carousel-fader-left,
-    .cta-carousel .carousel-container .carousel-fader-right{
-        background: unset;
-    }
 }

--- a/express/blocks/cta-carousel/cta-carousel.js
+++ b/express/blocks/cta-carousel/cta-carousel.js
@@ -126,7 +126,7 @@ function buildGenAIUpload(cta, card) {
   const innerWrapper = createTag('div', { class: 'gen-ai-upload-inner-wrapper' });
   const btnPill = createTag('div', { class: 'gen-ai-upload-btn' }, cta.ctaLinks[0].textContent);
 
-  innerWrapper.append(cta.image, btnPill);
+  innerWrapper.append(cta.icon, btnPill);
   uploadButton.append(innerWrapper);
 
   // Clean up empty divs && unused elements
@@ -163,15 +163,13 @@ export async function decorateCards(block, payload) {
       mediaWrapper.remove();
     }
 
-    // determine if Gen AI gets inserted after mediaWrapper has been concluded
-    const noMedia = mediaWrapper.children.length === 0 || (mediaWrapper.children.length === 1 && mediaWrapper.querySelector('img.icon, svg'));
     const hasGenAIEl = (block.classList.contains('gen-ai') && block.classList.contains('quick-action') && index === 0)
-      || (block.classList.contains('gen-ai') && noMedia);
+      || (block.classList.contains('gen-ai') && !block.classList.contains('quick-action') && !cta.image);
 
     if (cta.ctaLinks.length > 0) {
       if (hasGenAIEl) {
         card.classList.add('gen-ai-action');
-        const el = mediaWrapper.children.length ? buildGenAIUpload(cta, card) : buildGenAIForm(cta);
+        const el = block.classList.contains('upload') ? buildGenAIUpload(cta, card) : buildGenAIForm(cta);
         cardSleeve.append(el);
         linksWrapper.remove();
       }
@@ -233,9 +231,9 @@ function constructPayload(block) {
 
   rows.forEach((row) => {
     const ctaObj = {
-      image: row.querySelector(':scope > div:nth-of-type(1) picture, :scope > div:nth-of-type(1) img.icon, :scope > div:nth-of-type(1) svg'),
+      image: row.querySelector(':scope > div:nth-of-type(1) picture'),
       videoLink: row.querySelector(':scope > div:nth-of-type(1) a'),
-      icon: row.querySelector(':scope > div:nth-of-type(1) img.icon'),
+      icon: row.querySelector(':scope > div:nth-of-type(1) img.icon, :scope > div:nth-of-type(1) svg'),
       text: row.querySelector(':scope > div:nth-of-type(2) p:not(.button-container), :scope > div:nth-of-type(2) > *:last-of-type')?.textContent.trim(),
       subtext: row.querySelector(':scope > div:nth-of-type(2) p:not(.button-container) em')?.textContent.trim(),
       ctaLinks: row.querySelectorAll(':scope > div:nth-of-type(2) a'),

--- a/express/blocks/shared/carousel.css
+++ b/express/blocks/shared/carousel.css
@@ -48,6 +48,7 @@ main .carousel-container .carousel-fader-left {
   transition: opacity 0.2s, display 0.2s;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(0,0,0,0);
+  z-index: 1;
 }
 
 main .carousel-container .carousel-fader-right {
@@ -63,6 +64,7 @@ main .carousel-container .carousel-fader-right {
   transition: opacity 0.2s;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(0,0,0,0);
+  z-index: 1;
 }
 
 main .carousel-container a.button.carousel-arrow {
@@ -123,7 +125,7 @@ main .carousel-container.controls-hidden .carousel-platform {
   scroll-snap-type: none;
 }
 
-@media (min-width: 900px) {  
+@media (min-width: 900px) {
   main .carousel-container .carousel-platform::-webkit-scrollbar {
     display: none;
   }


### PR DESCRIPTION
The Gen AI variant of the CTA carousel used to only consider a row to be gen AI form input when the left column is empty
Now, when using Gen AI variant, if the left column has an SVG or image icon, it'll become an upload Gen AI input, which isn't an upload either, but a gen AI input looking link card.

Resolves: [MWPW-136569](https://jira.corp.adobe.com/browse/MWPW-136569)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/drafts/qiyundai/homepage-v3/cta-carousel?lighthouse=on
- After: https://mwpw-136569--express--adobecom.hlx.page/drafts/qiyundai/homepage-v3/cta-carousel?lighthouse=on

Documentation updated:
![Screen Shot 2023-09-19 at 10 09 51 AM](https://github.com/adobecom/express/assets/57737624/22444591-ec78-4a41-89bc-b040e9458dee)

