### PR TITLE
[CTA Carousel & Gen AI Cards] Expand features tag generation

### DIFF
--- a/express/blocks/cta-carousel/cta-carousel.css
+++ b/express/blocks/cta-carousel/cta-carousel.css
@@ -24,7 +24,7 @@
 }
 
 .cta-carousel h2.cta-carousel-heading .tag {
-    font-size: var(--heading-font-size-s);
+    font-size: 10px;
     padding: 0 4px;
     margin-left: 6px;
     font-weight: 700;
@@ -315,7 +315,7 @@
 }
 
 .cta-carousel .card .text-wrapper .tag {
-    font-size: 12px;
+    font-size: 10px;
     padding: 0 4px;
     margin-left: 6px;
     font-weight: 700;

--- a/express/blocks/cta-carousel/cta-carousel.css
+++ b/express/blocks/cta-carousel/cta-carousel.css
@@ -22,6 +22,17 @@
     margin-bottom: 8px;
     font-size: var(--heading-font-size-m);
 }
+
+.cta-carousel h2.cta-carousel-heading .tag {
+    font-size: var(--heading-font-size-s);
+    padding: 0 4px;
+    margin-left: 6px;
+    font-weight: 700;
+    background-color: #DEDEF9;
+    color: var(--color-info-accent);
+    border-radius: 4px;
+}
+
 .cta-carousel .cta-carousel-heading-section p {
     text-align: left;
     margin: 0;

--- a/express/blocks/cta-carousel/cta-carousel.js
+++ b/express/blocks/cta-carousel/cta-carousel.js
@@ -29,8 +29,8 @@ export function sanitizeInput(string) {
   return string.replace(/[&<>"'`=/]/g, (s) => charMap[s]);
 }
 
-export function decorateTextWithTag(textSource) {
-  const text = createTag('p', { class: 'cta-card-text' });
+export function decorateTextWithTag(textSource, baseTag, className) {
+  const text = createTag(baseTag, { class: className });
   const tagText = textSource.match(/\[(.*?)]/);
 
   if (tagText) {
@@ -50,9 +50,8 @@ export function decorateTextWithTag(textSource) {
 export function decorateHeading(block, payload) {
   const headingSection = createTag('div', { class: 'cta-carousel-heading-section' });
   const headingTextWrapper = createTag('div', { class: 'text-wrapper' });
-  const heading = createTag('h2', { class: 'cta-carousel-heading' });
+  const heading = decorateTextWithTag(payload.heading, 'h2', 'cta-carousel-heading');
 
-  heading.textContent = payload.heading;
   headingSection.append(headingTextWrapper);
   headingTextWrapper.append(heading);
 
@@ -199,7 +198,7 @@ async function decorateCards(block, payload) {
     }
 
     if (cta.text) {
-      textWrapper.append(decorateTextWithTag(cta.text));
+      textWrapper.append(decorateTextWithTag(cta.text, 'p', 'cta-card-text'));
     }
 
     if (cta.subtext && !hasGenAIEl) {

--- a/express/blocks/cta-carousel/cta-carousel.js
+++ b/express/blocks/cta-carousel/cta-carousel.js
@@ -29,13 +29,19 @@ export function sanitizeInput(string) {
   return string.replace(/[&<>"'`=/]/g, (s) => charMap[s]);
 }
 
-export function decorateTextWithTag(textSource, baseTag, className) {
-  const text = createTag(baseTag, { class: className });
+export function decorateTextWithTag(textSource, options = {}) {
+  const {
+    baseT,
+    tagT,
+    baseClass,
+    tagClass,
+  } = options;
+  const text = createTag(baseT || 'p', { class: baseClass || '' });
   const tagText = textSource.match(/\[(.*?)]/);
 
   if (tagText) {
     const [fullText, tagTextContent] = tagText;
-    const $tag = createTag('span', { class: 'tag' });
+    const $tag = createTag(tagT || 'span', { class: tagClass || 'tag' });
     text.textContent = textSource.replace(fullText, '').trim();
     text.dataset.text = text.textContent.toLowerCase();
     $tag.textContent = tagTextContent;
@@ -50,7 +56,7 @@ export function decorateTextWithTag(textSource, baseTag, className) {
 export function decorateHeading(block, payload) {
   const headingSection = createTag('div', { class: 'cta-carousel-heading-section' });
   const headingTextWrapper = createTag('div', { class: 'text-wrapper' });
-  const heading = decorateTextWithTag(payload.heading, 'h2', 'cta-carousel-heading');
+  const heading = decorateTextWithTag(payload.heading, { baseT: 'h2', tagT: 'sup', baseClass: 'cta-carousel-heading' });
 
   headingSection.append(headingTextWrapper);
   headingTextWrapper.append(heading);
@@ -198,7 +204,7 @@ async function decorateCards(block, payload) {
     }
 
     if (cta.text) {
-      textWrapper.append(decorateTextWithTag(cta.text, 'p', 'cta-card-text'));
+      textWrapper.append(decorateTextWithTag(cta.text, { baseClass: 'cta-card-text' }));
     }
 
     if (cta.subtext && !hasGenAIEl) {

--- a/express/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.css
@@ -69,6 +69,16 @@
   font-weight: 700;
 }
 
+.gen-ai-cards .card .text-wrapper .tag {
+  font-size: 10px;
+  padding: 0 4px;
+  margin-left: 6px;
+  font-weight: 700;
+  background-color: #DEDEF9;
+  color: var(--color-info-accent);
+  border-radius: 4px;
+}
+
 .gen-ai-cards .card .text-wrapper p.cta-card-desc {
   font-size: var(--body-font-size-s);
   line-height: var(--body-font-size-l);
@@ -178,7 +188,7 @@
 
 .gen-ai-cards .card .links-wrapper a:hover {
   /* 90% white to align with products */
-  background-color: #e6e6e6; 
+  background-color: #e6e6e6;
 }
 
 .gen-ai-cards .card .links-wrapper a:not(:hover) {

--- a/express/blocks/gen-ai-cards/gen-ai-cards.js
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.js
@@ -31,14 +31,19 @@ function sanitizeInput(string) {
   return string.replace(/[&<>"'`=/]/g, (s) => charMap[s]);
 }
 
-function decorateTextWithTag(textSource) {
-  const text = createTag('p', { class: 'cta-card-title' });
+export function decorateTextWithTag(textSource, options = {}) {
+  const {
+    baseT,
+    tagT,
+    baseClass,
+    tagClass,
+  } = options;
+  const text = createTag(baseT || 'p', { class: baseClass || '' });
   const tagText = textSource.match(/\[(.*?)]/);
 
-  // is this for analytics?
   if (tagText) {
     const [fullText, tagTextContent] = tagText;
-    const $tag = createTag('span', { class: 'tag' });
+    const $tag = createTag(tagT || 'span', { class: tagClass || 'tag' });
     text.textContent = textSource.replace(fullText, '').trim();
     text.dataset.text = text.textContent.toLowerCase();
     $tag.textContent = tagTextContent;
@@ -168,7 +173,7 @@ async function decorateCards(block, payload) {
       }
     }
 
-    const titleText = decorateTextWithTag(title);
+    const titleText = decorateTextWithTag(title, { tagT: 'sup', baseClass: 'cta-card-title' });
     textWrapper.append(titleText);
     const desc = createTag('p', { class: 'cta-card-desc' });
     desc.textContent = text;


### PR DESCRIPTION
The latest design is asking for the Beta tag to be added to the gen-ai-cards & cta-carousel blocks.

Resolves: [MWPW-137055](https://jira.corp.adobe.com/browse/MWPW-137055)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/?lighthouse=on
- After: https://cta-car-tag-to-heading--express--adobecom.hlx.page/express/?lighthouse=on
