### PR TITLE
Deprecate getAudiences/Identity/Segments

### DIFF
--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/* global _satellite __satelliteLoadedCallback alloy */
+/* global _satellite */
 
 import {
   loadScript,
@@ -989,88 +989,10 @@ const martechLoadedCB = () => {
   decorateAnalyticsEvents();
   initHemingway();
 
-  const ENABLE_PRICING_MODAL_AUDIENCE = 'enablePricingModal';
-  const RETURNING_VISITOR_SEGMENT_ID = 23153796;
-
-  const QUICK_ACTION_SEGMENTS = [
-    [24241150, 'enableRemoveBackgroundRating'],
-    [24793469, 'enableConvertToGifRating'],
-    [24793470, 'enableConvertToJpgRating'],
-    [24793471, 'enableConvertToMp4Rating'],
-    [24793472, 'enableConvertToPngRating'],
-    [24793473, 'enableConvertToSvgRating'],
-    [24793474, 'enableCropImageRating'],
-    [24793475, 'enableCropVideoRating'],
-    [24793476, 'enableLogoMakerRating'],
-    [24793477, 'enableMergeVideoRating'],
-    [24793478, 'enableQrGeneratorRating'],
-    [24793479, 'enableResizeImageRating'],
-    [24793480, 'enableChangeSpeedRating'],
-    [24793481, 'enableTrimVideoRating'],
-    [24793483, 'enableResizeVideoRating'],
-    [24793488, 'enableReverseVideoRating'],
-  ];
-
+  // TODO: remove after deprecating blocks that still rely on it (pricing-modal)
   BlockMediator.set('audiences', []);
+  // TODO: remove after refactoring blocks that still rely on it (rating)
   BlockMediator.set('segments', []);
-
-  function getAudiences() {
-    const getSegments = (ecid) => {
-      if (ecid) {
-        w.setAudienceManagerSegments = (json) => {
-          if (json && json.segments && json.segments.includes(RETURNING_VISITOR_SEGMENT_ID)) {
-            const audiences = BlockMediator.get('audiences');
-            const segments = BlockMediator.get('segments');
-            audiences.push(ENABLE_PRICING_MODAL_AUDIENCE);
-            segments.push(RETURNING_VISITOR_SEGMENT_ID);
-
-            _satellite.track('event', {
-              xdm: {},
-              data: {
-                eventType: 'web.webinteraction.linkClicks',
-                web: {
-                  webInteraction: {
-                    name: 'pricingModalUserInSegment',
-                    linkClicks: {
-                      value: 1,
-                    },
-                    type: 'other',
-                  },
-                },
-                _adobe_corpnew: {
-                  digitalData: {
-                    primaryEvent: {
-                      eventInfo: {
-                        eventName: 'pricingModalUserInSegment',
-                      },
-                    },
-                  },
-                },
-              },
-            });
-          }
-
-          QUICK_ACTION_SEGMENTS.forEach((QUICK_ACTION_SEGMENT) => {
-            if (json && json.segments && json.segments.includes(QUICK_ACTION_SEGMENT[0])) {
-              const audiences = BlockMediator.get('audiences');
-              const segments = BlockMediator.get('segments');
-              audiences.push(QUICK_ACTION_SEGMENT[1]);
-              segments.push(QUICK_ACTION_SEGMENT[0]);
-            }
-          });
-
-          document.dispatchEvent(new Event('context_loaded'));
-        };
-        // TODO: What the heck is this?  This needs to be behind one trust and cmp
-        loadScript(`https://adobe.demdex.net/event?d_dst=1&d_rtbd=json&d_cb=setAudienceManagerSegments&d_cts=2&d_mid=${ecid}`);
-      }
-    };
-
-    alloy('getIdentity')
-      .then((data) => getSegments(data && data.identity ? data.identity.ECID : null));
-  }
-
-  __satelliteLoadedCallback(getAudiences);
 };
 
 loadScript(martechURL).then(martechLoadedCB);

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -186,7 +186,6 @@ w.marketingtech = {
       ),
     },
     target: checkTesting(),
-    audienceManager: true,
   },
 };
 // w.targetGlobalSettings = w.targetGlobalSettings || {};


### PR DESCRIPTION
After a recent Martech performance refactoring, alloy has been configured by martech later, so our manual call of alloy('getIdentity') has been failing, throwing an error saying that alloy is used before getting configured.
We are still confirming with analysts that whether we can retire audiences/identity/segments, but since it is failing anyway, we can remove the code to avoid that console error.
If it is confirmed that we want to keep them, we will adapt our code and bring it back in a separate PR.

You should see no [alloy] console error compared to every page on production now.

Resolves: https://jira.corp.adobe.com/browse/MWPW-138693

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/
- After: https://deprecate-getidentity-segments--express--adobecom.hlx.page/express/templates/flyer?martech=off
