### PR TITLE
MWPW-138887 | Removing pricing and alternate name from schemas block

### DIFF
--- a/express/blocks/schemas/schemas.js
+++ b/express/blocks/schemas/schemas.js
@@ -30,7 +30,6 @@ function decorateSchemasBlocks(block) {
         '@type': 'Corporation',
         name: 'Adobe',
         legalName: 'Adobe Inc.',
-        alternateName: 'Adobe Systems Incorporated',
         '@id': 'https://www.adobe.com#organization',
         tickerSymbol: 'ADBE',
         sameAs: [
@@ -56,11 +55,6 @@ function decorateSchemasBlocks(block) {
       creator: { '@id': 'https://www.adobe.com#organization' },
       publisher: { '@id': 'https://www.adobe.com#organization' },
       maintainer: { '@id': 'https://www.adobe.com#organization' },
-      offers: {
-        '@type': 'offer',
-        price: '0.00',
-        priceCurrency: 'INR',
-      },
     },
   };
   webPageSchemaScript.textContent = JSON.stringify(webSchemaJson);


### PR DESCRIPTION
Removing pricing and alternate name from schemas block

Resolves: [MWPW-138887](https://jira.corp.adobe.com/browse/MWPW-138887)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/?martech=off
- After: https://MWPW-138887--express--adobecom.hlx.page/express/?martech=off

test page: https://mwpw-138887--express--adobecom.hlx.page/drafts/apganapa/us-homepage-index?martech=off

<img width="1641" alt="schema-validator-schemas-block" src="https://github.com/adobecom/express/assets/37915358/b9d527ce-a790-4548-bbe7-1cada4008b6f">



