### PR TITLE
Updated unit tests for gen-ai-cards

### DIFF
--- a/express/blocks/gen-ai-cards/gen-ai-cards.js
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.js
@@ -67,11 +67,17 @@ export function decorateHeading(block, payload) {
   block.append(headingSection);
 }
 
+export const windowHelper = {
+  redirect: (url) => {
+    window.location.assign(url);
+  },
+};
+
 function handleGenAISubmit(form, link) {
   const input = form.querySelector('input');
   if (input.value.trim() === '') return;
   const genAILink = link.replace(genAIPlaceholder, encodeURI(input.value).replaceAll(' ', '+'));
-  if (genAILink) window.location.assign(genAILink);
+  if (genAILink) windowHelper.redirect(genAILink);
 }
 
 function buildGenAIForm({ ctaLinks, subtext }) {

--- a/test/unit/blocks/gen-ai-cards/gen-ai-cards.test.js
+++ b/test/unit/blocks/gen-ai-cards/gen-ai-cards.test.js
@@ -14,7 +14,7 @@ import { readFile } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 
-const { default: decorate } = await import(
+const { default: decorate, windowHelper } = await import(
   '../../../../express/blocks/gen-ai-cards/gen-ai-cards.js'
 );
 const testBody = await readFile({ path: './mocks/body.html' });
@@ -85,7 +85,7 @@ describe('Gen AI Cards', () => {
     const form = card.querySelector('.gen-ai-input-form');
     const input = form.querySelector('input');
     const button = form.querySelector('button');
-    const stub = sinon.stub(window, 'open');
+    const stub = sinon.stub(windowHelper, 'redirect');
     expect(button.disabled).to.be.true;
     const enterEvent = new KeyboardEvent('keyup', {
       key: 'Enter',


### PR DESCRIPTION
Unit tests were broken due to a prod hotfix before MAX. This PR is to fix that. Since we're at code freeze, we don't have to merge it to main yet

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/
- After: https://gen-ai-cards-unit-tests--express--adobecom.hlx.page/express/?lighthouse=on
