### PR TITLE
fix tool-tip pointer issue

### DIFF
--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -2074,7 +2074,7 @@ main .template-x-wrapper.horizontal > .template-x.horizontal.tabbed > .template-
     border-color: transparent #33AB84 transparent transparent;
 }
 
-.template-x.horizontal .template:last-of-type .button-container .media-wrapper .share-icon-wrapper .shared-tooltip::after {
+.template-x.horizontal .template:nth-last-of-type(2) .button-container .media-wrapper .share-icon-wrapper .shared-tooltip::after {
     right: unset;
     left: 100%;
     border-color: transparent transparent transparent #33AB84;


### PR DESCRIPTION
The clipboard tooltip was not pointing at the correct side.
![Screenshot 2023-11-10 at 1 40 31 PM](https://github.com/adobecom/express/assets/57737624/0467a114-9780-44e9-a3e8-ebef82280ab9)
![Screenshot 2023-11-10 at 1 40 25 PM](https://github.com/adobecom/express/assets/57737624/5a7ced32-b78c-4832-ba68-8d6faf3428e0)

Resolves: [MWPW-139080](https://jira.corp.adobe.com/browse/MWPW-139080)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/?martech=off
- After: https://tool-tip-fix--express--adobecom.hlx.page/express/?martech=off
