### PR TITLE
[MWPW-135726] Tightened Check on YT Links

### DIFF
--- a/express/blocks/shared/video.js
+++ b/express/blocks/shared/video.js
@@ -189,7 +189,8 @@ function playInlineVideo($element, vidUrls = [], playerType, title, ts) {
 
 export function isVideoLink(url) {
   if (!url) return null;
-  return url.includes('youtu')
+  return url.includes('youtube.com/watch')
+    || url.includes('youtu.be/')
     || url.includes('vimeo')
     || /.*\/media_.*(mp4|webm|m3u8)$/.test(new URL(url).pathname);
 }


### PR DESCRIPTION
With the new way we are converting YouTube links to modals and embedded videos, it was picking up unintended YT links, such as account pages. See the subscribe section, where the button attempts to open the link as a modal video.

<img width="1020" alt="image" src="https://github.com/adobecom/express/assets/105597527/fc3c4e61-56a2-40b5-aa7b-01de51da81e0">

Resolves: [MWPW-135726](https://jira.corp.adobe.com/browse/MWPW-135726)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/community
- After: https://mwpw-135726-yt--express--adobecom.hlx.page/express/community?lighthouse=on
