### PR TITLE
Adding overpowering z-index for Split Action for when branch banner is active

### DIFF
--- a/express/blocks/split-action/split-action.css
+++ b/express/blocks/split-action/split-action.css
@@ -6,6 +6,10 @@ main .split-action-container.transparent {
     opacity: 0;
 }
 
+body.branch-banner-is-active main .split-action-container {
+    z-index: 100000;
+}
+
 main .split-action {
     position: fixed;
     bottom: 0;
@@ -15,7 +19,7 @@ main .split-action {
     margin: 10px;
     padding: 24px;
     border-radius: 24px;
-    z-index: 100001;
+    z-index: 1;
     background: linear-gradient(320deg, #7C84F3, #FF4DD2, #FF993B, #FF4DD2, #7C84F3, #FF4DD2, #FF993B);
     background-size: 400% 400%;
     -webkit-animation: buttonGradient 45s ease infinite;

--- a/express/blocks/split-action/split-action.css
+++ b/express/blocks/split-action/split-action.css
@@ -6,7 +6,7 @@ main .split-action-container.transparent {
     opacity: 0;
 }
 
-body.branch-banner-is-active main .split-action-container {
+body.branch-banner-is-active .split-action-container {
     z-index: 100000;
 }
 


### PR DESCRIPTION
This will fix the issue where the branch banner covers the split action CTAs. **Need to test on live as the branch banner is something that only loads live (unless someone knows how to trigger it in dev environment, of course.)**

Resolves: [MWPW-137189](https://jira.corp.adobe.com/browse/MWPW-137189)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/feature/image/remove-background?lighthouse=on
- After: https://mwpw-137189--express--adobecom.hlx.page/express/feature/image/remove-background?lighthouse=on
