### PR TITLE
[live bug]: Columns video modal causing page redirect fix

### DIFF
--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -66,7 +66,9 @@ function transformToVideoColumn(cell, aTag, block) {
   });
 
   // auto-play if hash matches title
-  if (toClassName(title) === window.location.hash.substring(1)) {
+  const hash = window.location.hash.substring(1);
+  const titleName = toClassName(title);
+  if ((hash && titleName) && titleName === hash && hash !== '#embed-video') {
     displayVideoModal(vidUrls, title);
   }
 }
@@ -125,7 +127,7 @@ function decorateIconList(columnCell, rowNum, blockClasses) {
 }
 
 const handleVideos = (cell, a, block, thumbnail) => {
-  if (a.href && new URL(a.href).hash === '#video-embed') {
+  if (a.href && new URL(a.href).hash === '#embed-video') {
     if (a.href.includes('youtu')) {
       embedYoutube(a);
     } else if (a.href.includes('vimeo')) {

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1149,7 +1149,7 @@ export function decorateButtons(block = document) {
       && !(linkText.startsWith('https') && linkText.includes('/media_'))
       && !linkText.includes('hlx.blob.core.windows.net')
       && !linkText.endsWith(' >')
-      && !(new URL($a.href).hash === '#video-embed')
+      && !(new URL($a.href).hash === '#embed-video')
       && !linkText.endsWith(' ›')) {
       const $up = $a.parentElement;
       const $twoup = $a.parentElement.parentElement;


### PR DESCRIPTION
In one of our earlier columns video embed integration, we made a mistake in the expected hash for video embed, which should be #embed-video instead of #video-embed.

We also need to check and prevent empty strings being compared when trying to trigger displayVideoModal on page load.

Resolves: [MWPW-136815](https://jira.corp.adobe.com/browse/MWPW-136815)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/casey/embed-video/embedded-inline-mixed?lighthouse=on
- After: https://mwpw-136815--express--adobecom.hlx.page/drafts/casey/embed-video/embedded-inline-mixed?lighthouse=on
