### PR TITLE
[MWPW-136647] Open Breadcrumbs to All Audiences

### DIFF
--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -166,7 +166,6 @@ async function loadFEDS() {
     );
 
     const placeholders = await fetchPlaceholders();
-    const validSecondPathSegments = ['create', 'feature'];
     const pathSegments = window.location.pathname
       .split('/')
       .filter((e) => e !== '')
@@ -180,7 +179,6 @@ async function loadFEDS() {
     if (!pagesShortName
       || pathSegments.length <= 2
       || !replacedCategory
-      || !validSecondPathSegments.includes(replacedCategory)
       || locale !== 'us') { // Remove this line once locale translations are complete
       return null;
     }


### PR DESCRIPTION
Opening up breadcrumbs to all audiences.

Partially resolves: [MWPW-136647](https://jira.corp.adobe.com/browse/MWPW-136647)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/discover/messages/card/sympathy
- After: https://mwpw-136647-2--express--adobecom.hlx.page/express/discover/messages/card/sympathy?lighthouse=on
