### PR TITLE
revert animation block change

### DIFF
--- a/express/blocks/animation/animation.js
+++ b/express/blocks/animation/animation.js
@@ -36,11 +36,11 @@ export default function init(el) {
 
       const video = createTag('video', attribs);
 
-      if (href.startsWith('https://hlx.blob.core.windows.net/external/')) {
-        video.innerHTML = `<source src=${href} type="video/mp4">`;
-      } else {
-        video.innerHTML = `<source src="./media_${suffix}" type="video/mp4">`;
-      }
+      // if (href.startsWith('https://hlx.blob.core.windows.net/external/')) {
+      //   video.innerHTML = `<source src=${href} type="video/mp4">`;
+      // } else {
+      //   video.innerHTML = `<source src="./media_${suffix}" type="video/mp4">`;
+      // }
 
       a.parentNode.replaceChild(video, a);
       if (isAnimation) {

--- a/express/blocks/animation/animation.js
+++ b/express/blocks/animation/animation.js
@@ -12,15 +12,16 @@
 
 import { createTag } from '../../scripts/scripts.js';
 
-export default function init(el) {
-  el.querySelectorAll('a:any-link').forEach((a) => {
+export default function decorate(block, name, doc) {
+  doc.querySelectorAll('.animation a[href], .video a[href]').forEach((a) => {
     const { href } = a;
     const url = new URL(href);
     const suffix = url.pathname.split('/media_')[1];
     const parent = a.parentNode;
 
     if (href.endsWith('.mp4')) {
-      const isAnimation = a.closest('.animation');
+      const isAnimation = !!a.closest('.animation');
+      // const isAnimation = true;
 
       let attribs = { controls: '' };
       if (isAnimation) {
@@ -35,13 +36,12 @@ export default function init(el) {
       }
 
       const video = createTag('video', attribs);
-
-      // if (href.startsWith('https://hlx.blob.core.windows.net/external/')) {
-      //   video.innerHTML = `<source src=${href} type="video/mp4">`;
-      // } else {
-      //   video.innerHTML = `<source src="./media_${suffix}" type="video/mp4">`;
-      // }
-
+      /*
+      if (href.startsWith('https://hlx.blob.core.windows.net/external/')) {
+        href='/hlx_'+href.split('/')[4].replace('#image','');
+      }
+      */
+      video.innerHTML = `<source src="./media_${suffix}" type="video/mp4">`;
       a.parentNode.replaceChild(video, a);
       if (isAnimation) {
         video.addEventListener('canplay', () => {

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -678,7 +678,6 @@ function decorateLinks(main) {
         url = new URL(a.href);
       }
 
-      const isLegacyVideoLink = a.textContent.startsWith('https://hlx.blob.core.windows.net/external/') && a.textContent.includes('#image');
       const isContactLink = ['tel:', 'mailto:', 'sms:'].includes(url.protocol);
       const isAdobeOwnedLinks = [
         'adobesparkpost.app.link',
@@ -704,8 +703,6 @@ function decorateLinks(main) {
       }
       if (a.href.includes('#_dnb')) {
         a.href = a.href.replace('#_dnb', '');
-      } else if (isLegacyVideoLink) {
-        a.href = a.textContent;
       } else {
         const autoBlock = decorateAutoBlock(a);
         if (autoBlock) {


### PR DESCRIPTION
Reverting animation block work around and deferring fix to Franklin core team.
Should expect to see the animation blocks breaking again on the preview page, compared to stage.

Resolves: [MWPW-137872](https://jira.corp.adobe.com/browse/MWPW-137872)

Test URLs:
- Before: https://stage--express--adobecom.hlx.live/express/learn/blog/android-users-meet-adobe-spark-post?martech=off
- After: https://revert-animation-change--express--adobecom.hlx.page/express/learn/blog/android-users-meet-adobe-spark-post?martech=off
