### PR TITLE
Template-list and Templates CKG link list carousel bug fix

### DIFF
--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -1587,7 +1587,7 @@ export async function decorateTemplateList($block, props) {
         }
       }
 
-      if (placeholders['template-filter-premium'] && !$block.classList.contains('mini')) {
+      if (placeholders['template-filter-premium'] && !$block.classList.contains('horizontal')) {
         document.addEventListener('linkspopulated', async (e) => {
           // desktop/mobile fires the same event
           if ($parent.contains(e.detail[0])) {

--- a/express/scripts/template-ckg.js
+++ b/express/scripts/template-ckg.js
@@ -73,10 +73,16 @@ function replaceLinkPill(linkPill, data) {
 }
 
 async function updateSEOLinkList(container, linkPill, list) {
+  const leftTrigger = container.querySelector('.carousel-left-trigger');
+  const rightTrigger = container.querySelector('.carousel-right-trigger');
+
   container.innerHTML = '';
+
   const templatePages = await fetchAllTemplatesMetadata();
 
   if (list && templatePages) {
+    if (leftTrigger) container.append(leftTrigger);
+
     list.forEach((d) => {
       const currentLocale = getLocale(window.location);
       const templatePageData = templatePages.find((p) => {
@@ -88,11 +94,13 @@ async function updateSEOLinkList(container, linkPill, list) {
         return isLive && titleMatch && localeMatch;
       });
 
-      if (templatePageData) {
-        const clone = replaceLinkPill(linkPill, templatePageData);
-        if (clone) container.append(clone);
-      }
+      if (!templatePageData) return;
+
+      const clone = replaceLinkPill(linkPill, templatePageData);
+      if (clone) container.append(clone);
     });
+
+    if (rightTrigger) container.append(rightTrigger);
   }
 }
 
@@ -127,6 +135,8 @@ async function updateLinkList(container, linkPill, list) {
   const pillsMapping = await memoizedGetPillWordsMapping();
   const pageLinks = [];
   const searchLinks = [];
+  const leftTrigger = container.querySelector('.carousel-left-trigger');
+  const rightTrigger = container.querySelector('.carousel-right-trigger');
   container.innerHTML = '';
 
   if (list && templatePages) {
@@ -172,11 +182,13 @@ async function updateLinkList(container, linkPill, list) {
       }
     });
 
+    if (leftTrigger) container.append(leftTrigger);
     pageLinks.concat(searchLinks).forEach((clone) => {
       container.append(clone);
     });
+    if (rightTrigger) container.append(rightTrigger);
 
-    if (container.children.length === 0) {
+    if (container.children.length === 2) {
       const linkListData = [];
 
       window.linkLists.sheetData.forEach((row) => {


### PR DESCRIPTION
Fixes:
All template-list horizontal versions except for 'mini' are trying to decorate a tool bar.
The carousel triggers behave slightly off on templates pages because the tiggers got wiped by template-ckg.js.

Resolves: [MWPW-139100](https://jira.corp.adobe.com/browse/MWPW-139100)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/templates/flyer?martech=off
- After: https://template-list-console-error--express--adobecom.hlx.page/express/templates/flyer?martech=off
