### PR TITLE
Fixing safari backdrop webkit bug on colors page

### DIFF
--- a/express/blocks/ckg-link-list/ckg-link-list.css
+++ b/express/blocks/ckg-link-list/ckg-link-list.css
@@ -39,8 +39,9 @@
 
 .ckg-link-list.block .button-container a.button.colorful {
     color: var(--color-white);
+    -webkit-backdrop-filter: brightness(0.7);
     backdrop-filter: brightness(0.7);
-    transition: backdrop-filter 0.2s;
+    transition: backdrop-filter 0.2s, -webkit-backdrop-filter 0.2s;
 }
 
 .ckg-link-list.block .button-container a.button:hover {
@@ -49,10 +50,12 @@
 
 .ckg-link-list.block .button-container a.button.colorful:hover {
     background-color: unset;
+    -webkit-backdrop-filter: brightness(0.6);
     backdrop-filter: brightness(0.6);
 }
 
 .ckg-link-list.block .button-container a.button.colorful:active {
     background-color: unset;
+    -webkit-backdrop-filter: brightness(0.4);
     backdrop-filter: brightness(0.4);
 }


### PR DESCRIPTION
The Color pills at the bottom of the page will now have the same backdrop shading as on chrome

Resolves: [MWPW-138620](https://jira.corp.adobe.com/browse/MWPW-138620)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/colors/pink?martech=off
- After: https://color-safari-bug--express--adobecom.hlx.page/express/colors/pink?martech=off

Goes without saying, please test on Safari 😄