### PR TITLE
MWPW-136974 make mega nav visible for uk pages under /uk/express/educ…

### DIFF
--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -151,6 +151,7 @@ async function loadFEDS() {
     || window.location.pathname.startsWith('/in/express')
     || window.location.pathname.startsWith('/uk/express')
     || window.location.pathname.startsWith('/education')
+    || window.location.pathname.startsWith('/uk/education')
     || window.location.pathname.startsWith('/drafts');
   const fedsExp = isMegaNav
     ? 'adobe-express/ax-gnav-x'


### PR DESCRIPTION
Makes the mega nav visible for uk education pages 

Resolves: [MWPW-136974](https://jira.corp.adobe.com/browse/MWPW-136974)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/uk/education/express/?martech=off
- After: https://MWPW-136974-mega-nav-uk-education--express--adobecom.hlx.page/uk/education/express/?martech=off
