### PR TITLE
MWPW-137822 | new font typekit fix

### DIFF
--- a/express/styles/lazy-styles.css
+++ b/express/styles/lazy-styles.css
@@ -17,10 +17,10 @@
  *
  * © 2009-2023 Adobe Systems Incorporated. All Rights Reserved.
  */
-/*{"last_published":"2022-09-30 20:31:33 UTC"}*/
+/*{"last_published":"2022-09-30 20:31:34 UTC"}*/
 @font-face {
   font-family: "adobe-clean";
-  src: url("https://use.typekit.net/af/c0160f/00000000000000007735dac8/30/l?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=n4&v=3") format("woff2"), url("https://use.typekit.net/af/c0160f/00000000000000007735dac8/30/d?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=n4&v=3") format("woff"), url("https://use.typekit.net/af/c0160f/00000000000000007735dac8/30/a?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=n4&v=3") format("opentype");
+  src: url("https://use.typekit.net/af/c0160f/00000000000000007735dac8/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff2"),url("https://use.typekit.net/af/c0160f/00000000000000007735dac8/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff"),url("https://use.typekit.net/af/c0160f/00000000000000007735dac8/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("opentype");
   font-display: swap;
   font-style: normal;
   font-weight: 400;
@@ -29,7 +29,7 @@
 
 @font-face {
   font-family: "adobe-clean";
-  src: url("https://use.typekit.net/af/95bf80/00000000000000007735dacd/30/l?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=i4&v=3") format("woff2"), url("https://use.typekit.net/af/95bf80/00000000000000007735dacd/30/d?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=i4&v=3") format("woff"), url("https://use.typekit.net/af/95bf80/00000000000000007735dacd/30/a?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=i4&v=3") format("opentype");
+  src: url("https://use.typekit.net/af/95bf80/00000000000000007735dacd/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("woff2"),url("https://use.typekit.net/af/95bf80/00000000000000007735dacd/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("woff"),url("https://use.typekit.net/af/95bf80/00000000000000007735dacd/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("opentype");
   font-display: swap;
   font-style: italic;
   font-weight: 400;
@@ -38,7 +38,7 @@
 
 @font-face {
   font-family: "adobe-clean";
-  src: url("https://use.typekit.net/af/5c07ba/00000000000000007735dad8/30/l?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=n7&v=3") format("woff2"), url("https://use.typekit.net/af/5c07ba/00000000000000007735dad8/30/d?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=n7&v=3") format("woff"), url("https://use.typekit.net/af/5c07ba/00000000000000007735dad8/30/a?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=n7&v=3") format("opentype");
+  src: url("https://use.typekit.net/af/5c07ba/00000000000000007735dad8/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("woff2"),url("https://use.typekit.net/af/5c07ba/00000000000000007735dad8/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("woff"),url("https://use.typekit.net/af/5c07ba/00000000000000007735dad8/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("opentype");
   font-display: swap;
   font-style: normal;
   font-weight: 700;
@@ -47,7 +47,7 @@
 
 @font-face {
   font-family: "adobe-clean";
-  src: url("https://use.typekit.net/af/dc1cb5/00000000000000007735dadb/30/l?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=n3&v=3") format("woff2"), url("https://use.typekit.net/af/dc1cb5/00000000000000007735dadb/30/d?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=n3&v=3") format("woff"), url("https://use.typekit.net/af/dc1cb5/00000000000000007735dadb/30/a?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=n3&v=3") format("opentype");
+  src: url("https://use.typekit.net/af/dc1cb5/00000000000000007735dadb/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n3&v=3") format("woff2"),url("https://use.typekit.net/af/dc1cb5/00000000000000007735dadb/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n3&v=3") format("woff"),url("https://use.typekit.net/af/dc1cb5/00000000000000007735dadb/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n3&v=3") format("opentype");
   font-display: swap;
   font-style: normal;
   font-weight: 300;
@@ -56,7 +56,7 @@
 
 @font-face {
   font-family: "adobe-clean";
-  src: url("https://use.typekit.net/af/bc79c1/00000000000000007735dad9/30/l?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=n9&v=3") format("woff2"), url("https://use.typekit.net/af/bc79c1/00000000000000007735dad9/30/d?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=n9&v=3") format("woff"), url("https://use.typekit.net/af/bc79c1/00000000000000007735dad9/30/a?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=n9&v=3") format("opentype");
+  src: url("https://use.typekit.net/af/bc79c1/00000000000000007735dad9/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n9&v=3") format("woff2"),url("https://use.typekit.net/af/bc79c1/00000000000000007735dad9/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n9&v=3") format("woff"),url("https://use.typekit.net/af/bc79c1/00000000000000007735dad9/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n9&v=3") format("opentype");
   font-display: swap;
   font-style: normal;
   font-weight: 900;
@@ -65,7 +65,7 @@
 
 @font-face {
   font-family: "adobe-clean";
-  src: url("https://use.typekit.net/af/f5ecaa/00000000000000007735dad6/30/l?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=i3&v=3") format("woff2"), url("https://use.typekit.net/af/f5ecaa/00000000000000007735dad6/30/d?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=i3&v=3") format("woff"), url("https://use.typekit.net/af/f5ecaa/00000000000000007735dad6/30/a?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=i3&v=3") format("opentype");
+  src: url("https://use.typekit.net/af/f5ecaa/00000000000000007735dad6/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i3&v=3") format("woff2"),url("https://use.typekit.net/af/f5ecaa/00000000000000007735dad6/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i3&v=3") format("woff"),url("https://use.typekit.net/af/f5ecaa/00000000000000007735dad6/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i3&v=3") format("opentype");
   font-display: swap;
   font-style: italic;
   font-weight: 300;
@@ -74,7 +74,7 @@
 
 @font-face {
   font-family: "adobe-clean-serif";
-  src: url("https://use.typekit.net/af/15eaed/00000000000000007735dac6/30/l?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=n4&v=3") format("woff2"), url("https://use.typekit.net/af/15eaed/00000000000000007735dac6/30/d?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=n4&v=3") format("woff"), url("https://use.typekit.net/af/15eaed/00000000000000007735dac6/30/a?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=n4&v=3") format("opentype");
+  src: url("https://use.typekit.net/af/15eaed/00000000000000007735dac6/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff2"),url("https://use.typekit.net/af/15eaed/00000000000000007735dac6/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff"),url("https://use.typekit.net/af/15eaed/00000000000000007735dac6/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("opentype");
   font-display: swap;
   font-style: normal;
   font-weight: 400;
@@ -83,7 +83,7 @@
 
 @font-face {
   font-family: "adobe-clean-serif";
-  src: url("https://use.typekit.net/af/2dc334/00000000000000007735dac7/30/l?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=n5&v=3") format("woff2"), url("https://use.typekit.net/af/2dc334/00000000000000007735dac7/30/d?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=n5&v=3") format("woff"), url("https://use.typekit.net/af/2dc334/00000000000000007735dac7/30/a?primer=ac8c128253c94f374040a4dde020a0c48540a1a7146e7c4a375a2dd0a9189251&fvd=n5&v=3") format("opentype");
+  src: url("https://use.typekit.net/af/2dc334/00000000000000007735dac7/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n5&v=3") format("woff2"),url("https://use.typekit.net/af/2dc334/00000000000000007735dac7/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n5&v=3") format("woff"),url("https://use.typekit.net/af/2dc334/00000000000000007735dac7/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n5&v=3") format("opentype");
   font-display: swap;
   font-style: normal;
   font-weight: 500;
@@ -91,11 +91,11 @@
 }
 
 .tk-adobe-clean {
-  font-family: "adobe-clean", sans-serif;
+  font-family: "adobe-clean",sans-serif;
 }
 
 .tk-adobe-clean-serif {
-  font-family: "adobe-clean-serif", sans-serif;
+  font-family: "adobe-clean-serif",sans-serif;
 }
 
 /* below the fold */


### PR DESCRIPTION
Grabbed another typekit css directly from adobe.com homepage

Resolves: [MWPW-137822](https://jira.corp.adobe.com/browse/MWPW-137822)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/es/express/?lighthouse=on
- After: https://typekit-fix-2--express--adobecom.hlx.page/es/express/?lighthouse=on
