### PR TITLE
MWPW-137043 deactivate template pages

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -13,7 +13,6 @@ folders:
   /kr/express/templates/: /kr/express/templates/default
   /nl/express/templates/: /nl/express/templates/default
   /tw/express/templates/: /tw/express/templates/default
-  /uk/express/templates/: /uk/express/templates/default
   /express/colors/: /express/colors/default
   /br/express/colors/: /br/express/colors/default
   /cn/express/colors/: /cn/express/colors/default

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -184,11 +184,6 @@ sitemaps:
         destination: /tw/express/templates/sitemap.xml
         hreflang: zh-Hant
         alternate: /tw/{path}
-      unitedkingdom:
-        source: /uk/express/templates/default/metadata.json?sheet=sitemap
-        destination: /uk/express/templates/sitemap.xml
-        hreflang: en-GB
-        alternate: /uk/{path}
       netherlands:
         source: /nl/express/templates/default/metadata.json?sheet=sitemap
         destination: /nl/express/templates/sitemap.xml


### PR DESCRIPTION
Make uk template pages reroute to US version.

**THIS WILL ONLY WORK ONCE MERGED TO MAIN**

Resolves: [MWPW-137043](https://jira.corp.adobe.com/browse/MWPW-137043)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/uk/express/templates/
- After: https://MWPW-137043-deactivate-uk-templates--express--adobecom.hlx.page/uk/express/templates/
