### PR TITLE
carousel.js: better toggle button invocation

### DIFF
--- a/express/blocks/puf/puf.css
+++ b/express/blocks/puf/puf.css
@@ -1,3 +1,7 @@
+main .section.puf-container {
+    padding-bottom: 0;
+}
+
 main .puf-container > div {
     max-width: none;
 }
@@ -327,10 +331,6 @@ main .block.puf .carousel-container .carousel-platform .carousel-left-trigger {
 
 main .block.puf .carousel-container .carousel-platform .carousel-right-trigger {
     right: 0;
-}
-
-main .block.puf .section.puf-container {
-    padding-bottom: 0;
 }
 
 main .block.puf .carousel-container {

--- a/express/blocks/puf/puf.css
+++ b/express/blocks/puf/puf.css
@@ -311,25 +311,25 @@ main .block.puf .puf-card .puf-card-banner a {
     text-decoration: underline;
 }
 
-main .carousel-container .carousel-platform {
+main .block.puf .carousel-container .carousel-platform {
     position: relative;
 }
 
-main .carousel-container .carousel-platform .carousel-left-trigger,
-main .carousel-container .carousel-platform .carousel-right-trigger {
+main .block.puf .carousel-container .carousel-platform .carousel-left-trigger,
+main .block.puf .carousel-container .carousel-platform .carousel-right-trigger {
     align-self: stretch;
     width: 1px;
 }
 
-main .carousel-container .carousel-platform .carousel-left-trigger {
+main .block.puf .carousel-container .carousel-platform .carousel-left-trigger {
     left: 0;
 }
 
-main .carousel-container .carousel-platform .carousel-right-trigger {
+main .block.puf .carousel-container .carousel-platform .carousel-right-trigger {
     right: 0;
 }
 
-main .section.puf-container {
+main .block.puf .section.puf-container {
     padding-bottom: 0;
 }
 
@@ -371,13 +371,13 @@ main .block.puf .puf-card-container {
     align-self: start;
 }
 
-main .carousel-container .carousel-fader-left,
-main .carousel-container .carousel-fader-right {
+main .block.puf .carousel-container .carousel-fader-left,
+main .block.puf .carousel-container .carousel-fader-right {
     margin-top: 100px;
 }
 
-main .carousel-container .carousel-fader-left a.button.carousel-arrow,
-main .carousel-container .carousel-fader-right a.button.carousel-arrow {
+main .block.puf .carousel-container .carousel-fader-left a.button.carousel-arrow,
+main .block.puf .carousel-container .carousel-fader-right a.button.carousel-arrow {
     position: sticky;
     top: calc(50% - 16px);
     bottom: calc(50% - 16px);
@@ -444,8 +444,8 @@ main .block.puf .carousel-container .carousel-platform .puf-card-container .puf-
         padding: 40px 60px;
     }
 
-    main .carousel-container .carousel-platform .carousel-left-trigger,
-    main .carousel-container .carousel-platform .carousel-right-trigger {
+    main .block.puf .carousel-container .carousel-platform .carousel-left-trigger,
+    main .block.puf .carousel-container .carousel-platform .carousel-right-trigger {
         align-self: stretch;
         position: relative;
         height: auto;

--- a/express/blocks/shared/carousel.js
+++ b/express/blocks/shared/carousel.js
@@ -12,6 +12,13 @@ function correctCenterAlignment(plat) {
 export function initToggleTriggers(parent) {
   if (!parent) return;
 
+  const isInHiddenSection = () => {
+    const parentSection = parent.closest('.section');
+    if (!parentSection) return false;
+
+    return parent.dataset.toggle && parent.style.display === 'none';
+  };
+
   const leftControl = parent.querySelector('.carousel-fader-left');
   const rightControl = parent.querySelector('.carousel-fader-right');
   const leftTrigger = parent.querySelector('.carousel-left-trigger');
@@ -20,6 +27,7 @@ export function initToggleTriggers(parent) {
 
   // Left intersection observers to toggle left arrow and gradient
   const onFirstSlideIntersect = ([entry]) => {
+    if (isInHiddenSection()) return;
     if (entry.isIntersecting) {
       leftControl.classList.add('arrow-hidden');
       platform.classList.remove('left-fader');
@@ -30,6 +38,7 @@ export function initToggleTriggers(parent) {
   };
   // Right intersection observers to toggle right arrow and gradient
   const onLastSlideIntersect = ([entry]) => {
+    if (isInHiddenSection()) return;
     if (entry.isIntersecting) {
       rightControl.classList.add('arrow-hidden');
       platform.classList.remove('right-fader');

--- a/express/blocks/shared/carousel.js
+++ b/express/blocks/shared/carousel.js
@@ -16,7 +16,7 @@ export function initToggleTriggers(parent) {
     const parentSection = parent.closest('.section');
     if (!parentSection) return false;
 
-    return parent.dataset.toggle && parent.style.display === 'none';
+    return parentSection.dataset.toggle && parentSection.style.display === 'none';
   };
 
   const leftControl = parent.querySelector('.carousel-fader-left');

--- a/express/blocks/shared/carousel.js
+++ b/express/blocks/shared/carousel.js
@@ -12,12 +12,66 @@ function correctCenterAlignment(plat) {
 export function initToggleTriggers(parent) {
   if (!parent) return;
 
-  const platform = parent.querySelector('.carousel-platform');
   const leftControl = parent.querySelector('.carousel-fader-left');
   const rightControl = parent.querySelector('.carousel-fader-right');
+  const leftTrigger = parent.querySelector('.carousel-left-trigger');
+  const rightTrigger = parent.querySelector('.carousel-right-trigger');
+  const platform = parent.querySelector('.carousel-platform');
+
+  // Left intersection observers to toggle left arrow and gradient
+  const onFirstSlideIntersect = ([entry]) => {
+    if (entry.isIntersecting) {
+      leftControl.classList.add('arrow-hidden');
+      platform.classList.remove('left-fader');
+    } else {
+      leftControl.classList.remove('arrow-hidden');
+      platform.classList.add('left-fader');
+    }
+  };
+  // Right intersection observers to toggle right arrow and gradient
+  const onLastSlideIntersect = ([entry]) => {
+    if (entry.isIntersecting) {
+      rightControl.classList.add('arrow-hidden');
+      platform.classList.remove('right-fader');
+    } else {
+      rightControl.classList.remove('arrow-hidden');
+      platform.classList.add('right-fader');
+    }
+  };
+
+  const options = { threshold: 0, root: parent };
+  const firstSlideObserver = new IntersectionObserver(onFirstSlideIntersect, options);
+  const lastSlideObserver = new IntersectionObserver(onLastSlideIntersect, options);
+  firstSlideObserver.observe(leftTrigger);
+  lastSlideObserver.observe(rightTrigger);
+  // todo: should unobserve triggers where/when appropriate...
+}
+
+export default async function buildCarousel(selector, parent, options = {}) {
+  // Load CSS
+  loadCSS('/express/blocks/shared/carousel.css');
+  // Build the carousel HTML
+  const carouselContent = selector ? parent.querySelectorAll(selector) : parent.querySelectorAll(':scope > *');
+
+  carouselContent.forEach((el) => el.classList.add('carousel-element'));
+
+  const container = createTag('div', { class: 'carousel-container' });
+  const platform = createTag('div', { class: 'carousel-platform' });
 
   const leftTrigger = createTag('div', { class: 'carousel-left-trigger' });
   const rightTrigger = createTag('div', { class: 'carousel-right-trigger' });
+
+  const faderLeft = createTag('div', { class: 'carousel-fader-left arrow-hidden' });
+  const faderRight = createTag('div', { class: 'carousel-fader-right arrow-hidden' });
+
+  const arrowLeft = createTag('a', { class: 'button carousel-arrow carousel-arrow-left' });
+  const arrowRight = createTag('a', { class: 'button carousel-arrow carousel-arrow-right' });
+
+  platform.append(leftTrigger, ...carouselContent, rightTrigger);
+  container.append(platform, faderLeft, faderRight);
+  faderLeft.append(arrowLeft);
+  faderRight.append(arrowRight);
+  parent.appendChild(container);
 
   // If flex container has a gap, add negative margins to compensate
   const gap = window.getComputedStyle(platform, null).getPropertyValue('gap');
@@ -26,63 +80,6 @@ export function initToggleTriggers(parent) {
     leftTrigger.style.marginRight = `-${gapInt + 1}px`;
     rightTrigger.style.marginLeft = `-${gapInt + 1}px`;
   }
-
-  platform.prepend(leftTrigger);
-  platform.append(rightTrigger);
-
-  // Left intersection observers to toggle left arrow and gradient
-  const onFirstSlideIntersect = (entries) => {
-    entries.forEach((entry) => {
-      if (entry.isIntersecting) {
-        leftControl.classList.add('arrow-hidden');
-        platform.classList.remove('left-fader');
-      } else {
-        leftControl.classList.remove('arrow-hidden');
-        platform.classList.add('left-fader');
-      }
-    });
-  };
-  // Right intersection observers to toggle right arrow and gradient
-  const onLastSlideIntersect = (entries) => {
-    entries.forEach((entry) => {
-      if (entry.isIntersecting) {
-        rightControl.classList.add('arrow-hidden');
-        platform.classList.remove('right-fader');
-      } else {
-        rightControl.classList.remove('arrow-hidden');
-        platform.classList.add('right-fader');
-      }
-    });
-  };
-  const firstSlideObserver = new IntersectionObserver(onFirstSlideIntersect, { threshold: 0 });
-  const lastSlideObserver = new IntersectionObserver(onLastSlideIntersect, { threshold: 0 });
-  firstSlideObserver.observe(leftTrigger);
-  lastSlideObserver.observe(rightTrigger);
-  // should unobserve triggers where/when appropriate...
-}
-
-export default async function buildCarousel(selector, parent, options = {}) {
-  // Load CSS
-  loadCSS('/express/blocks/shared/carousel.css');
-  // Build the carousel HTML
-  const carouselContent = selector ? parent.querySelectorAll(selector) : parent.querySelectorAll(':scope > *');
-  carouselContent.forEach((el) => el.classList.add('carousel-element'));
-  const container = createTag('div', { class: 'carousel-container' });
-  const platform = createTag('div', { class: 'carousel-platform' });
-  platform.append(...carouselContent);
-  container.appendChild(platform);
-
-  const faderLeft = createTag('div', { class: 'carousel-fader-left arrow-hidden' });
-  const faderRight = createTag('div', { class: 'carousel-fader-right arrow-hidden' });
-  container.appendChild(faderLeft);
-  container.appendChild(faderRight);
-
-  const arrowLeft = createTag('a', { class: 'button carousel-arrow carousel-arrow-left' });
-  const arrowRight = createTag('a', { class: 'button carousel-arrow carousel-arrow-right' });
-  faderLeft.append(arrowLeft);
-  faderRight.append(arrowRight);
-
-  parent.appendChild(container);
 
   // Scroll the carousel by clicking on the controls
   const moveCarousel = (increment) => {
@@ -154,17 +151,16 @@ export default async function buildCarousel(selector, parent, options = {}) {
       faderLeft.classList.remove('arrow-hidden');
       faderRight.classList.remove('arrow-hidden');
       platform.classList.add('left-fader', 'right-fader');
-    } else {
-      initToggleTriggers(container);
     }
 
-    const onIntersect = (entries, observer) => {
-      entries.forEach((entry) => {
-        if (!entry.isIntersecting) return;
-        if (opts.centerAlign) correctCenterAlignment(scrollable);
-        if (opts.startPosition === 'right') moveCarousel(-scrollable.scrollWidth);
-        observer.unobserve(scrollable);
-      });
+    const onIntersect = ([entry], observer) => {
+      if (!entry.isIntersecting) return;
+
+      if (opts.centerAlign) correctCenterAlignment(scrollable);
+      if (opts.startPosition === 'right') moveCarousel(-scrollable.scrollWidth);
+      if (!opts.infinityScrollEnabled) initToggleTriggers(container);
+
+      observer.unobserve(scrollable);
     };
 
     const carouselObserver = new IntersectionObserver(onIntersect, { threshold: 0 });

--- a/express/blocks/shared/carousel.js
+++ b/express/blocks/shared/carousel.js
@@ -80,7 +80,7 @@ export default async function buildCarousel(selector, parent, options = {}) {
   container.append(platform, faderLeft, faderRight);
   faderLeft.append(arrowLeft);
   faderRight.append(arrowRight);
-  parent.appendChild(container);
+  parent.append(container);
 
   // If flex container has a gap, add negative margins to compensate
   const gap = window.getComputedStyle(platform, null).getPropertyValue('gap');

--- a/express/blocks/shared/carousel.js
+++ b/express/blocks/shared/carousel.js
@@ -25,34 +25,37 @@ export function initToggleTriggers(parent) {
   const rightTrigger = parent.querySelector('.carousel-right-trigger');
   const platform = parent.querySelector('.carousel-platform');
 
-  // Left intersection observers to toggle left arrow and gradient
-  const onFirstSlideIntersect = ([entry]) => {
+  // intersection observer to toggle right arrow and gradient
+  const onSlideIntersect = (entries) => {
     if (isInHiddenSection()) return;
-    if (entry.isIntersecting) {
-      leftControl.classList.add('arrow-hidden');
-      platform.classList.remove('left-fader');
-    } else {
-      leftControl.classList.remove('arrow-hidden');
-      platform.classList.add('left-fader');
-    }
-  };
-  // Right intersection observers to toggle right arrow and gradient
-  const onLastSlideIntersect = ([entry]) => {
-    if (isInHiddenSection()) return;
-    if (entry.isIntersecting) {
-      rightControl.classList.add('arrow-hidden');
-      platform.classList.remove('right-fader');
-    } else {
-      rightControl.classList.remove('arrow-hidden');
-      platform.classList.add('right-fader');
-    }
+
+    entries.forEach((entry) => {
+      if (entry.target === leftTrigger) {
+        if (entry.isIntersecting) {
+          leftControl.classList.add('arrow-hidden');
+          platform.classList.remove('left-fader');
+        } else {
+          leftControl.classList.remove('arrow-hidden');
+          platform.classList.add('left-fader');
+        }
+      }
+
+      if (entry.target === rightTrigger) {
+        if (entry.isIntersecting) {
+          rightControl.classList.add('arrow-hidden');
+          platform.classList.remove('right-fader');
+        } else {
+          rightControl.classList.remove('arrow-hidden');
+          platform.classList.add('right-fader');
+        }
+      }
+    });
   };
 
   const options = { threshold: 0, root: parent };
-  const firstSlideObserver = new IntersectionObserver(onFirstSlideIntersect, options);
-  const lastSlideObserver = new IntersectionObserver(onLastSlideIntersect, options);
-  firstSlideObserver.observe(leftTrigger);
-  lastSlideObserver.observe(rightTrigger);
+  const slideObserver = new IntersectionObserver(onSlideIntersect, options);
+  slideObserver.observe(leftTrigger);
+  slideObserver.observe(rightTrigger);
   // todo: should unobserve triggers where/when appropriate...
 }
 


### PR DESCRIPTION
The toggle button should now be hidden by default and only appear when intersecting. It used to be the other way around which shows the buttons first and hide if not needed.

Resolves: [MWPW-136432](https://jira.corp.adobe.com/browse/MWPW-136432)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://carousel-toggle-enhance--express--adobecom.hlx.page/express/?martech=off
