### PR TITLE
Added carousel overflow fader effect

### DIFF
--- a/express/blocks/shared/carousel.css
+++ b/express/blocks/shared/carousel.css
@@ -134,15 +134,25 @@ main .carousel-container.controls-hidden .carousel-platform {
     margin: 0 10px;
   }
 
-  main .carousel-container .carousel-fader-left {
-    background: linear-gradient(to left, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
-  }
-
-  main .carousel-container .carousel-fader-right {
-    background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
-  }
-
   main .carousel-container.controls-hidden .carousel-platform {
     scroll-snap-type: x mandatory;
-  }
+  }  
+ 
 }
+
+:root {
+  --fader-gradient-width: 60px;
+}
+div.left-fader:not(.right-fader){
+  -webkit-mask-image: linear-gradient(to right, transparent, rgba(0,0,0,1) var(--fader-gradient-width), rgba(0,0,0,1) calc(100% - var(--fader-gradient-width)));
+  mask-image: linear-gradient(to right, transparent, rgba(0,0,0,1) var(--fader-gradient-width), rgba(0,0,0,1) calc(100% - var(--fader-gradient-width)));
+}
+div.right-fader:not(.left-fade){
+  -webkit-mask-image: linear-gradient(to right, rgba(0,0,0,1) var(--fader-gradient-width), rgba(0,0,0,1) calc(100% - var(--fader-gradient-width)), transparent);
+  mask-image: linear-gradient(to right, rgba(0,0,0,1) var(--fader-gradient-width), rgba(0,0,0,1) calc(100% - var(--fader-gradient-width)), transparent);
+}
+div.left-fader.right-fader{
+  -webkit-mask-image: linear-gradient(to right, transparent, rgba(0,0,0,1) var(--fader-gradient-width), rgba(0,0,0,1) calc(100% - var(--fader-gradient-width)), transparent);
+  mask-image: linear-gradient(to right, transparent, rgba(0,0,0,1) var(--fader-gradient-width), rgba(0,0,0,1) calc(100% - var(--fader-gradient-width)), transparent);
+}
+

--- a/express/blocks/shared/carousel.js
+++ b/express/blocks/shared/carousel.js
@@ -16,29 +16,6 @@ import {
 // eslint-disable-next-line import/no-unresolved
 } from '../../scripts/utils.js';
 
-function adjustFaderGradient(parent, faders) {
-  const parentSection = parent.closest('.section');
-  let inGradient;
-  let outGradient;
-
-  // fixme: early exit on negative condition
-  if (parentSection?.style?.background) {
-    if (parentSection.style.background.startsWith('rgb')) {
-      inGradient = parentSection.style.background.replace(')', ', 1)');
-      outGradient = parentSection.style.background.replace(')', ', 0)');
-    } else {
-      // todo: see if we can find a way to accommodate gradient background
-      faders.right.style.background = 'none';
-      faders.left.style.background = 'none';
-      return;
-    }
-  }
-
-  // fixme: these shouldn't run if the section doesn't have background set
-  faders.right.style.background = `linear-gradient(to right, ${outGradient}, ${inGradient})`;
-  faders.left.style.background = `linear-gradient(to left, ${outGradient}, ${inGradient})`;
-}
-
 // Wait for all media to load
 function waitForMediaToLoad(parent) {
   const medias = [...parent.querySelectorAll('img, video')];
@@ -94,14 +71,19 @@ export default async function buildCarousel(selector = ':scope > *', parent, opt
   };
   const toggleControls = () => {
     if (platform.classList.contains('infinity-scroll-loaded')) {
+      platform.classList.add('left-fader', 'right-fader');
       faderRight.classList.remove('arrow-hidden');
       faderLeft.classList.remove('arrow-hidden');
     } else {
       const platformScrollLeft = platform.scrollLeft;
       const left = (platformScrollLeft > 33);
       toggleArrow(faderLeft, left);
+      if(left) platform.classList.add('left-fader');
+      else platform.classList.remove('left-fader');
       const right = !(platform.offsetWidth + platformScrollLeft >= (platform.scrollWidth - 31));
       toggleArrow(faderRight, right);
+      if(right) platform.classList.add('right-fader');
+      else platform.classList.remove('right-fader');
     }
     if (hideControls) {
       $container.classList.add('controls-hidden');
@@ -251,7 +233,6 @@ export default async function buildCarousel(selector = ':scope > *', parent, opt
     lastPos = null;
   }, { passive: true });
 
-  adjustFaderGradient(parent, { left: faderLeft, right: faderRight });
   await Promise.all([css, media]);
 
   if (options.startPosition) {


### PR DESCRIPTION
Added the overflow fader effect to the carousel using mask-image

Implemented a fader effect to the edges of carousel.js using css mask-image to allow for overflowing content to fade out seamlessly over any background (gradient, images, etc.). 

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/?martech=off
- After: https://carousel-fader-effect--express--wbstry.hlx.page/express/?martech=off
