### PR TITLE
[Branch Links] Remove retired search term and update q and searchCategory

### DIFF
--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -76,10 +76,9 @@ async function trackBranchParameters($links) {
 
       if (templateSearchTag
         && placeholders['search-branch-links']?.replace(/\s/g, '').split(',').includes(`${btnUrl.origin}${btnUrl.pathname}`)) {
-        urlParams.set('search', templateSearchTag);
-        urlParams.set('q', templateSearchTag);
+        urlParams.set('q', 'templates');
         urlParams.set('category', 'templates');
-        urlParams.set('searchCategory', 'templates');
+        urlParams.set('searchCategory', templateSearchTag);
       }
 
       if (referrer) {


### PR DESCRIPTION
Updating the URL Param to prevent feature breakage when the branch side updates. Needs to coordinate this merge.

Resolves: [MWPW-138618](https://jira.corp.adobe.com/browse/MWPW-138618)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/create/flyer?martech=off
- After: https://branch-param-update--express--adobecom.hlx.page/express/create/flyer?martech=off
