### PR TITLE
[MWPW-137383] - Sticky Promo Bar (Technical Debt)

### DIFF
--- a/express/blocks/sticky-promo-bar/sticky-promo-bar.css
+++ b/express/blocks/sticky-promo-bar/sticky-promo-bar.css
@@ -32,7 +32,7 @@ main .sticky-promo-bar.rounded {
     max-width: 360px;
 }
 
-main .sticky-promo-bar.loadinbody {
+body[data-device="mobile"] main .sticky-promo-bar.loadinbody {
     margin: 12px auto;
     box-sizing: border-box;
     max-width: 360px;

--- a/express/blocks/sticky-promo-bar/sticky-promo-bar.css
+++ b/express/blocks/sticky-promo-bar/sticky-promo-bar.css
@@ -38,7 +38,7 @@ body[data-device="mobile"] main .sticky-promo-bar.loadinbody {
     max-width: 360px;
 }
 
-main .sticky-promo-bar:not(.rounded) a:any-link {
+main .sticky-promo-bar a:any-link:not(.inline-link) {
     color: white;
     border: 2px solid white;
     border-radius: 20px;
@@ -52,11 +52,15 @@ main .sticky-promo-bar:not(.rounded) a:any-link {
     margin-top: 5px;
 }
 
-main .sticky-promo-bar.rounded a:any-link {
+main .sticky-promo-bar a.inline-link:any-link {
     color: white;
     text-decoration: underline;
     white-space: nowrap;
     font-style: initial;
+}
+
+main .sticky-promo-bar:not(.rounded) a.inline-link:any-link {
+    font-weight: 900;
 }
 
 main .sticky-promo-bar.rounded p {

--- a/express/blocks/sticky-promo-bar/sticky-promo-bar.css
+++ b/express/blocks/sticky-promo-bar/sticky-promo-bar.css
@@ -10,7 +10,7 @@ main .sticky-promo-bar {
     font-weight: 900;
     z-index: 10;
     max-width: 500px;
-    margin: 16px auto;
+    margin: auto;
     transition: transform 0.4s;
 }
 
@@ -23,7 +23,7 @@ main .sticky-promo-bar.clone {
     transform: translateY(0);
 }
 
-body[data-device="mobile"] main .sticky-promo-bar.rounded {
+main .sticky-promo-bar.rounded {
     border-radius: 10px;
     font-weight: 300;
     padding: 7px 16px 9px;
@@ -32,7 +32,7 @@ body[data-device="mobile"] main .sticky-promo-bar.rounded {
     max-width: 360px;
 }
 
-body[data-device="mobile"] main .sticky-promo-bar.loadinbody {
+main .sticky-promo-bar.loadinbody {
     margin: 12px auto;
     box-sizing: border-box;
     max-width: 360px;

--- a/express/blocks/sticky-promo-bar/sticky-promo-bar.js
+++ b/express/blocks/sticky-promo-bar/sticky-promo-bar.js
@@ -37,12 +37,25 @@ function initScrollInteraction(block) {
   observer.observe(inBodyBanner);
 }
 
+function decorateLink(block) {
+  const links = block.querySelectorAll('a:any-link');
+
+  if (links.length) {
+    links.forEach((link) => {
+      if (link.nextSibling?.nodeName === '#text' && link.previousSibling?.nodeName === '#text') {
+        link.classList.add('inline-link');
+      }
+    })
+  }
+}
+
 export default function decorate(block) {
   const close = createTag('button', {
     class: 'close',
     'aria-label': 'close',
   });
   block.appendChild(close);
+  decorateLink(block);
 
   BlockMediator.set('promobar', {
     block,

--- a/express/blocks/sticky-promo-bar/sticky-promo-bar.js
+++ b/express/blocks/sticky-promo-bar/sticky-promo-bar.js
@@ -45,7 +45,7 @@ function decorateLink(block) {
       if (link.nextSibling?.nodeName === '#text' && link.previousSibling?.nodeName === '#text') {
         link.classList.add('inline-link');
       }
-    })
+    });
   }
 }
 


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/MWPW-137383

One of the items in the list of technical debts:
https://jira.corp.adobe.com/browse/MWPW-136321

**Description:**
- Remove extra 16px margin on the default version
- Make the variant (rounded) appear on desktop version

**Test URLs:**
Before for default version: https://main--express--adobecom.hlx.page/express/learn/blog/better-together-adobe-apps-now-integrate-with-schools-favorite-productivity-tools?lighthouse=on
After for default version: https://sticky-promo-bar--express--adobecom.hlx.page/express/learn/blog/better-together-adobe-apps-now-integrate-with-schools-favorite-productivity-tools?lighthouse=on

As for the rounded variant, it now works if section metadata is changed to 'desktop'.