### PR TITLE
Refactoring of puf block

### DIFF
--- a/express/blocks/pricing-summary/pricing-summary.css
+++ b/express/blocks/pricing-summary/pricing-summary.css
@@ -202,10 +202,6 @@ main .pricing-summary > div:last-of-type > div p {
   margin: 0 0 12px;
 }
 
-main .pricing-summary .pricing-feature-list {
-
-}
-
 main .pricing-summary .pricing-feature-list svg,
 main .pricing-summary .pricing-feature-list img {
   min-width: 22px;

--- a/express/blocks/puf/puf.css
+++ b/express/blocks/puf/puf.css
@@ -1,25 +1,11 @@
-main .puf-container > div {
+main .puf-container>div {
     max-width: none;
 }
 
-main .puf.block .carousel-platform {
-    align-items: flex-start;
-}
-
-main .puf.block .carousel-container {
+main .block.puf .carousel-container {
     overflow: visible;
     transition: max-height 0.3s, min-height 0.3s;
     max-width: 600px;
-}
-
-main .puf.block .carousel-container .carousel-fader-left,
-main .puf.block .carousel-container .carousel-fader-right {
-    align-items: flex-start;
-}
-
-main .puf.block .carousel-container a.button.carousel-arrow {
-    margin-top: 50vh;
-    position: sticky;
 }
 
 main .block.puf {
@@ -133,15 +119,15 @@ main .block.puf .puf-card .puf-card-top .puf-card-plans {
     margin: 0 auto;
 }
 
-main .block.puf .puf-card .puf-card-top .puf-card-plans > div {
+main .block.puf .puf-card .puf-card-top .puf-card-plans>div {
     color: var(--color-info-accent);
 }
 
-main .block.puf .puf-card .puf-card-top .puf-card-plans > div span {
+main .block.puf .puf-card .puf-card-top .puf-card-plans>div span {
     color: var(--color-gray-800);
 }
 
-main .block.puf .puf-card .puf-card-top .puf-card-plans > div.strong span {
+main .block.puf .puf-card .puf-card-top .puf-card-plans>div.strong span {
     -webkit-text-stroke-width: 0.6px;
     -webkit-text-stroke-color: var(--color-gray-800);
 }
@@ -187,15 +173,15 @@ main .block.puf .puf-card .puf-card-top .puf-card-slider::before {
     border-radius: 50%;
 }
 
-main .block.puf .puf-card .puf-card-top .puf-card-switch input:checked + .puf-card-slider {
+main .block.puf .puf-card .puf-card-top .puf-card-switch input:checked+.puf-card-slider {
     background-color: var(--color-info-accent);
 }
 
-main .block.puf .puf-card .puf-card-top .puf-card-switch input:focus + .puf-card-slider {
+main .block.puf .puf-card .puf-card-top .puf-card-switch input:focus+.puf-card-slider {
     box-shadow: 0 0 1px #2196f3;
 }
 
-main .block.puf .puf-card .puf-card-top .puf-card-switch input:checked + .puf-card-slider:before {
+main .block.puf .puf-card .puf-card-top .puf-card-switch input:checked+.puf-card-slider:before {
     transform: translateX(26px);
 }
 
@@ -235,10 +221,6 @@ main .block.puf .puf-card .puf-card-bottom h6 {
     margin: 0;
 }
 
-main .puf .puf-right {
-    width: 375px;
-}
-
 main .block.puf .puf-card .puf-sup {
     font-size: 0.5em;
 }
@@ -247,7 +229,7 @@ main .block.puf .puf-card .puf-text-and-sup-wrapper {
     display: inline;
 }
 
-main .block.puf .puf-card-banner.recommended ~ .puf-card-bottom .puf-highlighted-text,
+main .block.puf .puf-card-banner.recommended~.puf-card-bottom .puf-highlighted-text,
 main .block.puf .puf-highlighted-text {
     background-color: var(--color-info-accent-light);
     width: 100%;
@@ -292,29 +274,22 @@ main .block.puf .puf-card-banner.recommended .banner-text {
     margin: 0 8px;
 }
 
-main .block.puf.one-col .puf-card-container:not(:has(.recommended)) {
-    border: 1px #e5e5e5 solid;
+main .block.puf .puf-card-container .puf-card-border {
     border-radius: 20px;
-}
-
-main .block.puf.two-col .puf-card-container:not(:has(.recommended)) {
-    flex: 1;
-    align-self: stretch;
-    border-top: 1px #e5e5e5 solid;
-    border-left: 1px #e5e5e5 solid;
-    border-bottom: 1px #e5e5e5 solid;
-    margin: 70px -16px 0 0;
-    padding: 0 0 8px 0;
-    border-radius: 20px 0 0 20px;
-}
-
-main .block.puf .puf-card-container:has(.recommended) {
-    background: linear-gradient(90deg, #ff477b 0%, #5c5ce0 52%, #318fff 100%);
-    box-shadow: 0 0 24px #00000029;
     padding: 48px 8px 8px 8px;
     margin-top: 20px;
     height: auto;
     z-index: 0;
+}
+
+main .block.puf .puf-card-container .puf-card-border:has(.recommended) {
+    background: linear-gradient(90deg, #ff477b 0%, #5c5ce0 52%, #318fff 100%);
+    box-shadow: 0 0 24px #00000029;
+}
+
+main .block.puf.two-col .puf-card-container .puf-card {
+    border: 1px #e5e5e5 solid;
+    border-radius: 20px;
 }
 
 main .block.puf .puf-card .puf-card-banner {
@@ -336,30 +311,142 @@ main .block.puf .puf-card .puf-card-banner a {
     text-decoration: underline;
 }
 
+main .carousel-container .carousel-platform {
+    position: relative;
+}
+
+main .carousel-container .carousel-platform .carousel-left-trigger,
+main .carousel-container .carousel-platform .carousel-right-trigger {
+    align-self: stretch;
+    width: 1px;
+}
+
+main .carousel-container .carousel-platform .carousel-left-trigger {
+    left: 0;
+}
+
+main .carousel-container .carousel-platform .carousel-right-trigger {
+    right: 0;
+}
+
+main .section.puf-container {
+    padding-bottom: 0;
+}
+
+main .block.puf .carousel-container {
+    position: relative;
+}
+
+main .block.puf .puf-card .puf-card-top .puf-card-plans {
+    margin-top: 16px;
+}
+
+main .block.puf .carousel-platform {
+    gap: 0px;
+    max-height: unset;
+    height: 100%;
+    min-height: 100%;
+}
+
+main .block.puf .puf-card .puf-card-bottom p {
+    margin-bottom: 24px;
+}
+
+main .block.puf .carousel-container .carousel-platform .puf-card-container {
+    width: calc(100% - 2px);
+}
+
+main .block.puf .carousel-container .carousel-platform .puf-card-container .puf-card {
+    max-width: 325px;
+}
+
+main .block.puf .puf-card-banner.recommended~.puf-card-bottom .puf-highlighted-text {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+main .block.puf.two-col .puf-card-container {
+    align-self: start;
+}
+
+main .carousel-container .carousel-fader-left,
+main .carousel-container .carousel-fader-right {
+    margin-top: 25%;
+    max-height: 1400px;
+}
+
+main .carousel-container .carousel-fader-left a.button.carousel-arrow,
+main .carousel-container .carousel-fader-right a.button.carousel-arrow {
+    position: sticky;
+    top: calc(50% - 16px);
+    bottom: calc(50% - 16px);
+}
+
 @media (min-width: 600px) {
     main .block.puf .puf-card-banner.recommended {
         font-size: var(--body-font-size-xl);
     }
 }
 
+main .block.puf .carousel-container.slide-1-selected {
+    max-height: 1600px;
+}
+
+main .block.puf .carousel-container .carousel-platform .puf-card-container .puf-card-border .puf-card {
+    box-shadow: 0 0 20px #00000029;
+}
+
 @media (min-width: 900px) {
+
+    main .block.puf .carousel-container .carousel-platform .puf-card-container .puf-card {
+        max-width: none;
+    }
+
+    main .block.puf .carousel-container.slide-1-selected {
+        max-height: none;
+    }
+
+    main .block.puf .puf-card-container .puf-card-border:has(.recommended),
+    main .block.puf .carousel-container .carousel-platform .puf-card-container .puf-card-border .puf-card {
+        box-shadow: none;
+    }
+
+    main .block.puf .puf-card-container .puf-card-border .puf-card.puf-left {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+    }
+
+    main .block.puf .puf-card-container .puf-card-border:has(.puf-left) {
+        padding-right: 0;
+    }
+
+    main .block.puf .carousel-container .carousel-platform .puf-card-container {
+        align-self: stretch;
+        max-width: 100%;
+        width: auto;
+    }
+
+    main .block.puf .carousel-container .carousel-platform .puf-card-container .puf-card {
+        height: 100%;
+        width: 610px;
+        margin: 0;
+        padding: 40px 60px;
+    }
+
+    main .carousel-container .carousel-platform .carousel-left-trigger,
+    main .carousel-container .carousel-platform .carousel-right-trigger {
+        align-self: stretch;
+        position: relative;
+        height: auto;
+        right: auto;
+        left: auto;
+        top: auto;
+    }
+
     main .puf.block .carousel-container {
         max-width: none;
         max-height: none !important;
-    }
-
-    main .block.puf .puf-card-container {
-        width: auto;
-        margin-top: 70px;
-        padding-top: 0;
-    }
-
-    main .puf.block .carousel-container .carousel-fader-right {
-        right: -3rem;
-    }
-
-    main .puf .puf-card-container:has(.recommended) {
-        padding: 48px 8px 8px 8px;
     }
 
     main .block.puf .carousel-container {
@@ -367,21 +454,12 @@ main .block.puf .puf-card .puf-card-banner a {
     }
 
     main .block.puf .carousel-platform {
+        align-items: stretch;
         max-height: unset;
-      padding: 14px 24px 0 24px;
-      margin: -14px auto 0;
-    }
-
-    main .block.puf .puf-card {
-        width: 610px;
-        margin: 0;
-        padding: 40px 60px;
-    }
-
-    main .block.puf .puf-card.puf-left {
-        border-radius: 20px;
-        border-right: none;
-        min-height: 1200px;
+        max-width: 100%;
+        margin-left: auto;
+        margin-right: auto;
+        overflow: auto;
     }
 
     main .block.puf .puf-card-container:not(:has(.recommended)) .puf-card {
@@ -389,21 +467,9 @@ main .block.puf .puf-card .puf-card-banner a {
         padding-right: 76px;
     }
 
-    main .block.puf .puf-card.puf-right {
-        min-height: 1260px;
-    }
-
-    main .block.puf .puf-card .puf-card-top {
-        justify-content: flex-start;
-    }
-
     main .block.puf .puf-card .puf-card-top .puf-pricing-container {
         margin-top: 10px;
         gap: 4px;
-    }
-
-    main .block.puf .puf-card .puf-card-top h2 {
-        margin: 0;
     }
 
     main .block.puf .puf-card .puf-pricing-suf-container div {
@@ -412,30 +478,14 @@ main .block.puf .puf-card .puf-card-banner a {
         font-size: var(--body-font-size-xl);
     }
 
-    main .block.puf .puf-card .puf-pricing-context {
-        margin-bottom: 8px;
-    }
-
-    main .block.puf .puf-card .puf-card-top p {
-        text-align: left;
-    }
-
     main .block.puf .puf-card .puf-card-top .puf-card-plans {
         min-height: 40px;
-    }
-
-    main .block.puf .puf-card .puf-card-bottom {
-        align-items: flex-start;
     }
 
     main .block.puf .puf-card .puf-card-bottom p {
         display: flex;
         align-items: center;
         margin-bottom: 24px;
-        text-align: left;
-    }
-
-    main .block.puf .puf-card .puf-card-bottom h6 {
         text-align: left;
     }
 
@@ -471,87 +521,10 @@ main .block.puf .puf-card .puf-card-banner a {
         mask-size: contain;
     }
 
-    main .block.puf.one-col .puf-pricing-footer {
-        width: 628px;
-    }
 }
 
-@media (max-width: 899px) {
-    main .section.puf-container {
-        padding-bottom: 0;
-    }
-
-    main .block.puf .carousel-container {
-        position: relative;
-        overflow: hidden;
-        margin-bottom: 0;
-        padding: 0 12px 12px 0;
-    }
-
-    main .block.puf .puf-card .puf-card-top .puf-card-plans {
-        margin-top: 16px;
-    }
-
-    main .block.puf .carousel-platform {
-        display: block;
-        position: static;
-        overflow: visible;
-        height: 100%;
-        width: 100%;
-        min-height: 100%;
-    }
-
-    main .block.puf .puf-card .puf-card-bottom p {
-        margin-bottom: 24px;
-    }
-
-    main .block.puf .carousel-container.slide-2-selected .carousel-fader-right,
-    main .block.puf .carousel-container.slide-1-selected .carousel-fader-left {
-        opacity: 0;
-        pointer-events: none;
-    }
-
-    main .block.puf .carousel-container.slide-1-selected .carousel-fader-right {
-        right: 1rem;
-        opacity: 1;
-        pointer-events: auto;
-    }
-
-    main .block.puf .carousel-container.slide-2-selected .carousel-fader-left {
-        left: 0.7rem;
-        opacity: 1;
-        pointer-events: auto;
-    }
-
-    main .block.puf .carousel-container .carousel-platform .puf-card-container {
-        position: absolute;
-        max-width: fit-content;
-        transform: translateX(-50%);
-        right: auto;
-        top: 0;
-        left: 50%;
-        width: 100%;
-        border-right: 1px #e5e5e5 solid;
-        border-radius: 20px;
-        margin: 20px 0 0 0;
-        box-shadow: 0 0 20px #00000029;
-    }
-
-    main .block.puf .carousel-container .carousel-platform .puf-card-container .puf-card {
-        width: 325px;
-    }
-
-    main .block.puf .puf-card-banner.recommended ~ .puf-card-bottom .puf-highlighted-text {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
-
-    main .block.puf .carousel-container.slide-2-selected .carousel-platform .puf-card-container:first-child {
-        left: -150%;
-    }
-
-    main .block.puf .carousel-container.slide-1-selected .carousel-platform .puf-card-container:last-child {
-        left: 150%;
+@media (min-width:1200px) {
+    main .section h1 {
+        font-size: var(--heading-font-size-l);
     }
 }

--- a/express/blocks/puf/puf.css
+++ b/express/blocks/puf/puf.css
@@ -287,7 +287,7 @@ main .block.puf .puf-card-container .puf-card-border:has(.recommended) {
     box-shadow: 0 0 24px #00000029;
 }
 
-main .block.puf.two-col .puf-card-container .puf-card {
+main .block.puf .puf-card-container .puf-card {
     border: 1px #e5e5e5 solid;
     border-radius: 20px;
 }
@@ -366,14 +366,13 @@ main .block.puf .puf-card-banner.recommended~.puf-card-bottom .puf-highlighted-t
     justify-content: center;
 }
 
-main .block.puf.two-col .puf-card-container {
+main .block.puf .puf-card-container {
     align-self: start;
 }
 
 main .carousel-container .carousel-fader-left,
 main .carousel-container .carousel-fader-right {
-    margin-top: 25%;
-    max-height: 1400px;
+    margin-top: 100px;
 }
 
 main .carousel-container .carousel-fader-left a.button.carousel-arrow,
@@ -389,9 +388,6 @@ main .carousel-container .carousel-fader-right a.button.carousel-arrow {
     }
 }
 
-main .block.puf .carousel-container.slide-1-selected {
-    max-height: 1600px;
-}
 
 main .block.puf .carousel-container .carousel-platform .puf-card-container .puf-card-border .puf-card {
     box-shadow: 0 0 20px #00000029;
@@ -403,9 +399,6 @@ main .block.puf .carousel-container .carousel-platform .puf-card-container .puf-
         max-width: none;
     }
 
-    main .block.puf .carousel-container.slide-1-selected {
-        max-height: none;
-    }
 
     main .block.puf .puf-card-container .puf-card-border:has(.recommended),
     main .block.puf .carousel-container .carousel-platform .puf-card-container .puf-card-border .puf-card {
@@ -444,7 +437,7 @@ main .block.puf .carousel-container .carousel-platform .puf-card-container .puf-
         top: auto;
     }
 
-    main .puf.block .carousel-container {
+    main .block.puf .carousel-container {
         max-width: none;
         max-height: none !important;
     }
@@ -453,8 +446,12 @@ main .block.puf .carousel-container .carousel-platform .puf-card-container .puf-
         margin-bottom: 0;
     }
 
+    main .block.puf .carousel-container .carousel-platform {
+        align-items: start;
+    }
+
     main .block.puf .carousel-platform {
-        align-items: stretch;
+        align-items: start;
         max-height: unset;
         max-width: 100%;
         margin-left: auto;
@@ -521,10 +518,4 @@ main .block.puf .carousel-container .carousel-platform .puf-card-container .puf-
         mask-size: contain;
     }
 
-}
-
-@media (min-width:1200px) {
-    main .section h1 {
-        font-size: var(--heading-font-size-l);
-    }
 }

--- a/express/blocks/puf/puf.js
+++ b/express/blocks/puf/puf.js
@@ -24,12 +24,27 @@ function pushPricingAnalytics(adobeEventName, sparkEventName, plan) {
   /* global digitalData _satellite */
   digitalData._set('primaryEvent.eventInfo.eventName', adobeEventName);
   digitalData._set('spark.eventData.eventName', sparkEventName);
-  digitalData._set('spark.eventData.contextualData4', `billingFrequency:${plan.frequency}`);
-  digitalData._set('spark.eventData.contextualData6', `commitmentType:${plan.frequency}`);
-  digitalData._set('spark.eventData.contextualData7', `currencyCode:${plan.currency}`);
-  digitalData._set('spark.eventData.contextualData9', `offerId:${plan.offerId}`);
+  digitalData._set(
+    'spark.eventData.contextualData4',
+    `billingFrequency:${plan.frequency}`
+  );
+  digitalData._set(
+    'spark.eventData.contextualData6',
+    `commitmentType:${plan.frequency}`
+  );
+  digitalData._set(
+    'spark.eventData.contextualData7',
+    `currencyCode:${plan.currency}`
+  );
+  digitalData._set(
+    'spark.eventData.contextualData9',
+    `offerId:${plan.offerId}`
+  );
   digitalData._set('spark.eventData.contextualData10', `price:${plan.price}`);
-  digitalData._set('spark.eventData.contextualData12', `productName:${plan.name} - ${plan.frequency}`);
+  digitalData._set(
+    'spark.eventData.contextualData12',
+    `productName:${plan.name} - ${plan.frequency}`
+  );
   digitalData._set('spark.eventData.contextualData14', 'quantity:1');
   digitalData._set('spark.eventData.trigger', sparkTouchpoint);
 
@@ -87,13 +102,22 @@ async function selectPlan(card, planUrl, sendAnalyticEvent) {
 function displayPlans(card, plans) {
   const planContainer = card.querySelector('.puf-card-plans');
   const cardSwitch = createTag('label', { class: 'puf-card-switch' });
-  const checkbox = createTag('input', { type: 'checkbox', class: 'puf-card-checkbox' });
+  const checkbox = createTag('input', {
+    type: 'checkbox',
+    class: 'puf-card-checkbox',
+  });
   const slider = createTag('span', { class: 'puf-card-slider' });
   const defaultPlan = createTag('div', { class: 'strong' });
   const secondPlan = createTag('div');
 
-  defaultPlan.innerHTML = plans[0].text.replace(plans[0].plan, `<span>${plans[0].plan}</span>`);
-  secondPlan.innerHTML = plans[1].text.replace(plans[1].plan, `<span>${plans[1].plan}</span>`);
+  defaultPlan.innerHTML = plans[0].text.replace(
+    plans[0].plan,
+    `<span>${plans[0].plan}</span>`
+  );
+  secondPlan.innerHTML = plans[1].text.replace(
+    plans[1].plan,
+    `<span>${plans[1].plan}</span>`
+  );
 
   planContainer.append(defaultPlan);
   planContainer.append(cardSwitch);
@@ -144,13 +168,19 @@ async function decorateCard(block, cardClass = '') {
   const cardBottom = block.children[2].children[0];
   const cardHeader = cardTop.querySelector('h3, p:first-of-type');
   const cardHeaderSvg = cardTop.querySelector('svg');
-  const cardPricingContainer = createTag('div', { class: 'puf-pricing-container' });
+  const cardPricingContainer = createTag('div', {
+    class: 'puf-pricing-container',
+  });
   const cardBasePriceHeader = createTag('h2', { class: 'puf-bp-header' });
   const cardPricingHeader = createTag('h2', { class: 'puf-pricing-header' });
-  const cardPricingSufContainer = createTag('div', { class: 'puf-pricing-suf-container' });
+  const cardPricingSufContainer = createTag('div', {
+    class: 'puf-pricing-suf-container',
+  });
   const cardPricingSuf = createTag('div', { class: 'puf-pricing-suf' });
   const cardVat = createTag('div', { class: 'puf-vat-info' });
-  const cardAdditionalContext = createTag('div', { class: 'puf-pricing-context' });
+  const cardAdditionalContext = createTag('div', {
+    class: 'puf-pricing-context',
+  });
   const cardPlansContainer = createTag('div', { class: 'puf-card-plans' });
   const cardCta = createTag('a', { class: 'button large' });
   const plansElement = cardTop.querySelectorAll('li');
@@ -172,21 +202,29 @@ async function decorateCard(block, cardClass = '') {
   cardTop.classList.add('puf-card-top');
   cardBottom.classList.add('puf-card-bottom');
 
-  cardPricingContainer.append(cardBasePriceHeader, cardPricingHeader, cardPricingSufContainer);
+  cardPricingContainer.append(
+    cardBasePriceHeader,
+    cardPricingHeader,
+    cardPricingSufContainer
+  );
   cardPricingSufContainer.append(cardPricingSuf, cardVat);
   cardTop.prepend(
     cardHeader,
     cardPricingContainer,
     cardAdditionalContext,
     cardPlansContainer,
-    cardCta,
+    cardCta
   );
   card.append(cardBanner, cardTop, cardBottom);
 
   if (!cardBanner.textContent.trim()) {
     cardBanner.style.display = 'none';
   } else {
-    cardBanner.innerHTML = createTag('span', { class: 'banner-text' }, cardBanner.innerHTML).outerHTML;
+    cardBanner.innerHTML = createTag(
+      'span',
+      { class: 'banner-text' },
+      cardBanner.innerHTML
+    ).outerHTML;
     cardBanner.classList.add('recommended');
   }
 
@@ -212,7 +250,8 @@ async function decorateCard(block, cardClass = '') {
 
   const pricingContextContainer = cardTop.querySelector('em');
   if (pricingContextContainer) {
-    cardAdditionalContext.textContent = pricingContextContainer.textContent.trim();
+    cardAdditionalContext.textContent =
+      pricingContextContainer.textContent.trim();
     pricingContextContainer.parentNode.remove();
   } else {
     cardAdditionalContext.remove();
@@ -229,79 +268,6 @@ async function decorateCard(block, cardClass = '') {
   }
 
   return cardContainer;
-}
-
-function updatePUFCarousel(block) {
-  const carouselContainer = block.querySelector('.carousel-container');
-  const carouselPlatform = block.querySelector('.carousel-platform');
-  const leftCard = block.querySelector('.puf-left');
-  const rightCard = block.querySelector('.puf-right');
-  carouselContainer.classList.add('slide-1-selected');
-
-  const slideFunctionality = () => {
-    carouselPlatform.scrollLeft = carouselPlatform.offsetWidth;
-    carouselContainer.style.width = '100%';
-    carouselContainer.style.minHeight = `${leftCard.clientHeight + 40}px`;
-    const rightArrow = carouselContainer.querySelector('.carousel-fader-right');
-    const leftArrow = carouselContainer.querySelector('.carousel-fader-left');
-    const changeSlide = (index) => {
-      if (index === 0) {
-        carouselContainer.classList.add('slide-1-selected');
-        carouselContainer.classList.remove('slide-2-selected');
-        // carouselContainer.style.minHeight = `${leftCard.clientHeight + 40}px`;
-      } else {
-        carouselContainer.classList.remove('slide-1-selected');
-        carouselContainer.classList.add('slide-2-selected');
-        // carouselContainer.style.minHeight = `${rightCard.clientHeight + 110}px`;
-      }
-    };
-
-    leftArrow.addEventListener('click', () => changeSlide(0));
-    rightArrow.addEventListener('click', () => changeSlide(1));
-    block.addEventListener('keyup', (e) => {
-      if (e.key === 'ArrowLeft') {
-        changeSlide(0);
-      } else if (e.key === 'ArrowRight') {
-        changeSlide(1);
-      }
-    });
-    let initialX = null;
-    let initialY = null;
-    const startTouch = (e) => {
-      initialX = e.touches[0].clientX;
-      initialY = e.touches[0].clientY;
-    };
-    const moveTouch = (e) => {
-      if (initialX === null || initialY === null) return;
-      const currentX = e.touches[0].clientX;
-      const currentY = e.touches[0].clientY;
-      const diffX = initialX - currentX;
-      const diffY = initialY - currentY;
-      if (Math.abs(diffX) > Math.abs(diffY)) {
-        if (diffX > 0) {
-          changeSlide(1);
-        } else {
-          changeSlide(0);
-        }
-        e.preventDefault();
-      }
-      initialX = null;
-      initialY = null;
-    };
-    block.addEventListener('touchstart', startTouch, false);
-    block.addEventListener('touchmove', moveTouch, false);
-    const mediaQuery = window.matchMedia('(min-width: 900px)');
-    mediaQuery.onchange = () => {
-      carouselContainer.style.minHeight = `${leftCard.clientHeight + 40}px`;
-    };
-    const cardContainers = block.querySelectorAll('.puf-card-container');
-    cardContainers.forEach((c) => {
-      c.style.transition = 'left 0.5s';
-    });
-    parent.append(block);
-    invisContainer.remove();
-  };
-  slideFunctionality();
 }
 
 function wrapTextAndSup(block) {
@@ -322,7 +288,9 @@ function wrapTextAndSup(block) {
 
     const filteredChildrenExceptFirstText = filteredChildren.slice(1);
 
-    const textAndSupWrapper = createTag('div', { class: 'puf-text-and-sup-wrapper' });
+    const textAndSupWrapper = createTag('div', {
+      class: 'puf-text-and-sup-wrapper',
+    });
     textAndSupWrapper.append(...filteredChildrenExceptFirstText);
     listItem.append(textAndSupWrapper);
   });
@@ -333,106 +301,37 @@ function formatTextElements(block) {
   const dividerRegex = /^--.*--$/;
   const blockElements = Array.from(block.querySelectorAll('*'));
 
-  if (!blockElements.some((element) => highlightRegex.test(element.textContent)
-    || dividerRegex.test(element.textContent))) {
+  if (
+    !blockElements.some(
+      (element) =>
+        highlightRegex.test(element.textContent) ||
+        dividerRegex.test(element.textContent)
+    )
+  ) {
     return;
   }
 
-  const highlightedElements = blockElements
-    .filter((element) => highlightRegex.test(element.textContent));
+  const highlightedElements = blockElements.filter((element) =>
+    highlightRegex.test(element.textContent)
+  );
 
   highlightedElements.forEach((element) => {
     element.classList.add('puf-highlighted-text');
-    element.textContent = element.textContent.replace(/^\(\(/, '').replace(/\)\)$/, '');
+    element.textContent = element.textContent
+      .replace(/^\(\(/, '')
+      .replace(/\)\)$/, '');
   });
 
-  const dividerElements = blockElements
-    .filter((element) => dividerRegex.test(element.textContent));
+  const dividerElements = blockElements.filter((element) =>
+    dividerRegex.test(element.textContent)
+  );
 
   dividerElements.forEach((element) => {
     element.classList.add('puf-divider-text');
-    element.textContent = element.textContent.replace(/^--/, '').replace(/--$/, '');
+    element.textContent = element.textContent
+      .replace(/^--/, '')
+      .replace(/--$/, '');
   });
-}
-
-function alignP($block) {
-  const isDesktop = window.innerWidth >= 900;
-
-  if (isDesktop) {
-    const card1 = $block.querySelector('.puf-card.puf-left > .puf-card-top > p:last-of-type');
-    const card2 = $block.querySelector('.puf-card.puf-right > .puf-card-top > p:last-of-type');
-
-    const adjustHeight = () => {
-      if (card1 && card2) {
-        card1.style.height = 'auto';
-        card2.style.height = 'auto';
-
-        const maxHeight = Math.max(
-          card1.getBoundingClientRect().height,
-          card2.getBoundingClientRect().height,
-        );
-
-        card1.style.height = `${maxHeight}px`;
-        card2.style.height = `${maxHeight}px`;
-      } else if (card1) {
-        card1.style.height = 'auto';
-      } else if (card2) {
-        card2.style.height = 'auto';
-      }
-    };
-
-    const ro = new ResizeObserver(() => adjustHeight());
-
-    if (card1) {
-      ro.observe(card1);
-    }
-
-    if (card2) {
-      ro.observe(card2);
-    }
-
-    adjustHeight();
-  }
-}
-
-function alignHighlights($block) {
-  const isDesktop = window.innerWidth >= 900;
-
-  if (isDesktop) {
-    const cardLeft = $block.querySelector('.puf-card.puf-left > .puf-card-bottom > h3');
-    const cardRight = $block.querySelector('.puf-card.puf-right > .puf-card-bottom > h3');
-
-    const adjustHeight = () => {
-      if (cardLeft && cardRight) {
-        cardLeft.style.height = 'auto';
-        cardRight.style.height = 'auto';
-
-        const maxHeightTitle = Math.max(
-          cardLeft.getBoundingClientRect().height,
-          cardRight.getBoundingClientRect().height,
-        );
-
-        cardLeft.style.height = `${maxHeightTitle}px`;
-        cardRight.style.height = `${maxHeightTitle}px`;
-      } else if (cardLeft) {
-        cardLeft.style.height = 'auto';
-      } else if (cardRight) {
-        cardRight.style.height = 'auto';
-      }
-    };
-
-    const ro = new ResizeObserver(() => adjustHeight());
-
-    if (cardLeft) {
-      ro.observe(cardLeft);
-    }
-
-    if (cardRight) {
-      ro.observe(cardRight);
-    }
-
-    adjustHeight();
-  }
 }
 
 function decorateFooter(block) {
@@ -445,21 +344,51 @@ function decorateFooter(block) {
   }
 }
 
-async function build1ColDesign(block) {
-  block.classList.add('one-col');
-  const pricingCard = await decorateCard(block);
-  const footer = decorateFooter(block);
-
-  block.innerHTML = '';
-  block.append(pricingCard);
-
-  addPublishDependencies('/express/system/offers-new.json');
-  wrapTextAndSup(block);
-  block.append(footer);
-  formatTextElements(block);
+function matchTwoElementsHeight(el1, el2) {
+  // ^ not the clearest name (sets the shortest of two elements to the tallest element's height)
+  if (el1 && el2) {
+    const maxHeight = Math.max(
+      el1.getBoundingClientRect().height,
+      el2.getBoundingClientRect().height
+    );
+    el1.style.height = `${maxHeight}px`;
+    el2.style.height = `${maxHeight}px`;
+  }
 }
 
-async function build2ColDesign(block) {
+function alignContent() {
+  const block = document.querySelector('.puf');
+  const rightDescription = block.querySelector(
+    '.puf-card.puf-right > .puf-card-top > p:last-of-type'
+  );
+  const leftDescription = block.querySelector(
+    '.puf-card.puf-left > .puf-card-top > p:last-of-type'
+  );
+  const rightHeading = block.querySelector(
+    '.puf-card.puf-right > .puf-card-bottom > h3'
+  );
+  const leftHeading = block.querySelector(
+    '.puf-card.puf-left > .puf-card-bottom > h3'
+  );
+
+  if (rightDescription) rightDescription.style.height = 'auto';
+  if (leftDescription) leftDescription.style.height = 'auto';
+  if (rightHeading) rightHeading.style.height = 'auto';
+  if (leftHeading) leftHeading.style.height = 'auto';
+
+  if (window.innerWidth >= 900) {
+    matchTwoElementsHeight(rightDescription, leftDescription);
+    matchTwoElementsHeight(rightHeading, leftHeading);
+  }
+}
+
+const resizeObserver = new ResizeObserver((entries) => {
+  entries.forEach(() => {
+    alignContent();
+  });
+});
+
+export default async function decorate(block) {
   invisContainer = createTag('div');
   parent = block.parentElement;
   invisContainer.style.visibility = 'hidden';
@@ -467,7 +396,6 @@ async function build2ColDesign(block) {
   invisContainer.append(block);
   const main = document.body.querySelector('main');
   main.append(invisContainer);
-  block.classList.add('two-col');
   const leftCard = await decorateCard(block, 'puf-left');
   const rightCard = await decorateCard(block, 'puf-right');
   const footer = decorateFooter(block);
@@ -475,25 +403,46 @@ async function build2ColDesign(block) {
   block.append(leftCard, rightCard);
 
   await buildCarousel('.puf-card-container', block);
-  updatePUFCarousel(block);
+  parent.append(block);
+  invisContainer.remove();
+
+  resizeObserver.observe(rightCard);
+
+  const options = {
+    root: document.querySelector('.carousel-platform'),
+    rootMargin: '0px',
+    threshold: 1.0,
+  };
+  const carouselContainer = block.querySelector('.carousel-container');
+  const carouselLeftControlContainer = carouselContainer.querySelector(
+    '.carousel-fader-left'
+  );
+  const carouselRightControlContainer = carouselContainer.querySelector(
+    '.carousel-fader-right'
+  );
+  const callback = (entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        if (window.innerWidth >= 900) {
+          carouselContainer.style.maxHeight = 'none';
+        } else {
+          carouselContainer.style.maxHeight = `${entry.target.clientHeight}px`;
+        }
+        carouselLeftControlContainer.style.maxHeight = `${
+          entry.target.clientHeight - 125
+        }px`;
+        carouselRightControlContainer.style.maxHeight = `${
+          entry.target.clientHeight - 125
+        }px`;
+      }
+    });
+  };
+  const intersectionObserver = new IntersectionObserver(callback, options);
+  intersectionObserver.observe(leftCard);
+  intersectionObserver.observe(rightCard);
+
   addPublishDependencies('/express/system/offers-new.json');
   wrapTextAndSup(block);
   block.append(footer);
-  alignP(block);
   formatTextElements(block);
-  alignHighlights(block);
-}
-
-function getPUFDesign(block) {
-  return block.children[1].children.length === 2 ? '2-col' : '1-col';
-}
-
-export default async function decorate(block) {
-  if (getPUFDesign(block) === '1-col') {
-    await build1ColDesign(block);
-  }
-
-  if (getPUFDesign(block) === '2-col') {
-    await build2ColDesign(block);
-  }
 }

--- a/express/blocks/puf/puf.js
+++ b/express/blocks/puf/puf.js
@@ -137,6 +137,7 @@ function buildPlans(plansElement) {
 async function decorateCard(block, cardClass = '') {
   const cardClassName = `puf-card ${cardClass}`.trim();
   const cardContainer = createTag('div', { class: 'puf-card-container' });
+  const cardBorder = createTag('div', { class: 'puf-card-border' });
   const card = createTag('div', { class: cardClassName });
   const cardBanner = block.children[0].children[0];
   const cardTop = block.children[1].children[0];
@@ -217,7 +218,9 @@ async function decorateCard(block, cardClass = '') {
     cardAdditionalContext.remove();
   }
 
-  cardContainer.append(card);
+  // cardContainer.append(card);
+  cardContainer.append(cardBorder);
+  cardBorder.append(card);
 
   if (listItems) {
     listItems.forEach((listItem) => {
@@ -245,11 +248,11 @@ function updatePUFCarousel(block) {
       if (index === 0) {
         carouselContainer.classList.add('slide-1-selected');
         carouselContainer.classList.remove('slide-2-selected');
-        carouselContainer.style.minHeight = `${leftCard.clientHeight + 40}px`;
+        // carouselContainer.style.minHeight = `${leftCard.clientHeight + 40}px`;
       } else {
         carouselContainer.classList.remove('slide-1-selected');
         carouselContainer.classList.add('slide-2-selected');
-        carouselContainer.style.minHeight = `${rightCard.clientHeight + 110}px`;
+        // carouselContainer.style.minHeight = `${rightCard.clientHeight + 110}px`;
       }
     };
 

--- a/test/unit/scripts/mocks/carousel.html
+++ b/test/unit/scripts/mocks/carousel.html
@@ -1,0 +1,192 @@
+<main>
+
+      <div id="create-carousel" class="cta-carousel create">
+        <div>
+          <div>
+            <h2 id="get-started-with-the-all-in-one-editor">Get started with the all-in-one editor.</h2>
+            <p>Make flyers, TikToks, resumes, and Reels with professionally designed templates.</p>
+            <p><a href="https://new.express.adobe.com/">View all</a></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_19da7bd719145d2405fcd36afe6f468b7d6c7f30a.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_19da7bd719145d2405fcd36afe6f468b7d6c7f30a.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_19da7bd719145d2405fcd36afe6f468b7d6c7f30a.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_19da7bd719145d2405fcd36afe6f468b7d6c7f30a.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://new.express.adobe.com/new?width=2560&amp;height=2560&amp;unit=px&amp;aspectRatioLock=false">Create now</a></strong></p>
+            <p><strong>Start from scratch</strong></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_183b0679c6018733b42214e5a60d7c00e851f0d48.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_183b0679c6018733b42214e5a60d7c00e851f0d48.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_183b0679c6018733b42214e5a60d7c00e851f0d48.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_183b0679c6018733b42214e5a60d7c00e851f0d48.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://new.express.adobe.com/?category=document">Create now</a></strong></p>
+            <p><strong>Edit PDF</strong></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_170f82b6bdcc9c0d5f60f47a76f4185c6627fab11.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_170f82b6bdcc9c0d5f60f47a76f4185c6627fab11.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_170f82b6bdcc9c0d5f60f47a76f4185c6627fab11.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_170f82b6bdcc9c0d5f60f47a76f4185c6627fab11.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Create now</a></strong></p>
+            <p><strong>Instagram square post</strong></p>
+            <p><em>1080x1080px</em></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_1d7cf0896fd04ccf6a4616ffee399509c2c7a6879.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_1d7cf0896fd04ccf6a4616ffee399509c2c7a6879.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_1d7cf0896fd04ccf6a4616ffee399509c2c7a6879.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_1d7cf0896fd04ccf6a4616ffee399509c2c7a6879.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Create now</a></strong></p>
+            <p><strong>Flyer</strong></p>
+            <p><em>8.5x11in</em></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_1e9553ec5340415da35bcf5a88a96d9bbc94dc512.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_1e9553ec5340415da35bcf5a88a96d9bbc94dc512.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_1e9553ec5340415da35bcf5a88a96d9bbc94dc512.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_1e9553ec5340415da35bcf5a88a96d9bbc94dc512.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Create now</a></strong></p>
+            <p><strong>Instagram story</strong></p>
+            <p><em>1080x1920px</em></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_1a1afda6e8f82ee4034f1b174294503ee21979f1d.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_1a1afda6e8f82ee4034f1b174294503ee21979f1d.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_1a1afda6e8f82ee4034f1b174294503ee21979f1d.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_1a1afda6e8f82ee4034f1b174294503ee21979f1d.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Create now</a></strong></p>
+            <p><strong>TikTok video</strong></p>
+            <p><em>1080x1080px</em></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_1b5592ab5a133045e13c395db10b3a678b488ef4b.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_1b5592ab5a133045e13c395db10b3a678b488ef4b.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_1b5592ab5a133045e13c395db10b3a678b488ef4b.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_1b5592ab5a133045e13c395db10b3a678b488ef4b.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Create now</a></strong></p>
+            <p><a href="https://express.adobe.com/express-apps/logo-maker/">Logo Maker</a></p>
+            <p><strong>Logo</strong></p>
+            <p><em>500x500px</em></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_1f81a8109d0b7d537c053517a9eef70fbd6aedfac.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_1f81a8109d0b7d537c053517a9eef70fbd6aedfac.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_1f81a8109d0b7d537c053517a9eef70fbd6aedfac.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_1f81a8109d0b7d537c053517a9eef70fbd6aedfac.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Create now</a></strong></p>
+            <p><strong>Facebook post</strong></p>
+            <p><em>1080x1080px</em></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_1421e1d8091f13096c9b2220c5ab988c4402fc749.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_1421e1d8091f13096c9b2220c5ab988c4402fc749.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_1421e1d8091f13096c9b2220c5ab988c4402fc749.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_1421e1d8091f13096c9b2220c5ab988c4402fc749.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Create now</a></strong></p>
+            <p><strong>Instagram reel</strong></p>
+            <p><em>1080x1920px</em></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_1947eede9625800eb8235f9a7d8850fd4186ce021.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_1947eede9625800eb8235f9a7d8850fd4186ce021.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_1947eede9625800eb8235f9a7d8850fd4186ce021.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_1947eede9625800eb8235f9a7d8850fd4186ce021.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Create now</a></strong></p>
+            <p><strong>Poster</strong></p>
+            <p><em>11x17in</em></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_172ff54c5ca6d07476814391bfdabf611d76ade1a.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_172ff54c5ca6d07476814391bfdabf611d76ade1a.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_172ff54c5ca6d07476814391bfdabf611d76ade1a.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_172ff54c5ca6d07476814391bfdabf611d76ade1a.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Create now</a></strong></p>
+            <p><strong>YouTube thumbnail</strong></p>
+            <p><em>1280x720px</em></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_1cac787544e689a9b5949a552b2e8dd0bf45a12b2.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_1cac787544e689a9b5949a552b2e8dd0bf45a12b2.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_1cac787544e689a9b5949a552b2e8dd0bf45a12b2.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_1cac787544e689a9b5949a552b2e8dd0bf45a12b2.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Create now</a></strong></p>
+            <p><strong>YouTube video</strong></p>
+            <p><em>1920x1080px</em></p>
+          </div>
+        </div>
+      </div>
+  
+</main>

--- a/test/unit/scripts/mocks/infinite-carousel.html
+++ b/test/unit/scripts/mocks/infinite-carousel.html
@@ -1,0 +1,192 @@
+<main>
+
+      <div id="create-carousel" class="cta-carousel create">
+        <div>
+          <div>
+            <h2 id="get-started-with-the-all-in-one-editor">Get started with the all-in-one editor.</h2>
+            <p>Make flyers, TikToks, resumes, and Reels with professionally designed templates.</p>
+            <p><a href="https://new.express.adobe.com/">View all</a></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_19da7bd719145d2405fcd36afe6f468b7d6c7f30a.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_19da7bd719145d2405fcd36afe6f468b7d6c7f30a.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_19da7bd719145d2405fcd36afe6f468b7d6c7f30a.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_19da7bd719145d2405fcd36afe6f468b7d6c7f30a.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://new.express.adobe.com/new?width=2560&amp;height=2560&amp;unit=px&amp;aspectRatioLock=false">Create now</a></strong></p>
+            <p><strong>Start from scratch</strong></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_183b0679c6018733b42214e5a60d7c00e851f0d48.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_183b0679c6018733b42214e5a60d7c00e851f0d48.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_183b0679c6018733b42214e5a60d7c00e851f0d48.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_183b0679c6018733b42214e5a60d7c00e851f0d48.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://new.express.adobe.com/?category=document">Create now</a></strong></p>
+            <p><strong>Edit PDF</strong></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_170f82b6bdcc9c0d5f60f47a76f4185c6627fab11.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_170f82b6bdcc9c0d5f60f47a76f4185c6627fab11.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_170f82b6bdcc9c0d5f60f47a76f4185c6627fab11.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_170f82b6bdcc9c0d5f60f47a76f4185c6627fab11.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Create now</a></strong></p>
+            <p><strong>Instagram square post</strong></p>
+            <p><em>1080x1080px</em></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_1d7cf0896fd04ccf6a4616ffee399509c2c7a6879.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_1d7cf0896fd04ccf6a4616ffee399509c2c7a6879.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_1d7cf0896fd04ccf6a4616ffee399509c2c7a6879.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_1d7cf0896fd04ccf6a4616ffee399509c2c7a6879.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Create now</a></strong></p>
+            <p><strong>Flyer</strong></p>
+            <p><em>8.5x11in</em></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_1e9553ec5340415da35bcf5a88a96d9bbc94dc512.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_1e9553ec5340415da35bcf5a88a96d9bbc94dc512.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_1e9553ec5340415da35bcf5a88a96d9bbc94dc512.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_1e9553ec5340415da35bcf5a88a96d9bbc94dc512.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Create now</a></strong></p>
+            <p><strong>Instagram story</strong></p>
+            <p><em>1080x1920px</em></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_1a1afda6e8f82ee4034f1b174294503ee21979f1d.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_1a1afda6e8f82ee4034f1b174294503ee21979f1d.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_1a1afda6e8f82ee4034f1b174294503ee21979f1d.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_1a1afda6e8f82ee4034f1b174294503ee21979f1d.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Create now</a></strong></p>
+            <p><strong>TikTok video</strong></p>
+            <p><em>1080x1080px</em></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_1b5592ab5a133045e13c395db10b3a678b488ef4b.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_1b5592ab5a133045e13c395db10b3a678b488ef4b.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_1b5592ab5a133045e13c395db10b3a678b488ef4b.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_1b5592ab5a133045e13c395db10b3a678b488ef4b.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Create now</a></strong></p>
+            <p><a href="https://express.adobe.com/express-apps/logo-maker/">Logo Maker</a></p>
+            <p><strong>Logo</strong></p>
+            <p><em>500x500px</em></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_1f81a8109d0b7d537c053517a9eef70fbd6aedfac.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_1f81a8109d0b7d537c053517a9eef70fbd6aedfac.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_1f81a8109d0b7d537c053517a9eef70fbd6aedfac.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_1f81a8109d0b7d537c053517a9eef70fbd6aedfac.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Create now</a></strong></p>
+            <p><strong>Facebook post</strong></p>
+            <p><em>1080x1080px</em></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_1421e1d8091f13096c9b2220c5ab988c4402fc749.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_1421e1d8091f13096c9b2220c5ab988c4402fc749.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_1421e1d8091f13096c9b2220c5ab988c4402fc749.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_1421e1d8091f13096c9b2220c5ab988c4402fc749.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Create now</a></strong></p>
+            <p><strong>Instagram reel</strong></p>
+            <p><em>1080x1920px</em></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_1947eede9625800eb8235f9a7d8850fd4186ce021.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_1947eede9625800eb8235f9a7d8850fd4186ce021.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_1947eede9625800eb8235f9a7d8850fd4186ce021.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_1947eede9625800eb8235f9a7d8850fd4186ce021.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Create now</a></strong></p>
+            <p><strong>Poster</strong></p>
+            <p><em>11x17in</em></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_172ff54c5ca6d07476814391bfdabf611d76ade1a.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_172ff54c5ca6d07476814391bfdabf611d76ade1a.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_172ff54c5ca6d07476814391bfdabf611d76ade1a.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_172ff54c5ca6d07476814391bfdabf611d76ade1a.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Create now</a></strong></p>
+            <p><strong>YouTube thumbnail</strong></p>
+            <p><em>1280x720px</em></p>
+          </div>
+        </div>
+        <div>
+          <div>
+            <picture>
+              <source type="image/webp" srcset="./media_1cac787544e689a9b5949a552b2e8dd0bf45a12b2.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+              <source type="image/webp" srcset="./media_1cac787544e689a9b5949a552b2e8dd0bf45a12b2.png?width=750&amp;format=webply&amp;optimize=medium">
+              <source type="image/png" srcset="./media_1cac787544e689a9b5949a552b2e8dd0bf45a12b2.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+              <img loading="lazy" alt="" src="./media_1cac787544e689a9b5949a552b2e8dd0bf45a12b2.png?width=750&amp;format=png&amp;optimize=medium" width="400" height="280">
+            </picture>
+          </div>
+          <div>
+            <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Create now</a></strong></p>
+            <p><strong>YouTube video</strong></p>
+            <p><em>1920x1080px</em></p>
+          </div>
+        </div>
+      </div>
+  
+</main>


### PR DESCRIPTION
- Removed all slider scroll logic from puf.js, it now uses the logic from carousel.js.
- Removed all toggling of 1-col and 2-col layouts and the selected slide controls.
- Replaced 4 resize observes with a single observer.
- Added two intersection observers to handle adjusting the containers max height based on the selected slide.
- Fixed sticky arrow control behaviour.

(Still a number of functions to review and refactor in puf.js and a lot of classes can be cleaned up and improved in puf.css)

Resolves: [MWPW-136432](https://jira.corp.adobe.com/browse/MWPW-136432) (I think?)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/?martech=off
- After: https://carousel-fader-effect--express--wbstry.hlx.page/express/?martech=off