### PR TITLE
Replace getMeta with getMetadata

### DIFF
--- a/express/scripts/blog.js
+++ b/express/scripts/blog.js
@@ -14,7 +14,7 @@
 import {
   createTag,
   toClassName,
-  getMeta,
+  getMetaData,
   loadBlock,
   createOptimizedPicture,
   getLocale,
@@ -102,8 +102,8 @@ const loadImage = (img) => new Promise((resolve) => {
 export default async function decorateBlogPage() {
   const $main = document.querySelector('main');
   const $h1 = document.querySelector('main h1');
-  const author = getMeta('author');
-  const date = getMeta('publication-date');
+  const author = getMetaData('author');
+  const date = getMetaData('publication-date');
   if ($h1 && author && date) {
     const $heroPicture = $h1.parentElement.querySelector('picture');
     const heroSection = createTag('div', { class: 'hero' });
@@ -117,12 +117,12 @@ export default async function decorateBlogPage() {
     const $blogHeader = createTag('div', { class: 'blog-header' });
     $div.append($blogHeader);
     const $eyebrow = createTag('div', { class: 'eyebrow' });
-    const tagString = getMeta('article:tag');
+    const tagString = getMetaData('article:tag');
     // eslint-disable-next-line no-unused-vars
     const tags = tagString.split(',');
     const locale = getLocale(window.location);
     const urlPrefix = locale === 'us' ? '' : `/${locale}`;
-    $eyebrow.innerHTML = `<a href="${urlPrefix}/express/learn/blog/tags/${toClassName(getMeta('category'))}">${getMeta('category')}</a>`;
+    $eyebrow.innerHTML = `<a href="${urlPrefix}/express/learn/blog/tags/${toClassName(getMetaData('category'))}">${getMetaData('category')}</a>`;
     // $eyebrow.innerHTML = tags[0];
     $blogHeader.append($eyebrow);
     $blogHeader.append($h1);
@@ -135,7 +135,7 @@ export default async function decorateBlogPage() {
       timeZone: 'UTC',
     });
 
-    const subheading = getMeta('subheading');
+    const subheading = getMetaData('subheading');
     if (subheading) {
       const $subheading = createTag('p', { class: 'subheading' });
       $subheading.innerHTML = subheading;

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -233,19 +233,6 @@ export function createTag(tag, attributes, html) {
   return el;
 }
 
-export function getMeta(name) {
-  let value = '';
-  const nameLower = name.toLowerCase();
-  const $metas = [...document.querySelectorAll('meta')].filter(($m) => {
-    const nameAttr = $m.getAttribute('name');
-    const propertyAttr = $m.getAttribute('property');
-    return ((nameAttr && nameLower === nameAttr.toLowerCase())
-      || (propertyAttr && nameLower === propertyAttr.toLowerCase()));
-  });
-  if ($metas[0]) value = $metas[0].getAttribute('content');
-  return value;
-}
-
 // Get lottie animation HTML - remember to lazyLoadLottiePlayer() to see it.
 export function getLottie(name, src, loop = true, autoplay = true, control = false, hover = false) {
   return (`<lottie-player class="lottie lottie-${name}" src="${src}" background="transparent" speed="1" ${(loop) ? 'loop ' : ''}${(autoplay) ? 'autoplay ' : ''}${(control) ? 'controls ' : ''}${(hover) ? 'hover ' : ''}></lottie-player>`);
@@ -944,10 +931,10 @@ function decorateHeaderAndFooter() {
     }
   });
 
-  const headerMeta = getMeta('header');
+  const headerMeta = getMetadata('header');
   if (headerMeta !== 'off') header.innerHTML = '<div id="feds-header"></div>';
   else header.remove();
-  const footerMeta = getMeta('footer');
+  const footerMeta = getMetadata('footer');
   const footer = document.querySelector('footer');
   if (footerMeta !== 'off') {
     footer.innerHTML = `
@@ -1379,7 +1366,7 @@ export function decorateButtons(block = document) {
 // }
 
 export function checkTesting() {
-  return (getMeta('testing').toLowerCase() === 'on');
+  return (getMetadata('testing').toLowerCase() === 'on');
 }
 
 /**
@@ -1396,7 +1383,7 @@ export function toCamelCase(name) {
  * @returns {string} experimentid
  */
 export function getExperiment() {
-  let experiment = toClassName(getMeta('experiment'));
+  let experiment = toClassName(getMetadata('experiment'));
 
   if (!/adobe\.com/.test(window.location.hostname) && !/\.hlx\.live/.test(window.location.hostname)) {
     experiment = '';
@@ -1436,7 +1423,7 @@ export function getExperiment() {
  * @returns {object} containing the experiment manifest
  */
 export async function getExperimentConfig(experimentId) {
-  const instantExperiment = getMeta('instant-experiment');
+  const instantExperiment = getMetadata('instant-experiment');
   if (instantExperiment) {
     const config = {
       experimentName: `Instant Experiment: ${experimentId}`,
@@ -1952,7 +1939,7 @@ function splitSections($main) {
 }
 
 function setTheme() {
-  let theme = getMeta('theme');
+  let theme = getMetadata('theme');
   if (!theme && (window.location.pathname.startsWith('/express')
     || window.location.pathname.startsWith('/education')
     || window.location.pathname.startsWith('/drafts'))) {


### PR DESCRIPTION
We have 2 functions in utils.js that seem to do the same thing. getMeta is only used in blogs so I went ahead and deprecated it.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/
- After: https://standard-getmetadata--express--adobecom.hlx.page/express/?lighthouse=on
