### PR TITLE
[MWPW-137709-3] Author Control Over Link Target Location

### DIFF
--- a/express/features/links.js
+++ b/express/features/links.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+let fetched = false;
+let linkData = null;
+
+const getLinks = async (path) => {
+  if (!path) return null;
+  if (!fetched) {
+    const resp = await fetch(path);
+    if (resp.ok) {
+      const json = await resp.json();
+      linkData = json.data;
+    }
+    fetched = true;
+}
+  return linkData;
+};
+
+export default async function init(path, area = document) {
+  const data = await getLinks(path);
+  if (!data) return;
+  const links = area.querySelectorAll('a:not([href^="/"])');
+  [...links].forEach((link) => {
+    data.filter((s) => link.href.startsWith(s.domain))
+      .forEach((s) => {
+        if (s.rel) link.setAttribute('rel', s.rel);
+        if (s.window) link.setAttribute('target', s.window);
+      });
+  });
+}

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -662,27 +662,16 @@ function decorateLinks(main) {
       }
 
       const isContactLink = ['tel:', 'mailto:', 'sms:'].includes(url.protocol);
-      const isAdobeOwnedLinks = [
-        'adobesparkpost.app.link',
-        'new.express.adobe.com',
-        'express.adobe.com',
-        'www.adobe.com',
-        'www.stage.adobe.com',
-        'commerce.adobe.com',
-        'commerce-stg.adobe.com',
-        'helpx.adobe.com',
-      ].includes(url.hostname);
 
       if (!isContactLink) {
         // make url relative if needed
         const relative = url.hostname === window.location.hostname;
         const urlPath = `${url.pathname}${url.search}${url.hash}`;
         a.href = relative ? urlPath : `${url.origin}${urlPath}`;
-
-        if (!relative && !isAdobeOwnedLinks) {
-          // open external links in a new tab
-          a.target = '_blank';
-        }
+      }
+      if (a.href.includes('#_blank')) {
+        a.setAttribute('target', '_blank');
+        a.href = a.href.replace('#_blank', '');
       }
       if (a.href.includes('#_dnb')) {
         a.href = a.href.replace('#_dnb', '');
@@ -2478,6 +2467,8 @@ export async function loadArea(area = document) {
     import('../../tools/preview/preview.js');
   }
   await lazy;
+  const linkExclusionPath = '/express/seo/links.json';
+  import('../features/links.js').then((mod) => mod.default(linkExclusionPath, area));
   const { default: delayed } = await import('./delayed.js');
   delayed([createTag, getDevice], 8000);
 }


### PR DESCRIPTION
Replaces this [PR](https://github.com/adobecom/express/pull/361). This PR fully adopts milo's method of handling how links are opened

**Testing:** In the second section, each of the CTAs should act as expected. 

- All links open in the same tab by default
To override this behaviour
- For a relative link, '#_blank' is appended to the end of the href
- For an absolute link, the domain is added to this [spreadsheet](https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7BBA743C26-8AF3-4208-B869-3CB10FA2DBB5%7D&file=links.xlsx&action=default&mobileredirect=true), which will apply to the domain across the entire AX site.

Resolves: [MWPW-137709](https://jira.corp.adobe.com/browse/MWPW-137709)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/drafts/casey/link-handling?martech=off
- After: https://mwpw-137709--express--adobecom.hlx.page/drafts/casey/link-handling?martech=off
