### PR TITLE
[MWPW-137074] Long Text block: Plain variant to support color page layout

### DIFF
--- a/express/blocks/color-how-to-carousel/color-how-to-carousel.css
+++ b/express/blocks/color-how-to-carousel/color-how-to-carousel.css
@@ -1,10 +1,9 @@
 /* to remove after Milo migration */
 .section > .color-how-to-carousel-wrapper {
-    max-width: none;
+    max-width: 1200px;
 }
 
 .color-how-to-carousel {
-    margin: 120px 0 0 0;
     gap: 24px;
     padding: 0;
     display: flex;

--- a/express/blocks/hero-color/hero-color.css
+++ b/express/blocks/hero-color/hero-color.css
@@ -13,15 +13,15 @@ main .hero-color .content-container .text {
 
 main .hero-color .content-container {
   min-height: 200px;
-  max-width: 1440px;
+  max-width: 1200px;
   margin: auto;
 }
 
 main .hero-color .description-container {
-margin: 16px 0 32px 0;
-display: flex;
-flex-direction: column;
-gap: 10px;
+  margin: 16px 0 32px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 main .hero-color .text-container {

--- a/express/blocks/long-text/long-text.css
+++ b/express/blocks/long-text/long-text.css
@@ -17,7 +17,6 @@ main .long-text {
 
 main .long-text.plain {
     margin: unset;
-    padding: unset;
     background-color: initial;
     border-radius: unset;
 }
@@ -26,22 +25,26 @@ main .long-text * {
     text-align: left;
 }
 
+main .long-text.center * {
+    text-align: center;
+}
+
 main .long-text h2 {
     font-size: var(--heading-font-size-l);
 }
 
 main .long-text.plain h1 {
-    font-size: var(--heading-font-size-xl);
+    font-size: var(--heading-font-size-l);
     margin-bottom: 40px;
 }
 
 main .long-text.plain h2 {
-    font-size: var(--heading-font-size-l);
+    font-size: var(--heading-font-size-m);
     margin-bottom: 24px;
 }
 
 main .long-text.plain h3 {
-    font-size: var(--heading-font-size-m);
+    font-size: var(--heading-font-size-s);
     margin-bottom: 16px;
 }
 
@@ -59,5 +62,20 @@ main .long-text.plain p {
     main .long-text:not(.plain) {
         margin: 0 60px;
         padding: 28px;
+    }
+
+    main .long-text.plain h1 {
+        font-size: var(--heading-font-size-xl);
+        margin-bottom: 40px;
+    }
+
+    main .long-text.plain h2 {
+        font-size: var(--heading-font-size-l);
+        margin-bottom: 24px;
+    }
+
+    main .long-text.plain h3 {
+        font-size: var(--heading-font-size-m);
+        margin-bottom: 16px;
     }
 }

--- a/express/blocks/long-text/long-text.css
+++ b/express/blocks/long-text/long-text.css
@@ -4,6 +4,10 @@ main .section div.long-text-wrapper {
     padding: 0;
 }
 
+main .section div.long-text-wrapper.plain {
+    max-width: 1200px;
+}
+
 main .long-text {
     margin: 0 28px;
     padding: 28px;
@@ -11,21 +15,48 @@ main .long-text {
     border-radius: 20px;
 }
 
-main .long-text h2,
-main .long-text p {
+main .long-text.plain {
+    margin: unset;
+    padding: unset;
+    background-color: initial;
+    border-radius: unset;
+}
+
+main .long-text * {
     text-align: left;
 }
 
 main .long-text h2 {
+    font-size: var(--heading-font-size-l);
+}
+
+main .long-text.plain h1 {
+    font-size: var(--heading-font-size-xl);
+    margin-bottom: 40px;
+}
+
+main .long-text.plain h2 {
+    font-size: var(--heading-font-size-l);
+    margin-bottom: 24px;
+}
+
+main .long-text.plain h3 {
     font-size: var(--heading-font-size-m);
+    margin-bottom: 16px;
 }
 
 main .long-text p {
     font-size: var(--body-font-size-s);
 }
 
+main .long-text.plain p {
+    margin-top: 0;
+    margin-bottom: 80px;
+    font-size: var(--body-font-size-l);
+}
+
 @media (min-width: 900px) {
-    main .long-text {
+    main .long-text:not(.plain) {
         margin: 0 60px;
         padding: 28px;
     }

--- a/express/blocks/long-text/long-text.js
+++ b/express/blocks/long-text/long-text.js
@@ -11,6 +11,10 @@
  */
 
 export default function decorate(block) {
+  if (block.classList.contains('plain')) {
+    block.parentElement.classList.add('plain');
+  }
+
   if (block.textContent.trim() === '') {
     if (block.parentElement.classList.contains('long-text-wrapper')) {
       block.parentElement.remove();


### PR DESCRIPTION
Some updated stylings for color pages including a plain version of the long-text block

Resolves: [MWPW-137074](https://jira.corp.adobe.com/browse/MWPW-137074)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/colors/red?lighthouse=on
- After: https://mwpw-137074--express--adobecom.hlx.page/express/colors/red?lighthouse=on
