### PR TITLE
Colors page CKG Pills: Don't render search pill + QA changes

### DIFF
--- a/express/blocks/ckg-link-list/ckg-link-list.js
+++ b/express/blocks/ckg-link-list/ckg-link-list.js
@@ -56,6 +56,8 @@ export default async function decorate(block) {
     }
   });
 
+  if (!block.children) return;
+
   await buildCarousel('.button-container', block);
   block.style.visibility = 'visible';
 }

--- a/express/blocks/ckg-link-list/ckg-link-list.js
+++ b/express/blocks/ckg-link-list/ckg-link-list.js
@@ -28,6 +28,10 @@ export default async function decorate(block) {
   if (!pills || !pills.length) return;
 
   pills.forEach((pill) => {
+    if (pill.value.startsWith('/express/colors/search')) {
+      return;
+    }
+
     const colorPath = pill.value;
     const colorName = pill.displayValue;
     const buttonContainer = createTag('p', { class: 'button-container' });

--- a/express/blocks/color-how-to-carousel/color-how-to-carousel.css
+++ b/express/blocks/color-how-to-carousel/color-how-to-carousel.css
@@ -184,6 +184,11 @@
     color: var(--color-black);
 }
 
+.color-how-to-carousel.shadow .img-wrapper,
+.color-how-to-carousel.shadow .content-wrapper {
+    box-shadow: 0 3px 6px #00000029;
+}
+
 @media (min-width: 900px) {
     .color-how-to-carousel {
         gap: unset;

--- a/express/blocks/color-how-to-carousel/color-how-to-carousel.css
+++ b/express/blocks/color-how-to-carousel/color-how-to-carousel.css
@@ -36,7 +36,7 @@
 }
 
 .color-how-to-carousel > .content-wrapper > h2 {
-    font-size: var(--heading-font-size-xl);
+    font-size: var(--heading-font-size-l);
     text-align: left;
     margin-top: 0;
 }
@@ -214,8 +214,7 @@
     }
 
     .color-how-to-carousel .tips .tip {
-        margin-top: 64px;
-        margin-bottom: 80px;
+        margin: 64px 0;
     }
 
     .color-how-to-carousel {

--- a/express/blocks/color-how-to-carousel/color-how-to-carousel.js
+++ b/express/blocks/color-how-to-carousel/color-how-to-carousel.js
@@ -163,10 +163,11 @@ function colorizeSVG(block, payload) {
     });
 
   if (!(block.classList.contains('dark') || block.classList.contains('light'))) {
-    if (!isDarkOverlayReadable(payload.primaryHex)) {
-      block.classList.add('dark');
-    } else {
+    if (isDarkOverlayReadable(payload.primaryHex)) {
       block.classList.add('light');
+      block.classList.add('shadow');
+    } else {
+      block.classList.add('dark');
     }
   }
 }

--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -570,7 +570,7 @@ main .columns.color p {
 }
 
 main .columns.color h2 {
-  font-size: 36px;
+  font-size: var(--heading-font-size-l);
 }
 
 main .collapsible-card-wrapper + .columns-wrapper .columns > div {
@@ -756,10 +756,6 @@ main .columns.fullsize.top .column .columns-iconlist .columns-iconlist-descripti
     width: 418px;
   }
 
-  main .columns.color h2 {
-    font-size: 45px;
-  }
-
   main .columns.color h2, main .columns.color p {
     text-align: left;
   }
@@ -823,7 +819,7 @@ main .columns.fullsize.top .column .columns-iconlist .columns-iconlist-descripti
     margin: 0;
   }
 
-  main .columns.width-2-columns .column-picture, 
+  main .columns.width-2-columns .column-picture,
   main .columns.width-2-columns .hero-animation-overlay,
   main .columns.highlight.width-2-columns .column-picture  {
     order: 0;

--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -563,6 +563,10 @@ main .columns.color .column.text {
   max-width: 345px;
 }
 
+main .columns.color.shadow .img-wrapper {
+  box-shadow: 0 3px 6px #00000029;
+}
+
 main .columns.color h2,
 main .columns.color p {
   hyphens: manual;

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -357,6 +357,12 @@ export default async function decorate(block) {
     svg.style.backgroundColor = primaryColor;
     svg.style.fill = accentColor;
     rows[0].append(svg);
+
+    const { default: isDarkOverlayReadable } = await import('../../scripts/color-tools.js');
+
+    if (isDarkOverlayReadable(primaryColor)) {
+      block.classList.add('shadow');
+    }
   }
 
   const phoneNumberTags = block.querySelectorAll('a[title="{{business-sales-numbers}}"]');

--- a/express/blocks/hero-color/hero-color.css
+++ b/express/blocks/hero-color/hero-color.css
@@ -118,7 +118,7 @@ main .hero-color .hidden-svg {
   }
 
   main .hero-color .text-container > div {
-    max-width: 600px;
+    max-width: 50%;
   }
 
   main .hero-color.dark .button,

--- a/express/blocks/hero-color/hero-color.css
+++ b/express/blocks/hero-color/hero-color.css
@@ -118,7 +118,7 @@ main .hero-color .hidden-svg {
   }
 
   main .hero-color .text-container > div {
-    max-width: 50%;
+    max-width: calc(50% - 24px);
   }
 
   main .hero-color.dark .button,

--- a/express/blocks/hero-color/hero-color.css
+++ b/express/blocks/hero-color/hero-color.css
@@ -35,13 +35,13 @@ main .hero-color .text-container {
 
 main .hero-color .text-container h1 {
   margin: 0 0 16px;
-  font-size: var(--heading-font-size-xl);
+  font-size: var(--heading-font-size-l);
   text-align: left;
 }
 
 main .hero-color .text-container h2 {
   margin: 0;
-  font-size: var(--heading-font-size-l);
+  font-size: var(--heading-font-size-m);
   text-align: left;
 }
 

--- a/express/blocks/long-text/long-text.css
+++ b/express/blocks/long-text/long-text.css
@@ -75,7 +75,7 @@ main .long-text.plain p {
     }
 
     main .long-text.plain h3 {
-        font-size: var(--heading-font-size-m);
+        font-size: var(--heading-font-size-s);
         margin-bottom: 16px;
     }
 }

--- a/express/scripts/browse-api-controller.js
+++ b/express/scripts/browse-api-controller.js
@@ -26,7 +26,8 @@ const endpoints = {
     key: window.atob('ZXhwcmVzcy1ja2ctc3RhZ2U='),
   },
   stage: {
-    cdn: 'https://www.stage.adobe.com/ax-uss-api/',
+    // cdn: 'https://www.stage.adobe.com/ax-uss-api/',
+    cdn: 'https://uss-templates-stage.adobe.io/uss/v3/query',
     url: 'https://uss-templates-stage.adobe.io/uss/v3/query',
     token: window.atob('ZGI3YTNkMTQtNWFhYS00YTNkLTk5YzMtNTJhMGYwZGJiNDU5'),
     key: window.atob('ZXhwcmVzcy1ja2ctc3RhZ2U='),

--- a/express/scripts/browse-api-controller.js
+++ b/express/scripts/browse-api-controller.js
@@ -24,6 +24,12 @@ const endpoints = {
     token: window.atob('Y2QxODIzZWQtMDEwNC00OTJmLWJhOTEtMjVmNDE5NWQ1ZjZj'),
     key: window.atob('ZXhwcmVzcy1ja2ctc3RhZ2U='),
   },
+  stage: {
+    cdn: 'https://www.stage.adobe.com/ax-uss-api/',
+    url: 'https://uss-templates-stage.adobe.io/uss/v3/query',
+    token: window.atob('ZGI3YTNkMTQtNWFhYS00YTNkLTk5YzMtNTJhMGYwZGJiNDU5'),
+    key: window.atob('ZXhwcmVzcy1ja2ctc3RhZ2U='),
+  },
   prod: {
     cdn: 'https://www.adobe.com/ax-uss-api/',
     url: 'https://uss-templates.adobe.io/uss/v3/query',

--- a/express/scripts/browse-api-controller.js
+++ b/express/scripts/browse-api-controller.js
@@ -11,6 +11,7 @@
  */
 
 import {
+  getHelixEnv,
   getLanguage,
   getLocale,
   getMetadata,
@@ -88,8 +89,9 @@ export async function getDataWithContext({ urlPath }) {
       facets: [{ facet: 'categories', limit: 10 }],
     }],
   };
-  const env = window.location.host === 'localhost:3000' ? 'dev' : 'prod';
-  const result = await getData(env, data);
+
+  const env = window.location.host === 'localhost:3000' ? { name: 'dev' } : getHelixEnv();
+  const result = await getData(env.name, data);
   if (result?.status?.httpCode !== 200) return null;
 
   return result;
@@ -128,9 +130,8 @@ export async function getDataWithId() {
     ],
   };
 
-  const env = window.location.host === 'localhost:3000' ? 'dev' : 'prod';
-  const result = await getData(env, dataRaw);
-
+  const env = window.location.host === 'localhost:3000' ? { name: 'dev' } : getHelixEnv();
+  const result = await getData(env.name, dataRaw);
   if (result.status.httpCode !== 200) return null;
 
   return result;

--- a/express/scripts/browse-api-controller.js
+++ b/express/scripts/browse-api-controller.js
@@ -26,8 +26,7 @@ const endpoints = {
     key: window.atob('ZXhwcmVzcy1ja2ctc3RhZ2U='),
   },
   stage: {
-    // cdn: 'https://www.stage.adobe.com/ax-uss-api/',
-    cdn: 'https://uss-templates-stage.adobe.io/uss/v3/query',
+    cdn: 'https://www.stage.adobe.com/ax-uss-api/',
     url: 'https://uss-templates-stage.adobe.io/uss/v3/query',
     token: window.atob('ZGI3YTNkMTQtNWFhYS00YTNkLTk5YzMtNTJhMGYwZGJiNDU5'),
     key: window.atob('ZXhwcmVzcy1ja2ctc3RhZ2U='),
@@ -64,7 +63,13 @@ export async function getPillWordsMapping() {
 
 export default async function getData(env = 'dev', data = {}) {
   const endpoint = endpoints[env];
-  return mFetch(endpoint.cdn, {
+  let targetURl = endpoint.url;
+
+  if (['www.adobe.com', 'www.stage.adobe.com'].includes(window.location.hostname)) {
+    targetURl = endpoint.cdn;
+  }
+
+  return mFetch(targetURl, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/vnd.adobe.search-request+json',

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -850,7 +850,7 @@ export function getHelixEnv() {
   let envName = sessionStorage.getItem('helix-env');
   if (!envName) {
     envName = 'stage';
-    if (window.spark.hostname === 'www.adobe.com') envName = 'prod';
+    if (window.spark?.hostname === 'www.adobe.com') envName = 'prod';
   }
   const envs = {
     stage: {


### PR DESCRIPTION
The CKG API returns search link pills for Color pages too, but we don't have search pages. CKG-Link-List block will stop the search pills rendering from the block side.

Also I revived the stage browse API instance in the PR. We'll also be only using endpoint.cdn on the 2 adobe.com domains to avoid CORS in testing. The request to revive stage endpoint came from the browse API team as they need to do E2E testing on stage using our branch links.

Along the PR there are some small QA changes:
- font size change
- spacing fixes
- light color drop shadow

Resolves: [MWPW-130181](https://jira.corp.adobe.com/browse/MWPW-130181)

**Timeline: They are hoping to launch the feature blocked by this PR next Tuesday**

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/colors/blue?martech=off
- After: https://ckg-test--express--adobecom.hlx.page/express/colors/blue?martech=off
