### PR TITLE
[Urgent] Added Video Abort Handler

### DIFF
--- a/express/blocks/hero-animation-beta/hero-animation-beta.js
+++ b/express/blocks/hero-animation-beta/hero-animation-beta.js
@@ -98,7 +98,13 @@ function adjustLayout(animations, $parent) {
       $parent.replaceChild($newVideo, $parent.querySelector('video'));
       $newVideo.addEventListener('canplay', () => {
         $newVideo.muted = true;
-        $newVideo.play();
+        $newVideo.play().catch((e) => {
+          if (e instanceof DOMException && e.name === 'AbortError') {
+            // ignore
+          } else {
+            throw e;
+          }
+        });
       });
     }
   }
@@ -211,7 +217,13 @@ export default async function decorate($block) {
         $div.prepend($video);
         $video.addEventListener('canplay', () => {
           $video.muted = true;
-          $video.play();
+          $video.play().catch((e) => {
+            if (e instanceof DOMException && e.name === 'AbortError') {
+              // ignore
+            } else {
+              throw e;
+            }
+          });
         });
         window.addEventListener('resize', () => {
           adjustLayout(animations, $div);

--- a/express/blocks/hero-animation/hero-animation.js
+++ b/express/blocks/hero-animation/hero-animation.js
@@ -99,7 +99,13 @@ function adjustLayout(animations, $parent) {
       $parent.replaceChild($newVideo, $parent.querySelector('video'));
       $newVideo.addEventListener('canplay', () => {
         $newVideo.muted = true;
-        $newVideo.play();
+        $newVideo.play().catch((e) => {
+          if (e instanceof DOMException && e.name === 'AbortError') {
+            // ignore
+          } else {
+            throw e;
+          }
+        });
       });
     }
   }
@@ -210,7 +216,13 @@ export default async function decorate($block) {
         $div.prepend($video);
         $video.addEventListener('canplay', () => {
           $video.muted = true;
-          $video.play();
+          $video.play().catch((e) => {
+            if (e instanceof DOMException && e.name === 'AbortError') {
+              // ignore
+            } else {
+              throw e;
+            }
+          });
         });
         window.addEventListener('resize', () => {
           adjustLayout(animations, $div);

--- a/express/blocks/marquee/marquee.js
+++ b/express/blocks/marquee/marquee.js
@@ -119,7 +119,13 @@ async function buildReduceMotionSwitch(block) {
         video.pause();
       } else {
         video.muted = true;
-        video.play();
+        video.play().catch((e) => {
+          if (e instanceof DOMException && e.name === 'AbortError') {
+            // ignore
+          } else {
+            throw e;
+          }
+        });
       }
     }
 
@@ -185,7 +191,13 @@ function adjustLayout(animations, parent) {
       newVideo.addEventListener('canplay', () => {
         if (localStorage.getItem('reduceMotion') !== 'on') {
           newVideo.muted = true;
-          newVideo.play();
+          newVideo.play().catch((e) => {
+            if (e instanceof DOMException && e.name === 'AbortError') {
+              // ignore
+            } else {
+              throw e;
+            }
+          });
         }
       });
     }

--- a/express/blocks/shared/video.js
+++ b/express/blocks/shared/video.js
@@ -152,7 +152,13 @@ function playInlineVideo($element, vidUrls = [], playerType, title, ts) {
         document.dispatchEvent(videoLoaded);
       }
 
-      $video.play();
+      $video.play().catch((e) => {
+        if (e instanceof DOMException && e.name === 'AbortError') {
+          // ignore
+        } else {
+          throw e;
+        }
+      });
     });
     $video.addEventListener('ended', async () => {
       // hide player and show promotion

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -394,7 +394,13 @@ function populateTemplates($block, templates, props) {
           $imgLink.remove();
           $video.addEventListener('canplay', () => {
             $video.muted = true;
-            $video.play();
+            $video.play().catch((e) => {
+              if (e instanceof DOMException && e.name === 'AbortError') {
+                // ignore
+              } else {
+                throw e;
+              }
+            });
           });
         }
       }

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -439,7 +439,13 @@ export function transformLinkToAnimation($a, $videoLooping = true) {
   // autoplay animation
   $video.addEventListener('canplay', () => {
     $video.muted = true;
-    $video.play();
+    $video.play().catch((e) => {
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        // ignore
+      } else {
+        throw e;
+      }
+    });
   });
   return $video;
 }
@@ -2081,8 +2087,15 @@ export function addAnimationToggle(target) {
     const videos = target.querySelectorAll('video');
     const paused = videos[0] ? videos[0].paused : false;
     videos.forEach((video) => {
-      if (paused) video.play();
-      else video.pause();
+      if (paused) {
+        video.play().catch((e) => {
+          if (e instanceof DOMException && e.name === 'AbortError') {
+            // ignore
+          } else {
+            throw e;
+          }
+        });
+      } else video.pause();
     });
   }, true);
 }


### PR DESCRIPTION
Our Lana team reports that we have way too many this Video Abort Low Battery errors on iOS devices and we will soon get throttled. This is a quick workaround for handling the error.

Test URLs:
- Before: https://handle-video-abort-error--express--adobecom.hlx.page/express/feature/image/remove-background?lighthouse=on
- After: https://stage--express--adobecom.hlx.page/express/feature/image/remove-background?lighthouse=on
