### PR TITLE
Template CTAs open in tabs

### DIFF
--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -255,6 +255,7 @@ async function processResponse(props) {
         href: template.branchURL,
         title: placeholders['edit-this-template'] ?? 'Edit this template',
         class: 'button accent',
+        target: '_blank',
       });
 
       $button.textContent = placeholders['edit-this-template'] ?? 'Edit this template';

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -135,6 +135,7 @@ function renderCTA(placeholders, branchUrl) {
     href: branchUrl,
     title: btnTitle,
     class: 'button accent small',
+    target: '_blank',
   });
   btnEl.textContent = btnTitle;
   return btnEl;


### PR DESCRIPTION
All Template CTAs when clicked should open in new tabs now.

https://jira.corp.adobe.com/browse/MWPW-136681

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/templates/?lighthouse=on
- After: https://template-cta-new-tab--express--adobecom.hlx.page/express/templates/?lighthouse=on
