### PR TITLE
MWPW-137559 | Gen-ai-cards img Not Load Lazy After Left Neighbor Loaded

### DIFF
--- a/express/blocks/gen-ai-cards/gen-ai-cards.js
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.js
@@ -115,7 +115,7 @@ async function decorateCards(block, payload) {
   const cards = createTag('div', { class: 'gen-ai-cards-cards' });
   const placeholders = await fetchPlaceholders();
 
-  payload.actions.forEach((cta) => {
+  payload.actions.forEach((cta, index) => {
     const {
       image,
       ctaLinks,
@@ -128,8 +128,18 @@ async function decorateCards(block, payload) {
     const textWrapper = createTag('div', { class: 'text-wrapper' });
 
     card.append(textWrapper, mediaWrapper, linksWrapper);
-
-    if (image) mediaWrapper.append(image);
+    if (image) {
+      mediaWrapper.append(image);
+      if (index > 0) {
+        const lastPicture = payload.actions[index - 1].image;
+        lastPicture.querySelector('img').onload = (e) => {
+          if (e.eventPhase >= Event.AT_TARGET) {
+            console.log('last loaded!', index, text, title);
+            image.querySelector('img').removeAttribute('loading');
+          }
+        };
+      }
+    }
 
     const hasGenAIForm = (new RegExp(genAIPlaceholder).test(ctaLinks?.[0]?.href));
 

--- a/express/blocks/gen-ai-cards/gen-ai-cards.js
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.js
@@ -133,10 +133,8 @@ async function decorateCards(block, payload) {
       if (index > 0) {
         const lastPicture = payload.actions[index - 1].image;
         lastPicture.querySelector('img').onload = (e) => {
-          if (e.eventPhase >= Event.AT_TARGET) {
-            console.log('last loaded!', index, text, title);
-            image.querySelector('img').removeAttribute('loading');
-          }
+          console.log('last loaded!', index, text, title);
+          image.querySelector('img').removeAttribute('loading');
         };
       }
     }

--- a/express/blocks/gen-ai-cards/gen-ai-cards.js
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.js
@@ -111,11 +111,20 @@ function buildGenAIForm({ ctaLinks, subtext }) {
   return genAIForm;
 }
 
-async function decorateCards(block, payload) {
+function removeLazyAfterNeighborLoaded(image, lastImage) {
+  if (!image || !lastImage) return;
+  lastImage.onload = (e) => {
+    if (e.eventPhase >= Event.AT_TARGET) {
+      image.querySelector('img').removeAttribute('loading');
+    }
+  };
+}
+
+async function decorateCards(block, { actions }) {
   const cards = createTag('div', { class: 'gen-ai-cards-cards' });
   const placeholders = await fetchPlaceholders();
 
-  payload.actions.forEach((cta, index) => {
+  actions.forEach((cta, i) => {
     const {
       image,
       ctaLinks,
@@ -130,12 +139,9 @@ async function decorateCards(block, payload) {
     card.append(textWrapper, mediaWrapper, linksWrapper);
     if (image) {
       mediaWrapper.append(image);
-      if (index > 0) {
-        const lastPicture = payload.actions[index - 1].image;
-        lastPicture.querySelector('img').onload = (e) => {
-          console.log('last loaded!', index, text, title);
-          image.querySelector('img').removeAttribute('loading');
-        };
+      if (i > 0) {
+        const lastImage = actions[i - 1].image?.querySelector('img');
+        removeLazyAfterNeighborLoaded(image, lastImage);
       }
     }
 


### PR DESCRIPTION
Sometimes the fourth image would not load on smaller window, as it's loading=lazy and also not appearing enough in the view port and browser wouldn't load them. After this change, every image will eagerly load after its left neighbor finished loading. This won't affect performance since the first ones still load lazily. This experience also makes sense in carousels, since users likely want the next one after seeing the current one.

https://jira.corp.adobe.com/browse/MWPW-137559

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/jingle/gen-ai-cards?lighthouse=on
- After: https://gen-ai-cards-img-lazy--express--adobecom.hlx.page/drafts/jingle/gen-ai-cards?lighthouse=on
