### PR TITLE
Expand non-target blank rule for links

### DIFF
--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -255,7 +255,6 @@ async function processResponse(props) {
         href: template.branchURL,
         title: placeholders['edit-this-template'] ?? 'Edit this template',
         class: 'button accent',
-        target: '_blank',
       });
 
       $button.textContent = placeholders['edit-this-template'] ?? 'Edit this template';
@@ -408,7 +407,6 @@ function populateTemplates($block, templates, props) {
 
     if (isPlaceholder) {
       $tmplt.classList.add('placeholder');
-      $tmplt.target = '_blank';
     }
   }
 }

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -135,7 +135,6 @@ function renderCTA(placeholders, branchUrl) {
     href: branchUrl,
     title: btnTitle,
     class: 'button accent small',
-    target: '_blank',
   });
   btnEl.textContent = btnTitle;
   return btnEl;

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -256,7 +256,6 @@ function populateTemplates(block, props, templates) {
         if (isPlaceholder) {
           const aTag = createTag('a', {
             href: link.href ? addSearchQueryToHref(link.href) : '#',
-            target: '_blank',
           });
 
           aTag.append(...tmplt.children);

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1905,9 +1905,15 @@ function decorateLinks(main) {
       }
 
       const isContactLink = ['tel:', 'mailto:', 'sms:'].includes(url.protocol);
-      const isBranchLink = url.hostname === 'adobesparkpost.app.link';
-      const isProductLink = ['new.express.adobe.com', 'express.adobe.com'].includes(url.hostname);
-      const isAdotcomLink = ['www.adobe.com', 'www.stage.adobe.com'].includes(url.hostname);
+      const isAdobeOwnedLinks = [
+        'adobesparkpost.app.link',
+        'new.express.adobe.com',
+        'express.adobe.com',
+        'www.adobe.com',
+        'www.stage.adobe.com',
+        'commerce.adobe.com',
+        'commerce-stg.adobe.com',
+      ].includes(url.hostname);
 
       if (!isContactLink) {
         // make url relative if needed
@@ -1915,7 +1921,7 @@ function decorateLinks(main) {
         const urlPath = `${url.pathname}${url.search}${url.hash}`;
         a.href = relative ? urlPath : `${url.origin}${urlPath}`;
 
-        if (!(relative || isBranchLink || isProductLink || isAdotcomLink)) {
+        if (!isAdobeOwnedLinks) {
           // open external links in a new tab
           a.target = '_blank';
         }

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1906,13 +1906,16 @@ function decorateLinks(main) {
 
       const isContactLink = ['tel:', 'mailto:', 'sms:'].includes(url.protocol);
       const isBranchLink = url.hostname === 'adobesparkpost.app.link';
+      const isProductLink = ['new.express.adobe.com', 'express.adobe.com'].includes(url.hostname);
+      const isAdotcomLink = url.hostname === 'www.adobe.com';
+
       if (!isContactLink) {
         // make url relative if needed
         const relative = url.hostname === window.location.hostname;
         const urlPath = `${url.pathname}${url.search}${url.hash}`;
         a.href = relative ? urlPath : `${url.origin}${urlPath}`;
 
-        if (!relative && !isBranchLink) {
+        if (!(relative || isBranchLink || isProductLink || isAdotcomLink)) {
           // open external links in a new tab
           a.target = '_blank';
         }

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1907,7 +1907,7 @@ function decorateLinks(main) {
       const isContactLink = ['tel:', 'mailto:', 'sms:'].includes(url.protocol);
       const isBranchLink = url.hostname === 'adobesparkpost.app.link';
       const isProductLink = ['new.express.adobe.com', 'express.adobe.com'].includes(url.hostname);
-      const isAdotcomLink = url.hostname === 'www.adobe.com';
+      const isAdotcomLink = ['www.adobe.com', 'www.stage.adobe.com'].includes(url.hostname);
 
       if (!isContactLink) {
         // make url relative if needed


### PR DESCRIPTION
expanding the target="_blank" rule to:
**Branch links**
https://adobesparkpost.app.link/...
**Product links**
https://new.express.adobe.com/...
https://express.adobe.com/...
**Any adobe.com/... link**
shall open in same tab. 

any non adobe.com links shall open in new tab

Resolves: [MWPW-137270](https://jira.corp.adobe.com/browse/MWPW-137270)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/business?lighthouse=on
- After: https://mwpw-137270--express--adobecom.hlx.page/express/business?lighthouse=on
