### PR TITLE
Generate missing unit tests

### DIFF
--- a/express/blocks/feature-list/feature-list.js
+++ b/express/blocks/feature-list/feature-list.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export default function decorate() {
+  throw new Error('Not implemented');
+}

--- a/express/scripts/embed-videos.js
+++ b/express/scripts/embed-videos.js
@@ -21,7 +21,7 @@ function isInTextNode(node) {
   return node.parentElement.firstChild.nodeType === Node.TEXT_NODE;
 }
 
-function getDefaultEmbed(url) {
+export function getDefaultEmbed(url) {
   return `<div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%;">
     <iframe src="${url.href}" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen=""
       scrolling="no" allow="encrypted-media" title="Content from ${url.hostname}" loading="lazy">

--- a/test/gen-missing-units.js
+++ b/test/gen-missing-units.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-disable no-console */
+
+// this script will find all blocks in the express/blocks folder that are missing unit tests
+// and create a unit test folder and an initial .test.js for them
+// so that blocks without unit tests will be included in coverage reports
+const fs = require('fs');
+const path = require('path');
+
+async function main() {
+  const blocksFolder = path.join(__dirname, '../express/blocks');
+  // for every block
+  const blocks = [];
+  fs.readdirSync(blocksFolder).forEach((name) => {
+    if (name === 'shared') {
+      // TODO: we need to move shared to scripts in the future
+      return;
+    }
+    const blockPath = path.join(blocksFolder, name);
+    if (fs.statSync(blockPath).isDirectory()) {
+      blocks.push(name);
+    }
+  });
+
+  const blockUnitFolder = path.join(__dirname, '/unit/blocks');
+  const blockUnits = [];
+  fs.readdirSync(blockUnitFolder).forEach((name) => {
+    const blockUnitPath = path.join(blockUnitFolder, name);
+    if (fs.statSync(blockUnitPath).isDirectory() && fs.readdirSync(blockUnitPath).length > 0) {
+      blockUnits.push(name);
+    }
+  });
+  const missing = [];
+  for (const block of blocks) {
+    if (!blockUnits.includes(block)) {
+      missing.push(block);
+    }
+  }
+  console.log(missing);
+
+  for (const block of missing) {
+    const blockPath = path.join(blockUnitFolder, block);
+    if (!fs.existsSync(blockPath)) fs.mkdirSync(blockPath);
+    const testPath = path.join(blockPath, `${block}.test.js`);
+    console.log('generating test file', testPath);
+    fs.writeFileSync(
+      testPath,
+      `/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/${block}/${block}.js');\n`,
+    );
+  }
+}
+
+main().catch(console.error);

--- a/test/unit/blocks/animation/animation.test.js
+++ b/test/unit/blocks/animation/animation.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/animation/animation.js');

--- a/test/unit/blocks/app-banner/app-banner.test.js
+++ b/test/unit/blocks/app-banner/app-banner.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/app-banner/app-banner.js');

--- a/test/unit/blocks/app-store-blade/app-store-blade.test.js
+++ b/test/unit/blocks/app-store-blade/app-store-blade.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/app-store-blade/app-store-blade.js');

--- a/test/unit/blocks/app-store-highlight/app-store-highlight.test.js
+++ b/test/unit/blocks/app-store-highlight/app-store-highlight.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/app-store-highlight/app-store-highlight.js');

--- a/test/unit/blocks/banner/banner.test.js
+++ b/test/unit/blocks/banner/banner.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/banner/banner.js');

--- a/test/unit/blocks/blog-posts/blog-posts.test.js
+++ b/test/unit/blocks/blog-posts/blog-posts.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/blog-posts/blog-posts.js');

--- a/test/unit/blocks/branch-io/branch-io.test.js
+++ b/test/unit/blocks/branch-io/branch-io.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/branch-io/branch-io.js');

--- a/test/unit/blocks/browse-by-category/browse-by-category.test.js
+++ b/test/unit/blocks/browse-by-category/browse-by-category.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/browse-by-category/browse-by-category.js');

--- a/test/unit/blocks/browse-by-collaboration/browse-by-collaboration.test.js
+++ b/test/unit/blocks/browse-by-collaboration/browse-by-collaboration.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/browse-by-collaboration/browse-by-collaboration.js');

--- a/test/unit/blocks/bubble-ui-button/bubble-ui-button.test.js
+++ b/test/unit/blocks/bubble-ui-button/bubble-ui-button.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/bubble-ui-button/bubble-ui-button.js');

--- a/test/unit/blocks/cards/cards.test.js
+++ b/test/unit/blocks/cards/cards.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/cards/cards.js');

--- a/test/unit/blocks/carousel-card-mobile/carousel-card-mobile.test.js
+++ b/test/unit/blocks/carousel-card-mobile/carousel-card-mobile.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/carousel-card-mobile/carousel-card-mobile.js');

--- a/test/unit/blocks/category-list/category-list.test.js
+++ b/test/unit/blocks/category-list/category-list.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/category-list/category-list.js');

--- a/test/unit/blocks/chat/chat.test.js
+++ b/test/unit/blocks/chat/chat.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/chat/chat.js');

--- a/test/unit/blocks/checker-board/checker-board.test.js
+++ b/test/unit/blocks/checker-board/checker-board.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/checker-board/checker-board.js');

--- a/test/unit/blocks/choose-your-path/choose-your-path.test.js
+++ b/test/unit/blocks/choose-your-path/choose-your-path.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/choose-your-path/choose-your-path.js');

--- a/test/unit/blocks/collapsible-card/collapsible-card.test.js
+++ b/test/unit/blocks/collapsible-card/collapsible-card.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/collapsible-card/collapsible-card.js');

--- a/test/unit/blocks/columns/columns.test.js
+++ b/test/unit/blocks/columns/columns.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/columns/columns.js');

--- a/test/unit/blocks/commerce-cta/commerce-cta.test.js
+++ b/test/unit/blocks/commerce-cta/commerce-cta.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/commerce-cta/commerce-cta.js');

--- a/test/unit/blocks/contact/contact.test.js
+++ b/test/unit/blocks/contact/contact.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/contact/contact.js');

--- a/test/unit/blocks/content-toggle/content-toggle.test.js
+++ b/test/unit/blocks/content-toggle/content-toggle.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/content-toggle/content-toggle.js');

--- a/test/unit/blocks/download-cards/download-cards.test.js
+++ b/test/unit/blocks/download-cards/download-cards.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/download-cards/download-cards.js');

--- a/test/unit/blocks/download-screens/download-screens.test.js
+++ b/test/unit/blocks/download-screens/download-screens.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/download-screens/download-screens.js');

--- a/test/unit/blocks/embed/embed.test.js
+++ b/test/unit/blocks/embed/embed.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/embed/embed.js');

--- a/test/unit/blocks/faq/faq.test.js
+++ b/test/unit/blocks/faq/faq.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/faq/faq.js');

--- a/test/unit/blocks/feature-grid-desktop/feature-grid-desktop.test.js
+++ b/test/unit/blocks/feature-grid-desktop/feature-grid-desktop.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/feature-grid-desktop/feature-grid-desktop.js');

--- a/test/unit/blocks/feature-list/feature-list.test.js
+++ b/test/unit/blocks/feature-list/feature-list.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/feature-list/feature-list.js');

--- a/test/unit/blocks/filter-pages/filter-pages.test.js
+++ b/test/unit/blocks/filter-pages/filter-pages.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/filter-pages/filter-pages.js');

--- a/test/unit/blocks/firefly-card/firefly-card.test.js
+++ b/test/unit/blocks/firefly-card/firefly-card.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/firefly-card/firefly-card.js');

--- a/test/unit/blocks/floating-button/floating-button.test.js
+++ b/test/unit/blocks/floating-button/floating-button.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/floating-button/floating-button.js');

--- a/test/unit/blocks/floating-panel/floating-panel.test.js
+++ b/test/unit/blocks/floating-panel/floating-panel.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/floating-panel/floating-panel.js');

--- a/test/unit/blocks/fragment/fragment.test.js
+++ b/test/unit/blocks/fragment/fragment.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/fragment/fragment.js');

--- a/test/unit/blocks/full-width/full-width.test.js
+++ b/test/unit/blocks/full-width/full-width.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/full-width/full-width.js');

--- a/test/unit/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.test.js
+++ b/test/unit/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.js');

--- a/test/unit/blocks/fullscreen-marquee/fullscreen-marquee.test.js
+++ b/test/unit/blocks/fullscreen-marquee/fullscreen-marquee.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/fullscreen-marquee/fullscreen-marquee.js');

--- a/test/unit/blocks/hero-3d/hero-3d.test.js
+++ b/test/unit/blocks/hero-3d/hero-3d.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/hero-3d/hero-3d.js');

--- a/test/unit/blocks/hero-animation-beta/hero-animation-beta.test.js
+++ b/test/unit/blocks/hero-animation-beta/hero-animation-beta.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/hero-animation-beta/hero-animation-beta.js');

--- a/test/unit/blocks/hero-animation/hero-animation.test.js
+++ b/test/unit/blocks/hero-animation/hero-animation.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/hero-animation/hero-animation.js');

--- a/test/unit/blocks/hero-color/hero-color.test.js
+++ b/test/unit/blocks/hero-color/hero-color.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/hero-color/hero-color.js');

--- a/test/unit/blocks/hero-image/hero-image.test.js
+++ b/test/unit/blocks/hero-image/hero-image.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/hero-image/hero-image.js');

--- a/test/unit/blocks/how-to-steps-carousel/how-to-steps-carousel.test.js
+++ b/test/unit/blocks/how-to-steps-carousel/how-to-steps-carousel.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/how-to-steps-carousel/how-to-steps-carousel.js');

--- a/test/unit/blocks/how-to-steps/how-to-steps.test.js
+++ b/test/unit/blocks/how-to-steps/how-to-steps.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/how-to-steps/how-to-steps.js');

--- a/test/unit/blocks/icon-list/icon-list.test.js
+++ b/test/unit/blocks/icon-list/icon-list.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/icon-list/icon-list.js');

--- a/test/unit/blocks/image-list/image-list.test.js
+++ b/test/unit/blocks/image-list/image-list.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/image-list/image-list.js');

--- a/test/unit/blocks/inline-banner/inline-banner.test.js
+++ b/test/unit/blocks/inline-banner/inline-banner.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/inline-banner/inline-banner.js');

--- a/test/unit/blocks/layouts/layouts.test.js
+++ b/test/unit/blocks/layouts/layouts.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/layouts/layouts.js');

--- a/test/unit/blocks/legal/legal.test.js
+++ b/test/unit/blocks/legal/legal.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/legal/legal.js');

--- a/test/unit/blocks/library-config/library-config.test.js
+++ b/test/unit/blocks/library-config/library-config.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/library-config/library-config.js');

--- a/test/unit/blocks/link-list/link-list.test.js
+++ b/test/unit/blocks/link-list/link-list.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/link-list/link-list.js');

--- a/test/unit/blocks/linked-image/linked-image.test.js
+++ b/test/unit/blocks/linked-image/linked-image.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/linked-image/linked-image.js');

--- a/test/unit/blocks/list/list.test.js
+++ b/test/unit/blocks/list/list.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/list/list.js');

--- a/test/unit/blocks/long-text/long-text.test.js
+++ b/test/unit/blocks/long-text/long-text.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/long-text/long-text.js');

--- a/test/unit/blocks/make-a-project/make-a-project.test.js
+++ b/test/unit/blocks/make-a-project/make-a-project.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/make-a-project/make-a-project.js');

--- a/test/unit/blocks/modal/modal.test.js
+++ b/test/unit/blocks/modal/modal.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/modal/modal.js');

--- a/test/unit/blocks/multifunction-button/multifunction-button.test.js
+++ b/test/unit/blocks/multifunction-button/multifunction-button.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/multifunction-button/multifunction-button.js');

--- a/test/unit/blocks/page-list/page-list.test.js
+++ b/test/unit/blocks/page-list/page-list.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/page-list/page-list.js');

--- a/test/unit/blocks/plans-comparison/plans-comparison.test.js
+++ b/test/unit/blocks/plans-comparison/plans-comparison.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/plans-comparison/plans-comparison.js');

--- a/test/unit/blocks/premium-plan/premium-plan.test.js
+++ b/test/unit/blocks/premium-plan/premium-plan.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/premium-plan/premium-plan.js');

--- a/test/unit/blocks/pricing-columns/pricing-columns.test.js
+++ b/test/unit/blocks/pricing-columns/pricing-columns.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/pricing-columns/pricing-columns.js');

--- a/test/unit/blocks/pricing-hub/pricing-hub.test.js
+++ b/test/unit/blocks/pricing-hub/pricing-hub.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/pricing-hub/pricing-hub.js');

--- a/test/unit/blocks/pricing-modal/pricing-modal.test.js
+++ b/test/unit/blocks/pricing-modal/pricing-modal.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/pricing-modal/pricing-modal.js');

--- a/test/unit/blocks/pricing-plan/pricing-plan.test.js
+++ b/test/unit/blocks/pricing-plan/pricing-plan.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/pricing-plan/pricing-plan.js');

--- a/test/unit/blocks/pricing/pricing.test.js
+++ b/test/unit/blocks/pricing/pricing.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/pricing/pricing.js');

--- a/test/unit/blocks/promotion/promotion.test.js
+++ b/test/unit/blocks/promotion/promotion.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/promotion/promotion.js');

--- a/test/unit/blocks/puf/puf.test.js
+++ b/test/unit/blocks/puf/puf.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/puf/puf.js');

--- a/test/unit/blocks/quick-action-card/quick-action-card.test.js
+++ b/test/unit/blocks/quick-action-card/quick-action-card.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/quick-action-card/quick-action-card.js');

--- a/test/unit/blocks/quick-action-cards/quick-action-cards.test.js
+++ b/test/unit/blocks/quick-action-cards/quick-action-cards.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/quick-action-cards/quick-action-cards.js');

--- a/test/unit/blocks/quick-action-hub/quick-action-hub.test.js
+++ b/test/unit/blocks/quick-action-hub/quick-action-hub.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/quick-action-hub/quick-action-hub.js');

--- a/test/unit/blocks/quick-action/quick-action.test.js
+++ b/test/unit/blocks/quick-action/quick-action.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/quick-action/quick-action.js');

--- a/test/unit/blocks/quotes/quotes.test.js
+++ b/test/unit/blocks/quotes/quotes.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/quotes/quotes.js');

--- a/test/unit/blocks/ratings/ratings.test.js
+++ b/test/unit/blocks/ratings/ratings.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/ratings/ratings.js');

--- a/test/unit/blocks/schemas/schemas.test.js
+++ b/test/unit/blocks/schemas/schemas.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/schemas/schemas.js');

--- a/test/unit/blocks/search-marquee/search-marquee.test.js
+++ b/test/unit/blocks/search-marquee/search-marquee.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/search-marquee/search-marquee.js');

--- a/test/unit/blocks/seo-nav/seo-nav.test.js
+++ b/test/unit/blocks/seo-nav/seo-nav.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/seo-nav/seo-nav.js');

--- a/test/unit/blocks/show-section-only/show-section-only.test.js
+++ b/test/unit/blocks/show-section-only/show-section-only.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/show-section-only/show-section-only.js');

--- a/test/unit/blocks/split-action/split-action.test.js
+++ b/test/unit/blocks/split-action/split-action.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/split-action/split-action.js');

--- a/test/unit/blocks/steps/steps.test.js
+++ b/test/unit/blocks/steps/steps.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/steps/steps.js');

--- a/test/unit/blocks/sticky-footer/sticky-footer.test.js
+++ b/test/unit/blocks/sticky-footer/sticky-footer.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/sticky-footer/sticky-footer.js');

--- a/test/unit/blocks/sticky-promo-bar/sticky-promo-bar.test.js
+++ b/test/unit/blocks/sticky-promo-bar/sticky-promo-bar.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/sticky-promo-bar/sticky-promo-bar.js');

--- a/test/unit/blocks/submit-email/submit-email.test.js
+++ b/test/unit/blocks/submit-email/submit-email.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/submit-email/submit-email.js');

--- a/test/unit/blocks/table-of-contents/table-of-contents.test.js
+++ b/test/unit/blocks/table-of-contents/table-of-contents.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/table-of-contents/table-of-contents.js');

--- a/test/unit/blocks/tags/tags.test.js
+++ b/test/unit/blocks/tags/tags.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/tags/tags.js');

--- a/test/unit/blocks/template-list-ace/template-list-ace.test.js
+++ b/test/unit/blocks/template-list-ace/template-list-ace.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/template-list-ace/template-list-ace.js');

--- a/test/unit/blocks/template-list/template-list.test.js
+++ b/test/unit/blocks/template-list/template-list.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/template-list/template-list.js');

--- a/test/unit/blocks/template-x/template-x.test.js
+++ b/test/unit/blocks/template-x/template-x.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/template-x/template-x.js');

--- a/test/unit/blocks/toc/toc.test.js
+++ b/test/unit/blocks/toc/toc.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/toc/toc.js');

--- a/test/unit/blocks/toggle-bar/toggle-bar.test.js
+++ b/test/unit/blocks/toggle-bar/toggle-bar.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/toggle-bar/toggle-bar.js');

--- a/test/unit/blocks/tutorials/tutorials.test.js
+++ b/test/unit/blocks/tutorials/tutorials.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+const { default: decorate } = await import('../../../../express/blocks/tutorials/tutorials.js');


### PR DESCRIPTION
As of now, the generated unit test coverage reports don't include unmentioned blocks.
This benign PR uses a script to generate dummy test, and will allow those un-tested blocks to be included in reports. Our reports will look more precise and meaningful.
This will also encourage devs to slowly fill those tests up, when people see low coverage in reports.
I might set up GH pages to track those coverages weekly in the future.

https://jira.corp.adobe.com/browse/MWPW-137292

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/
- After: https://generate-missing-unit-tests--express--adobecom.hlx.page/express/templates/flyer?lighthouse=on
