### PR TITLE
Template X sixcols design regression fix

### DIFF
--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -9,7 +9,6 @@ div[class='section section-wrapper browse-by-category-card-fullwidth-container t
     padding: 0;
 }
 
-.template-x > .default-content-wrapper,
 .template-x > .default-content-wrapper {
     padding: 0 15px;
 }
@@ -1612,7 +1611,6 @@ main .template-x-wrapper.horizontal > .template-x.horizontal.tabbed > .template-
     left: -4px
 }
 
-
 .template-x.horizontal.holiday .template-x-inner-wrapper .carousel-container {
     max-width: 1090px;
 }
@@ -2458,25 +2456,6 @@ nav ol.templates-breadcrumbs li:not(:first-child):before {
         padding-right: 6px;
     }
 
-    .template-x.with-categories-list .category-list-wrapper ul > li > a {
-        font-family: var(--body-font-family);
-        color: var(--color-black);
-        font-weight: 400;
-        font-size: 14px;
-        line-height: 24px;
-        cursor: pointer;
-        user-select: none;
-        display: flex;
-        align-items: center;
-        white-space: nowrap;
-    }
-
-    .template-x.with-categories-list .category-list-wrapper ul > li > a > .category-list-template-count {
-        font-family: var(--body-font-family);
-        margin-left: 2px;
-        font-size: 14px;
-    }
-
     .template-x.with-categories-list .category-list::before {
         content: '';
         z-index: 0;
@@ -2516,6 +2495,159 @@ nav ol.templates-breadcrumbs li:not(:first-child):before {
         padding-left: 56px;
     }
 
+    .template-x.horizontal .carousel-container {
+        margin-left: auto;
+        margin-right: auto;
+        display: block;
+    }
+
+    .template-x.horizontal.fullwidth .carousel-container {
+        margin-bottom: 20px;
+        max-width: none;
+        display: block;
+    }
+
+    .template-x.horizontal.fullwidth .carousel-container .carousel-fader-left,
+    .template-x.horizontal.fullwidth .carousel-container .carousel-fader-right {
+        width: 150px;
+    }
+
+    .template-x .api-templates-toolbar {
+        border-radius: 12px;
+    }
+
+    .template-x .api-templates-toolbar .wrapper-functions .functions-container {
+        display: flex;
+    }
+
+    .template-x .api-templates-toolbar .functions-drawer {
+        display: none;
+    }
+
+    .template-x .api-templates-toolbar .wrapper-content-search {
+        flex-basis: unset;
+        padding-right: 16px;
+    }
+
+    .template-x .api-templates-toolbar .functions-drawer .function-sort:hover .options-wrapper {
+        display: flex;
+    }
+
+    .template-x .api-templates-toolbar .functions-drawer .function-sort:hover .button-wrapper .icon.icon-drop-down-arrow {
+        transform: rotate(180deg);
+    }
+
+    .template-x-horizontal-holiday-container {
+        padding-bottom: 0;
+    }
+
+    .template-x-horizontal-holiday-container .toggle-bar {
+        max-width: 1024px;
+    }
+
+    .template-x-horizontal-holiday-container .mobile-only {
+        display: none;
+    }
+
+    .template-x-horizontal-holiday-container .toggle-bar-bottom {
+        display: flex;
+    }
+
+    .template-x-horizontal-holiday-container .template-x-wrapper.expanded {
+        padding-top: 0;
+    }
+
+    .template-x .template-x-fallback-msg-wrapper {
+        padding-left: 60px;
+        text-align: left;
+    }
+
+    .template-x-wrapper.fourcols {
+        max-width: 1200px;
+    }
+
+    .template-x-wrapper.sixcols {
+        max-width: 1122px;
+    }
+
+    .template-x-wrapper.fullwidth {
+        max-width: none;
+    }
+
+    /* template-x inside columns */
+
+    .columns .template-x-inner-wrapper {
+        flex-direction: row;
+        flex-wrap: nowrap;
+        justify-content: flex-start;
+    }
+
+    .columns .template-x .template {
+        justify-content: flex-start;
+        min-width: 132px;
+    }
+
+    .columns .template-x .template-link {
+        font-size: 0.875rem;
+        font-weight: 400;
+    }
+
+    .template-x.fullwidth.with-categories-list .template-x-inner-wrapper {
+        padding-left: 40px;
+        padding-right: 0;
+    }
+
+    .template-x.with-categories-list .category-list-wrapper ul {
+        position: relative;
+        list-style: none;
+        max-height: 800px;
+        overflow: hidden;
+        transition: max-height 0.2s;
+        padding-left: 0;
+    }
+
+    .template-x.with-categories-list .category-list-wrapper ul > li {
+        margin-bottom: 4px;
+        border-radius: 8px;
+        transition: background-color .2s, color .2s;
+    }
+
+    .template-x.with-categories-list .category-list-wrapper ul > li {
+        padding: 4px 8px;
+    }
+
+    .template-x.with-categories-list .category-list-wrapper ul > li.active > a {
+        color: var(--color-info-accent);
+        font-weight: 600;
+    }
+
+    .template-x.with-categories-list .category-list-wrapper ul > li .icon {
+        height: 18px;
+        width: 18px;
+        min-width: 18px;
+        display: block;
+        padding-right: 6px;
+    }
+
+    .template-x.with-categories-list .category-list-wrapper ul > li > a {
+        font-family: var(--body-font-family);
+        color: var(--color-black);
+        font-weight: 400;
+        font-size: 14px;
+        line-height: 24px;
+        cursor: pointer;
+        user-select: none;
+        display: flex;
+        align-items: center;
+        white-space: nowrap;
+    }
+
+    .template-x.with-categories-list .category-list-wrapper ul > li > a > .category-list-template-count {
+        font-family: var(--body-font-family);
+        margin-left: 2px;
+        font-size: 14px;
+    }
+
     .template-x.horizontal .carousel-container.controls-hidden .carousel-fader-left,
     .template-x.horizontal .carousel-container.controls-hidden .carousel-fader-right {
         opacity: unset;
@@ -2539,12 +2671,6 @@ nav ol.templates-breadcrumbs li:not(:first-child):before {
 
     .template-x.horizontal .carousel-container.controls-hidden .carousel-platform {
         scroll-snap-type: x mandatory;
-    }
-
-    .template-x.horizontal .carousel-container {
-        margin-left: auto;
-        margin-right: auto;
-        display: block;
     }
 
     .template-x.horizontal.fullwidth .carousel-container {


### PR DESCRIPTION
carousel.js refactor ended up introducing a small regression on template x 'sixcols' design max-width, making it look more like 'fourcols' rather than 'sixcols'. This PR will fix it.

Resolves: [MWPW-136432](https://jira.corp.adobe.com/browse/MWPW-136432)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/create/logo?martech=off
- After: https://template-x-sixcols-fix--express--adobecom.hlx.page/express/create/logo?martech=off
