### PR TITLE
Smoother Template Cnt Loading

### DIFF
--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -218,9 +218,7 @@ async function appendCategoryTemplatesCount($section, props) {
   const lang = getLanguage(getLocale(window.location));
 
   const fetchCntSpanPromises = [...categories]
-    .map((li) => li.querySelector('a'))
-    .filter((a) => a?.dataset?.tasks)
-    .map((a) => fetchCntSpan(props, a, lang));
+    .map((li) => fetchCntSpan(props, li.querySelector('a'), lang));
   const res = await Promise.all(fetchCntSpanPromises);
 
   // append one by one to gain attention

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -227,7 +227,7 @@ async function appendCategoryTemplatesCount($section, props) {
   for (const { cntSpan, anchor } of res) {
     anchor.append(cntSpan);
     // eslint-disable-next-line no-await-in-loop
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await new Promise((resolve) => setTimeout(resolve, 25));
   }
 }
 

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -617,7 +617,7 @@ async function appendCategoryTemplatesCount(block, props) {
   for (const { cntSpan, anchor } of res) {
     anchor.append(cntSpan);
     // eslint-disable-next-line no-await-in-loop
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await new Promise((resolve) => setTimeout(resolve, 25));
   }
 }
 

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -608,9 +608,7 @@ async function appendCategoryTemplatesCount(block, props) {
   const lang = getLanguage(getLocale(window.location));
 
   const fetchCntSpanPromises = [...categories]
-    .map((li) => li.querySelector('a'))
-    .filter((a) => a?.dataset?.tasks)
-    .map((a) => fetchCntSpan(props, a, lang));
+    .map((li) => fetchCntSpan(props, li.querySelector('a'), lang));
   const res = await Promise.all(fetchCntSpanPromises);
 
   // append one by one to gain attention


### PR DESCRIPTION
Designers want to reduce the delay for the loading effect so that the loading of the number seems smoother and can better attract the attention of users. 

Resolves: https://jira.corp.adobe.com/browse/MWPW-138096

Test URLs:

Before: https://stage--express--adobecom.hlx.page/express/templates/
After: https://template-cnt-loading--express--adobecom.hlx.page/express/templates/?lighthouse=on