### PR TITLE
Audience no longer case sensitive

### DIFF
--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -512,7 +512,7 @@ export function removeIrrelevantSections(main) {
 
       // section meant for different device
       let sectionRemove = !!(sectionMeta.audience
-        && sectionMeta.audience !== document.body.dataset?.device);
+        && sectionMeta.audience.toLowerCase() !== document.body.dataset?.device);
 
       // section visibility steered over metadata
       if (!sectionRemove && sectionMeta.showwith !== undefined) {


### PR DESCRIPTION
A 1-line fix to always compare lower-case data audience
The authors have been carefully using 'desktop' and 'mobile' everywhere. But if you check [this after draft page](https://audience-case-insensitive--express--adobecom.hlx.page/drafts/qiyundai/create/christmas-autumn?martech=off) you'll see the hero columns block whereas the [before draft page](https://stage--express--adobecom.hlx.page/drafts/qiyundai/create/christmas-autumn?martech=off) will be missing it

Resolves: [MWPW-139055](https://jira.corp.adobe.com/browse/MWPW-139055)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/?martech=off
- After: https://audience-case-insensitive--express--adobecom.hlx.page/express/?martech=off
