### PR TITLE
MWPW-136203 | Fixing empty blog post section to load current locale query-index json

### DIFF
--- a/express/blocks/blog-posts/blog-posts.js
+++ b/express/blocks/blog-posts/blog-posts.js
@@ -22,13 +22,8 @@ import {
 
 async function fetchBlogIndex(config) {
   const prefix = getLocale(window.location);
-  let currentLocalePrefix;
   let currentLocaleProcessed = false;
-  if (prefix === 'express' || prefix === 'drafts' || prefix === 'documentation' || prefix === 'us') {
-    currentLocalePrefix = '';
-  } else {
-    currentLocalePrefix = `/${prefix}`;
-  }
+  const currentLocalePrefix = (prefix === 'us') ? '' : `/${prefix}`;
   const consolidatedJsonData = [];
   if (config.featuredOnly) {
     const linkLocales = [];
@@ -42,7 +37,7 @@ async function fetchBlogIndex(config) {
       if (localePrefix === 'us') {
         localePrefix = '';
       }
-      if (linkLocales.indexOf(localePrefix) === -1 && !(localePrefix === 'drafts' || localePrefix === 'documentation')) {
+      if (linkLocales.indexOf(localePrefix) === -1) {
         linkLocales.push(localePrefix);
         const prefixedLocale = localePrefix === '' ? '' : `/${localePrefix}`;
         urls.push(`${prefixedLocale}/express/learn/blog/query-index.json`);

--- a/express/blocks/blog-posts/blog-posts.js
+++ b/express/blocks/blog-posts/blog-posts.js
@@ -37,7 +37,7 @@ async function fetchBlogIndex(config) {
       if (localePrefix === 'us') {
         localePrefix = '';
       }
-      if (linkLocales.indexOf(localePrefix) === -1) {
+      if (!linkLocales.includes(localePrefix)) {
         linkLocales.push(localePrefix);
         const prefixedLocale = localePrefix === '' ? '' : `/${localePrefix}`;
         urls.push(`${prefixedLocale}/express/learn/blog/query-index.json`);

--- a/express/blocks/blog-posts/blog-posts.js
+++ b/express/blocks/blog-posts/blog-posts.js
@@ -21,8 +21,14 @@ import {
 } from '../../scripts/scripts.js';
 
 async function fetchBlogIndex(config) {
-  let prefix = getLocale(window.location);
-  if (prefix === 'express' || prefix === 'drafts' || prefix === 'documentation' || prefix === 'us') prefix = '';
+  const prefix = getLocale(window.location);
+  let currentLocalePrefix;
+  let currentLocaleProcessed;
+  if (prefix === 'express' || prefix === 'drafts' || prefix === 'documentation' || prefix === 'us') {
+    currentLocalePrefix = '';
+  } else {
+    currentLocalePrefix = `/${prefix}`;
+  }
   const consolidatedJsonData = [];
   if (config.featuredOnly) {
     const linkLocales = [];
@@ -30,6 +36,9 @@ async function fetchBlogIndex(config) {
     const links = config.featured;
     for (let i = 0; i < links.length; i += 1) {
       let localePrefix = getLocale(new URL(links[i]));
+      if (localePrefix === prefix) {
+        currentLocaleProcessed = true;
+      }
       if (localePrefix === 'us') {
         localePrefix = '';
       }
@@ -43,8 +52,9 @@ async function fetchBlogIndex(config) {
       .then((res) => res.ok && res.json())))
       .then((res) => res);
     resp.forEach((item) => consolidatedJsonData.push(...item.data));
-  } else {
-    const resp = await fetch(`${prefix}/express/learn/blog/query-index.json`);
+  }
+  if (!currentLocaleProcessed) {
+    const resp = await fetch(`${currentLocalePrefix}/express/learn/blog/query-index.json`);
     const res = await resp.json();
     consolidatedJsonData.push(...res.data);
   }

--- a/express/blocks/blog-posts/blog-posts.js
+++ b/express/blocks/blog-posts/blog-posts.js
@@ -23,7 +23,7 @@ import {
 async function fetchBlogIndex(config) {
   const prefix = getLocale(window.location);
   let currentLocalePrefix;
-  let currentLocaleProcessed;
+  let currentLocaleProcessed = false;
   if (prefix === 'express' || prefix === 'drafts' || prefix === 'documentation' || prefix === 'us') {
     currentLocalePrefix = '';
   } else {


### PR DESCRIPTION
Fixing empty blog post section to load current locale query-index json

While testing today, noticed that empty blog post sections are added on pages just to load the current query-index.json file so that the tags can be loaded based on the link comparison and fetching data for each tags.
This PR fixes it by adding original logic and condition to check if the locale is processed or not.

Resolves: MWPW-136203

Test URLs:

- Before: https://main--express--adobecom.hlx.page/drafts/apganapa/blog-fr?lighthouse=on
- After: https://blog-fix--express--adobecom.hlx.page/drafts/apganapa/blog-fr?lighthouse=on

- Before: https://main--express--adobecom.hlx.page/uk/express/learn/blog/introducing-creative-cloud-express?lighthouse=on
- After: https://blog-fix--express--adobecom.hlx.page/uk/express/learn/blog/introducing-creative-cloud-express?lighthouse=on
