### PR TITLE
Gen-AI-Cards update lineheight for 2-line subtext

### DIFF
--- a/express/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.css
@@ -71,6 +71,7 @@
 
 .gen-ai-cards .card .text-wrapper p.cta-card-desc {
   font-size: var(--body-font-size-s);
+  line-height: var(--body-font-size-l);
 }
 
 


### PR DESCRIPTION
Pixels are not defined in XD, so I'm doing some adjustments on my end by myself. I think this looks better

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/jingle/gen-ai-cards?lighthouse=on
- After: https://gen-ai-cards--express--adobecom.hlx.page/drafts/jingle/gen-ai-cards?lighthouse=on
