### PR TITLE
Delay Loading Template-Fetch-Task-Count

### DIFF
--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -203,6 +203,9 @@ function fetchTemplatesByTasks(tasks, props) {
 }
 
 async function appendCategoryTemplatesCount($section, props) {
+  if (props.loadedOtherCategoryCounts) {
+    return;
+  }
   const categories = $section.querySelectorAll('ul.category-list > li');
   const lang = getLanguage(getLocale(window.location));
 
@@ -216,6 +219,7 @@ async function appendCategoryTemplatesCount($section, props) {
       anchor.append(countSpan);
     }
   }
+  props.loadedOtherCategoryCounts = true;
 }
 
 async function processResponse(props) {
@@ -628,7 +632,7 @@ function updateFilterIcon(block) {
   });
 }
 
-function decorateFunctionsContainer($block, $section, functions, placeholders) {
+function decorateFunctionsContainer($block, $section, functions, placeholders, props) {
   const $functionsContainer = createTag('div', { class: 'functions-container' });
   const $functionContainerMobile = createTag('div', { class: 'functions-drawer' });
 
@@ -712,6 +716,11 @@ function decorateFunctionsContainer($block, $section, functions, placeholders) {
     $sortButton.textContent = placeholders.sort;
     $sortButton.className = 'filter-mobile-option-heading';
   }
+
+  $mobileFilterButton.addEventListener('click', () => {
+    console.log('clicked');
+    appendCategoryTemplatesCount($section, props);
+  }, { once: true });
 
   return { mobile: $functionContainerMobile, desktop: $functionsContainer };
 }
@@ -927,6 +936,10 @@ async function decorateCategoryList(block, section, placeholders, props) {
     $listItem.append($a);
     $categories.append($listItem);
   });
+
+  $categoriesDesktopWrapper.addEventListener('mouseover', () => {
+    appendCategoryTemplatesCount(section, props);
+  }, { once: true });
 
   $categoriesToggleWrapper.append($categoriesToggle);
   $categoriesDesktopWrapper.append($categories);
@@ -1477,7 +1490,13 @@ function decorateToolbar($block, $section, placeholders, props) {
     lgView.append(getIconElement('large_grid'));
 
     const functionsObj = makeTemplateFunctions(placeholders);
-    const $functions = decorateFunctionsContainer($block, $section, functionsObj, placeholders);
+    const $functions = decorateFunctionsContainer(
+      $block,
+      $section,
+      functionsObj,
+      placeholders,
+      props,
+    );
 
     $viewsWrapper.append(smView, mdView, lgView);
     functionsWrapper.append($viewsWrapper, $functions.desktop);
@@ -1603,7 +1622,6 @@ export async function decorateTemplateList($block, props) {
           if ($parent.contains(e.detail[0])) {
             decorateToolbar($block, $parent, placeholders, props);
             await decorateCategoryList($block, $parent, placeholders, props);
-            appendCategoryTemplatesCount($parent, props);
           }
         });
       }
@@ -1952,6 +1970,7 @@ function constructProps() {
       dimension: 'width',
       size: 151,
     },
+    loadedOtherCategoryCounts: false,
   };
 }
 

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -718,7 +718,6 @@ function decorateFunctionsContainer($block, $section, functions, placeholders, p
   }
 
   $mobileFilterButton.addEventListener('click', () => {
-    console.log('clicked');
     appendCategoryTemplatesCount($section, props);
   }, { once: true });
 

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -192,6 +192,7 @@ function constructProps(block) {
     backgroundColor: '#000B1D',
     backgroundAnimation: null,
     textColor: '#FFFFFF',
+    loadedOtherCategoryCounts: false,
   };
 
   Array.from(block.children).forEach((row) => {
@@ -592,6 +593,9 @@ function updateLottieStatus(block) {
 }
 
 async function appendCategoryTemplatesCount(block, props) {
+  if (props.loadedOtherCategoryCounts) {
+    return;
+  }
   const categories = block.querySelectorAll('ul.category-list > li');
   // FIXME: props already contain start: 70 at this time
   const tempProps = JSON.parse(JSON.stringify(props));
@@ -608,6 +612,7 @@ async function appendCategoryTemplatesCount(block, props) {
       anchor.append(countSpan);
     }
   }
+  props.loadedOtherCategoryCounts = true;
 }
 
 async function decorateCategoryList(block, props) {


### PR DESCRIPTION
Delay loading those numbers on the sidebar for different tasks until users interact with them.
You should see that on page landing, we only call the API once. When we hover on the left sidebar on Desktop or click Filter on Mobile, we start fetching and loading those numbers.
Not trying to improve LH performance. This is only to help the backend team save some money, as not every user will interact with the sidebar.

Resolves: https://jira.corp.adobe.com/browse/MWPW-138017 

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/templates/
- After: https://template-fetch-task-count-later--express--adobecom.hlx.live/express/templates/?lighthouse=on
