### PR TITLE
Update config.js rename CCX to AX

### DIFF
--- a/tools/sidekick/config.js
+++ b/tools/sidekick/config.js
@@ -13,7 +13,7 @@
 // This file contains the project-specific configuration for the sidekick.
 (() => {
   window.hlx.initSidekick({
-    project: 'CCX',
+    project: 'AX',
     outerHost: 'express--adobecom.hlx.live',
     host: 'www.adobe.com',
     byocdn: true,


### PR DESCRIPTION
Rename ccx to ax. That file is probably not really used though, but this is better consistency still

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/
- After: https://JingleH-patch-1--express--adobecom.hlx.page/express/?lighthouse=on
