### PR TITLE
Bring Ratings back (#421)

### DIFF
--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/* global _satellite */
+/* global _satellite __satelliteLoadedCallback alloy */
 
 import {
   loadScript,
@@ -186,6 +186,7 @@ w.marketingtech = {
       ),
     },
     target: checkTesting(),
+    audienceManager: true,
   },
 };
 // w.targetGlobalSettings = w.targetGlobalSettings || {};
@@ -988,10 +989,89 @@ const martechLoadedCB = () => {
   decorateAnalyticsEvents();
   initHemingway();
 
-  // TODO: remove after deprecating blocks that still rely on it (pricing-modal)
+  const ENABLE_PRICING_MODAL_AUDIENCE = 'enablePricingModal';
+  const RETURNING_VISITOR_SEGMENT_ID = 23153796;
+
+  const QUICK_ACTION_SEGMENTS = [
+    [24241150, 'enableRemoveBackgroundRating'],
+    [24793469, 'enableConvertToGifRating'],
+    [24793470, 'enableConvertToJpgRating'],
+    [24793471, 'enableConvertToMp4Rating'],
+    [24793472, 'enableConvertToPngRating'],
+    [24793473, 'enableConvertToSvgRating'],
+    [24793474, 'enableCropImageRating'],
+    [24793475, 'enableCropVideoRating'],
+    [24793476, 'enableLogoMakerRating'],
+    [24793477, 'enableMergeVideoRating'],
+    [24793478, 'enableQrGeneratorRating'],
+    [24793479, 'enableResizeImageRating'],
+    [24793480, 'enableChangeSpeedRating'],
+    [24793481, 'enableTrimVideoRating'],
+    [24793483, 'enableResizeVideoRating'],
+    [24793488, 'enableReverseVideoRating'],
+  ];
+
   BlockMediator.set('audiences', []);
-  // TODO: remove after refactoring blocks that still rely on it (rating)
   BlockMediator.set('segments', []);
+
+  async function getAudiences() {
+    const getSegments = (ecid) => {
+      if (ecid) {
+        w.setAudienceManagerSegments = (json) => {
+          if (json && json.segments && json.segments.includes(RETURNING_VISITOR_SEGMENT_ID)) {
+            const audiences = BlockMediator.get('audiences');
+            const segments = BlockMediator.get('segments');
+            audiences.push(ENABLE_PRICING_MODAL_AUDIENCE);
+            segments.push(RETURNING_VISITOR_SEGMENT_ID);
+
+            _satellite.track('event', {
+              xdm: {},
+              data: {
+                eventType: 'web.webinteraction.linkClicks',
+                web: {
+                  webInteraction: {
+                    name: 'pricingModalUserInSegment',
+                    linkClicks: {
+                      value: 1,
+                    },
+                    type: 'other',
+                  },
+                },
+                _adobe_corpnew: {
+                  digitalData: {
+                    primaryEvent: {
+                      eventInfo: {
+                        eventName: 'pricingModalUserInSegment',
+                      },
+                    },
+                  },
+                },
+              },
+            });
+          }
+
+          QUICK_ACTION_SEGMENTS.forEach((QUICK_ACTION_SEGMENT) => {
+            if (json && json.segments && json.segments.includes(QUICK_ACTION_SEGMENT[0])) {
+              const audiences = BlockMediator.get('audiences');
+              const segments = BlockMediator.get('segments');
+              audiences.push(QUICK_ACTION_SEGMENT[1]);
+              segments.push(QUICK_ACTION_SEGMENT[0]);
+            }
+          });
+
+          document.dispatchEvent(new Event('context_loaded'));
+        };
+        // TODO: What the heck is this?  This needs to be behind one trust and cmp
+        loadScript(`https://adobe.demdex.net/event?d_dst=1&d_rtbd=json&d_cb=setAudienceManagerSegments&d_cts=2&d_mid=${ecid}`);
+      }
+    };
+
+    await _satellite.alloyConfigurePromise;
+    const data = await alloy('getIdentity');
+    getSegments(data && data.identity ? data.identity.ECID : null);
+  }
+
+  __satelliteLoadedCallback(getAudiences);
 };
 
 loadScript(martechURL).then(martechLoadedCB);


### PR DESCRIPTION
We'll see if this PR can bring back our ratings block. Due to CORS we didn't get to test on branch urls or stage. This should be a benign PR and won't break anything on PROD

---------

We should hopefully be able to see "you need to use the feature before rating", then after using the feature and come back, we should be able to rate now.

Resolves: https://jira.corp.adobe.com/browse/MWPW-138753

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://stage--express--adobecom.hlx.page/express/
