### PR TITLE
[Ratings Block] Special spacing rule for KR

### DIFF
--- a/express/blocks/ratings/ratings.js
+++ b/express/blocks/ratings/ratings.js
@@ -343,6 +343,7 @@ export default async function decorate($block) {
       $stars.innerHTML = `${star.repeat(filledStars)}${starHalf.repeat(halfStars)}${starEmpty.repeat(emptyStars)}`;
       const $votes = createTag('span', { class: 'rating-votes' });
       $votes.innerHTML = `<strong>${rating} / 5</strong> - ${ratingAmount} ${votesText}`;
+      if (getLocale(window.location) === 'kr') $votes.innerHTML = `<strong>${rating} / 5</strong> - ${ratingAmount}${votesText}`;
       $stars.appendChild($votes);
       if (rating > 4.2) {
         buildSchema(actionTitle);


### PR DESCRIPTION
Removing an extra spacing for KR in ratings block.

<img width="713" alt="Screen Shot 2023-09-28 at 3 23 57 PM" src="https://github.com/adobecom/express/assets/57737624/5f32578d-2a42-4485-b843-4948f92c299b">
<img width="753" alt="Screen Shot 2023-09-28 at 3 23 49 PM" src="https://github.com/adobecom/express/assets/57737624/8ca1f749-4043-4cce-a849-d520b89a7bab">


Resolves: [MWPW-137209](https://jira.corp.adobe.com/browse/MWPW-137209)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/kr/express/feature/image/resize?lighthouse=on
- After: https://mwpw-137209--express--adobecom.hlx.page/kr/express/feature/image/resize?lighthouse=on
