### PR TITLE
Template LH back to 90+

### DIFF
--- a/express/scripts/content-replace.js
+++ b/express/scripts/content-replace.js
@@ -18,6 +18,12 @@ import {
 } from './utils.js';
 import HtmlSanitizer from './html-sanitizer.js';
 
+function yieldToMain() {
+  return new Promise((r) => {
+    setTimeout(r, 0);
+  });
+}
+
 async function replaceDefaultPlaceholders(block, components) {
   block.innerHTML = block.innerHTML.replaceAll('https://www.adobe.com/express/templates/default-create-link', components.link);
 
@@ -102,29 +108,33 @@ async function updateMetadataForTemplates() {
   }
 }
 
+const ignoredMeta = [
+  'serp-content-type',
+  'description',
+  'primaryproductname',
+  'theme',
+  'show-free-plan',
+  'sheet-powered',
+  'viewport',
+];
+
+async function sanitizeMeta(meta) {
+  if (meta.property || meta.name.includes(':') || ignoredMeta.includes(meta.name)) return;
+  await yieldToMain();
+  meta.content = HtmlSanitizer.SanitizeHtml(meta.content);
+}
+
 // metadata -> dom blades
-function autoUpdatePage(main) {
+async function autoUpdatePage(main) {
   const wl = ['{{heading_placeholder}}', '{{type}}', '{{quantity}}'];
   // FIXME: deprecate wl
   if (!main) return;
 
   const regex = /\{\{([a-zA-Z0-9_-]+)}}/g;
-  const ignoredMeta = [
-    'serp-content-type',
-    'description',
-    'primaryproductname',
-    'theme',
-    'show-free-plan',
-    'sheet-powered',
-    'viewport',
-  ];
 
   const metaTags = document.head.querySelectorAll('meta');
 
-  metaTags.forEach((meta) => {
-    if (meta.property || meta.name.includes(':') || ignoredMeta.includes(meta.name)) return;
-    meta.content = HtmlSanitizer.SanitizeHtml(meta.content);
-  });
+  await Promise.all(Array.from(metaTags).map((meta) => sanitizeMeta(meta)));
 
   main.innerHTML = main.innerHTML.replaceAll(regex, (match, p1) => {
     if (!wl.includes(match.toLowerCase())) {
@@ -207,7 +217,7 @@ export function setBlockTheme(block) {
 
 export default async function replaceContent(main) {
   await updateMetadataForTemplates();
-  autoUpdatePage(main);
+  await autoUpdatePage(main);
   await updateNonBladeContent(main);
   validatePage();
 }

--- a/express/scripts/content-replace.js
+++ b/express/scripts/content-replace.js
@@ -15,14 +15,9 @@ import {
   getHelixEnv,
   getMetadata,
   titleCase,
+  yieldToMain,
 } from './utils.js';
 import HtmlSanitizer from './html-sanitizer.js';
-
-function yieldToMain() {
-  return new Promise((r) => {
-    setTimeout(r, 0);
-  });
-}
 
 async function replaceDefaultPlaceholders(block, components) {
   block.innerHTML = block.innerHTML.replaceAll('https://www.adobe.com/express/templates/default-create-link', components.link);

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -14,7 +14,6 @@ import {
   sampleRUM,
   getDevice,
   removeIrrelevantSections,
-  yieldToMain,
   loadArea,
   stamp,
   registerPerformanceLogger,
@@ -55,7 +54,6 @@ const eagerLoad = (img) => {
 
 (async function loadPage() {
   if (window.hlx.init || window.isTestEnv) return;
-  await yieldToMain();
   await loadArea();
 }());
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -14,6 +14,7 @@ import {
   sampleRUM,
   getDevice,
   removeIrrelevantSections,
+  yieldToMain,
   loadArea,
   stamp,
   registerPerformanceLogger,
@@ -39,7 +40,7 @@ const eagerLoad = (img) => {
   img?.setAttribute('fetchpriority', 'high');
 };
 
-(async function loadLCPImage() {
+(function loadLCPImage() {
   const body = document.querySelector('body');
   body.dataset.device = getDevice();
   const main = body.querySelector('main');
@@ -53,9 +54,9 @@ const eagerLoad = (img) => {
 }());
 
 (async function loadPage() {
-  if (!window.hlx.init && !window.isTestEnv) {
-    await loadArea();
-  }
+  if (window.hlx.init || window.isTestEnv) return;
+  await yieldToMain();
+  await loadArea();
 }());
 
 stamp('start');

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -12,6 +12,8 @@
 
 import {
   sampleRUM,
+  getDevice,
+  removeIrrelevantSections,
   loadArea,
   stamp,
   registerPerformanceLogger,
@@ -38,7 +40,11 @@ const eagerLoad = (img) => {
 };
 
 (async function loadLCPImage() {
-  const firstDiv = document.querySelector('body > main > div:nth-child(1) > div');
+  const body = document.querySelector('body');
+  body.dataset.device = getDevice();
+  const main = body.querySelector('main');
+  removeIrrelevantSections(main);
+  const firstDiv = main.querySelector('div:nth-child(1) > div');
   if (firstDiv?.classList.contains('marquee')) {
     firstDiv.querySelectorAll('img').forEach(eagerLoad);
   } else {

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -511,6 +511,12 @@ export function getMetadata(name) {
   return ($meta && $meta.content) || '';
 }
 
+export function yieldToMain() {
+  return new Promise((r) => {
+    setTimeout(r, 0);
+  });
+}
+
 export function removeIrrelevantSections(main) {
   if (!main) return;
   main.querySelectorAll(':scope > div').forEach((section) => {

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2149,7 +2149,9 @@ export async function decorateMain(main) {
   decorateButtons(main);
   decorateMarqueeColumns(main);
   await fixIcons(main);
+  await yieldToMain();
   decoratePictures(main);
+  await yieldToMain();
   decorateLinkedPictures(main);
   decorateSocialIcons(main);
 

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2149,9 +2149,7 @@ export async function decorateMain(main) {
   decorateButtons(main);
   decorateMarqueeColumns(main);
   await fixIcons(main);
-  await yieldToMain();
   decoratePictures(main);
-  await yieldToMain();
   decorateLinkedPictures(main);
   decorateSocialIcons(main);
 

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -512,6 +512,7 @@ export function getMetadata(name) {
 }
 
 export function removeIrrelevantSections(main) {
+  if (!main) return;
   main.querySelectorAll(':scope > div').forEach((section) => {
     const sectionMetaBlock = section.querySelector('div.section-metadata');
     if (sectionMetaBlock) {
@@ -1923,6 +1924,10 @@ function splitSections($main) {
   });
 }
 
+export function getDevice() {
+  return navigator.userAgent.includes('Mobile') ? 'mobile' : 'desktop';
+}
+
 function setTheme() {
   let theme = getMetadata('theme');
   if (!theme && (window.location.pathname.startsWith('/express')
@@ -1942,7 +1947,6 @@ function setTheme() {
       blog = true;
     }
   }
-  body.dataset.device = navigator.userAgent.includes('Mobile') ? 'mobile' : 'desktop';
 }
 
 function decorateLinkedPictures($main) {
@@ -2415,8 +2419,6 @@ export async function loadArea(area = document) {
     langSplits.pop();
     const htmlLang = langSplits.join('-');
     document.documentElement.setAttribute('lang', htmlLang);
-
-    removeIrrelevantSections(main);
   }
   if (window.hlx.testing) await decorateTesting();
 


### PR DESCRIPTION
I noticed that template pages have fallen below 90 recently. This is to bring it back to 90+.
**Problems:**
1. htmlSanitizer takes too many cpu cycles
2. First LCP becomes desktop-only search-marquee again, because our loadLCPImage() is called before removeIrrelevantSections()

**Solutions:**

1. Broke down content-replace and html-sanitize long tasks to reduce TBT.
2. Remove Irrelevant Sections before loadLCPImage()

Now we're back to consistently 90+ again!

Note that the last 2 commits are for reducing TBT on mega pages (like homepage) (https://pagespeed.web.dev/analysis/https-stage--express--adobecom-hlx-page-express/2ovw7w6yz0?form_factor=mobile to https://pagespeed.web.dev/analysis/https-template-perf--express--adobecom-hlx-page-express/021bg34h60?form_factor=mobile). Since our DOM for homepage is so large, there are 2 sources of TBT:

1. removeIrrelevantSections actually causes TBT in homepage since we have like 50 sections
2. Functions in decorateMain like decoratePictures and Icons are blocking now, since we have so many images

Resolves: https://jira.corp.adobe.com/browse/MWPW-138184

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/templates/
- After: https://template-perf--express--adobecom.hlx.page/express/templates/?lighthouse=on
