### PR TITLE
[Urgent] Undo Gen-AI-Cards Prompt Open in New Tab

### DIFF
--- a/express/blocks/gen-ai-cards/gen-ai-cards.js
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.js
@@ -71,7 +71,7 @@ function handleGenAISubmit(form, link) {
   const input = form.querySelector('input');
   if (input.value.trim() === '') return;
   const genAILink = link.replace(genAIPlaceholder, encodeURI(input.value).replaceAll(' ', '+'));
-  window.open(genAILink);
+  if (genAILink) window.location.assign(genAILink);
 }
 
 function buildGenAIForm({ ctaLinks, subtext }) {


### PR DESCRIPTION
Undo Gen-AI-Cards prompt links opening in new tabs. We want the same tabs.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/
- After: https://gen-ai-cards-prompt-same-tab--express--adobecom.hlx.page/express/?lighthouse=on
