### PR TITLE
MWPW-137186 allow for blocks to also be steered over feature flag

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -563,6 +563,19 @@ export async function decorateBlock(block) {
     const section = block.closest('.section');
     if (section) section.classList.add(`${[...block.classList].join('-')}-container`);
 
+    const showWith = [...block.classList].filter((c) => c.toLowerCase().startsWith('showwith'));
+    // block visibility steered over metadata
+    if (showWith.length) {
+      let showWithSearchParam = null;
+      if (!['www.adobe.com'].includes(window.location.hostname)) {
+        const urlParams = new URLSearchParams(window.location.search);
+        showWithSearchParam = urlParams.get(`${showWith[0].toLowerCase()}`)
+          || urlParams.get(`${showWith[0]}`);
+      }
+      const blockRemove = showWithSearchParam !== null ? showWithSearchParam !== 'on' : getMetadata(showWith[0].slice(8).toLowerCase()) !== 'on';
+      if (blockRemove) block.remove();
+    }
+
     // begin CCX custom block option class handling
     // split and add options with a dash
     // (fullscreen-center -> fullscreen-center + fullscreen + center)

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -543,8 +543,8 @@ export function removeIrrelevantSections(main) {
         let showWithSearchParam = null;
         if (!['www.adobe.com'].includes(window.location.hostname)) {
           const urlParams = new URLSearchParams(window.location.search);
-          showWithSearchParam = urlParams.get(`showwith${sectionMeta.showwith.toLowerCase()}`)
-            || urlParams.get(`showwith${sectionMeta.showwith}`);
+          showWithSearchParam = urlParams.get(`${sectionMeta.showwith.toLowerCase()}`)
+            || urlParams.get(`${sectionMeta.showwith}`);
         }
         sectionRemove = showWithSearchParam !== null ? showWithSearchParam !== 'on' : getMetadata(sectionMeta.showwith.toLowerCase()) !== 'on';
       }


### PR DESCRIPTION
Built some code which allows for block visibility to also be steered over the feature flag. 
I haven't assigned the task to myself though as this is just a proposal of how it could be. It would be good for a dev to take on this task, document the changes and then finish up the ticket. 

Resolves: [MWPW-137186](https://jira.corp.adobe.com/browse/MWPW-137186)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/docs/library/kitchen-sink/section-metadata/show-with-example-usage?martech=off
- After: https://block-feature-flag--express--adobecom.hlx.page/docs/library/kitchen-sink/section-metadata/show-with-example-usage?martech=off
