### PR TITLE
fix remaining old loadScript param

### DIFF
--- a/express/scripts/embed-videos.js
+++ b/express/scripts/embed-videos.js
@@ -35,7 +35,7 @@ export function embedYoutube(a) {
   const searchParams = new URLSearchParams(a.search);
   const id = searchParams.get('v') || a.pathname.split('/').pop();
   searchParams.delete('v');
-  loadScript('/express/scripts/libs/lite-yt-embed/lite-yt-embed.js', null, 'module');
+  loadScript('/express/scripts/libs/lite-yt-embed/lite-yt-embed.js', 'module');
   loadCSS('/express/scripts/libs/lite-yt-embed/lite-yt-embed.css');
   const embedHTML = `<lite-youtube videoid="${id}" playlabel="${title}"></lite-youtube>`;
   a.insertAdjacentHTML('afterend', embedHTML);


### PR DESCRIPTION
Found one more missing loadScript param correction

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER) Pending

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://load-script-fix--express--adobecom.hlx.page/express/
