### PR TITLE
Load template other task counts with controlled delay

### DIFF
--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -202,24 +202,33 @@ function fetchTemplatesByTasks(tasks, props) {
   return null;
 }
 
+async function fetchCntSpan(props, anchor, lang) {
+  const json = await fetchTemplatesByTasks(anchor.dataset.tasks, props);
+  const cntSpan = createTag('span', { class: 'category-list-template-count' });
+  cntSpan.textContent = `(${json?._embedded?.total?.toLocaleString(lang) ?? 0})`;
+  return { cntSpan, anchor };
+}
+
 async function appendCategoryTemplatesCount($section, props) {
   if (props.loadedOtherCategoryCounts) {
     return;
   }
+  props.loadedOtherCategoryCounts = true;
   const categories = $section.querySelectorAll('ul.category-list > li');
   const lang = getLanguage(getLocale(window.location));
 
-  for (const li of categories) {
-    const anchor = li.querySelector('a');
-    if (anchor) {
-      // eslint-disable-next-line no-await-in-loop
-      const json = await fetchTemplatesByTasks(anchor.dataset.tasks, props);
-      const countSpan = createTag('span', { class: 'category-list-template-count' });
-      countSpan.textContent = `(${json?._embedded?.total?.toLocaleString(lang) ?? 0})`;
-      anchor.append(countSpan);
-    }
+  const fetchCntSpanPromises = [...categories]
+    .map((li) => li.querySelector('a'))
+    .filter((a) => a?.dataset?.tasks)
+    .map((a) => fetchCntSpan(props, a, lang));
+  const res = await Promise.all(fetchCntSpanPromises);
+
+  // append one by one to gain attention
+  for (const { cntSpan, anchor } of res) {
+    anchor.append(cntSpan);
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((resolve) => setTimeout(resolve, 150));
   }
-  props.loadedOtherCategoryCounts = true;
 }
 
 async function processResponse(props) {

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -592,27 +592,33 @@ function updateLottieStatus(block) {
   }
 }
 
+async function fetchCntSpan(props, anchor, lang) {
+  const cntSpan = createTag('span', { class: 'category-list-template-count' });
+  const cnt = await fetchTemplatesCategoryCount(props, anchor.dataset.tasks);
+  cntSpan.textContent = `(${cnt.toLocaleString(lang)})`;
+  return { cntSpan, anchor };
+}
+
 async function appendCategoryTemplatesCount(block, props) {
   if (props.loadedOtherCategoryCounts) {
     return;
   }
+  props.loadedOtherCategoryCounts = true;
   const categories = block.querySelectorAll('ul.category-list > li');
-  // FIXME: props already contain start: 70 at this time
-  const tempProps = JSON.parse(JSON.stringify(props));
-  tempProps.limit = 0;
   const lang = getLanguage(getLocale(window.location));
 
-  for (const li of categories) {
-    const anchor = li.querySelector('a');
-    if (anchor) {
-      const countSpan = createTag('span', { class: 'category-list-template-count' });
-      // eslint-disable-next-line no-await-in-loop
-      const cnt = await fetchTemplatesCategoryCount(props, anchor.dataset.tasks);
-      countSpan.textContent = `(${cnt.toLocaleString(lang)})`;
-      anchor.append(countSpan);
-    }
+  const fetchCntSpanPromises = [...categories]
+    .map((li) => li.querySelector('a'))
+    .filter((a) => a?.dataset?.tasks)
+    .map((a) => fetchCntSpan(props, a, lang));
+  const res = await Promise.all(fetchCntSpanPromises);
+
+  // append one by one to gain attention
+  for (const { cntSpan, anchor } of res) {
+    anchor.append(cntSpan);
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((resolve) => setTimeout(resolve, 150));
   }
-  props.loadedOtherCategoryCounts = true;
 }
 
 async function decorateCategoryList(block, props) {


### PR DESCRIPTION
As of now, we load the template task counts in the sidebar one by one. Designers want a more controlled loading effect so that the loading of the number can also attract the attention of users. Compared to PROD, you should see in the sidebar those numbers getting loaded in a more controlled and consistent 150ms sequence.

Resolves: https://jira.corp.adobe.com/browse/MWPW-138096

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/templates/
- After: https://enhance-template-category-count-loading--express--adobecom.hlx.page/express/templates/?lighthouse=on
