### PR TITLE
Floating CTA scroll arrow disable control

### DIFF
--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -237,7 +237,7 @@ export async function createFloatingButton(block, audience, data) {
     },
   }));
 
-  if (data.useLottieArrow !== 'no') {
+  if (data.useLottieArrow) {
     const heroCTA = document.querySelector('a.button.same-as-floating-button-CTA');
     if (heroCTA) {
       const hideButtonWhenIntersecting = new IntersectionObserver(([e]) => {
@@ -279,6 +279,7 @@ export async function createFloatingButton(block, audience, data) {
     document.dispatchEvent(new CustomEvent('linkspopulated', { detail: [floatButtonLink, lottieScrollButton] }));
   } else {
     data.scrollState = 'withoutLottie';
+    floatButtonWrapper.classList.add('floating-button--scrolled');
     document.dispatchEvent(new CustomEvent('linkspopulated', { detail: [floatButtonLink] }));
   }
 
@@ -308,6 +309,7 @@ export async function collectFloatingButtonData() {
 
   const data = {
     scrollState: 'withLottie',
+    useLottieArrow: true,
     delay: 3,
     tools: [],
     appStore: {},
@@ -351,7 +353,7 @@ export async function collectFloatingButtonData() {
     }
 
     if (key === 'use lottie arrow') {
-      data.useLottieArrow = value;
+      data.useLottieArrow = !['no', 'N', 'false', 'off'].includes(value);
     }
 
     for (let i = 1; i < 7; i += 1) {

--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -11,202 +11,209 @@ import {
 
 import BlockMediator from '../../scripts/block-mediator.min.js';
 
-export const hideScrollArrow = ($floatButtonWrapper, $lottieScrollButton) => {
-  $floatButtonWrapper.classList.add('floating-button--scrolled');
-  if (document.activeElement === $lottieScrollButton) $lottieScrollButton.blur();
-  $lottieScrollButton.tabIndex = -1;
+export const hideScrollArrow = (floatButtonWrapper, lottieScrollButton) => {
+  floatButtonWrapper.classList.add('floating-button--scrolled');
+  if (document.activeElement === lottieScrollButton) lottieScrollButton.blur();
+  lottieScrollButton.tabIndex = -1;
 };
 
-export const showScrollArrow = ($floatButtonWrapper, $lottieScrollButton) => {
-  $floatButtonWrapper.classList.remove('floating-button--scrolled');
-  $lottieScrollButton.removeAttribute('tabIndex');
+export const showScrollArrow = (floatButtonWrapper, lottieScrollButton) => {
+  floatButtonWrapper.classList.remove('floating-button--scrolled');
+  lottieScrollButton.removeAttribute('tabIndex');
 };
 
-export function openToolBox($wrapper, $lottie, data, userInitiated) {
-  const $toolbox = $wrapper.querySelector('.toolbox');
-  const $button = $wrapper.querySelector('.floating-button');
+export function openToolBox(wrapper, lottie, data, userInitiated) {
+  const toolbox = wrapper.querySelector('.toolbox');
+  const button = wrapper.querySelector('.floating-button');
 
-  const $scrollAnchor = document.querySelector('.section:not(:nth-child(1)):not(:nth-child(2)) .template-list, .section:not(:nth-child(1)):not(:nth-child(2)) .layouts, .section:not(:nth-child(1)):not(:nth-child(2)) .steps-highlight-container') ?? document.querySelector('.section:nth-child(3)');
-  if (data.scrollState === 'withLottie' && $scrollAnchor) {
-    showScrollArrow($wrapper, $lottie);
+  const scrollAnchor = document.querySelector('.section:not(:nth-child(1)):not(:nth-child(2)) .template-list, .section:not(:nth-child(1)):not(:nth-child(2)) .layouts, .section:not(:nth-child(1)):not(:nth-child(2)) .steps-highlight-container') ?? document.querySelector('.section:nth-child(3)');
+  if (data.scrollState === 'withLottie' && scrollAnchor) {
+    showScrollArrow(wrapper, lottie);
   }
-  $wrapper.classList.remove('toolbox-opened');
+  wrapper.classList.remove('toolbox-opened');
   if (userInitiated) {
     setTimeout(() => {
-      if (!$wrapper.classList.contains('toolbox-opened')) {
-        $toolbox.classList.add('hidden');
-        $wrapper.classList.remove('clamped');
-        $button.classList.remove('toolbox-opened');
+      if (!wrapper.classList.contains('toolbox-opened')) {
+        toolbox.classList.add('hidden');
+        wrapper.classList.remove('clamped');
+        button.classList.remove('toolbox-opened');
       }
     }, 500);
   } else {
     setTimeout(() => {
-      if ($wrapper.classList.contains('initial-load')) {
-        $toolbox.classList.add('hidden');
-        $wrapper.classList.remove('clamped');
-        $button.classList.remove('toolbox-opened');
+      if (wrapper.classList.contains('initial-load')) {
+        toolbox.classList.add('hidden');
+        wrapper.classList.remove('clamped');
+        button.classList.remove('toolbox-opened');
       }
     }, 2000);
   }
 }
 
-export function closeToolBox($wrapper, $lottie) {
-  const $toolbox = $wrapper.querySelector('.toolbox');
-  const $button = $wrapper.querySelector('.floating-button');
+export function closeToolBox(wrapper, lottie) {
+  const toolbox = wrapper.querySelector('.toolbox');
+  const button = wrapper.querySelector('.floating-button');
 
-  $toolbox.classList.remove('hidden');
-  $wrapper.classList.add('clamped');
-  $button.classList.add('toolbox-opened');
-  hideScrollArrow($wrapper, $lottie);
+  toolbox.classList.remove('hidden');
+  wrapper.classList.add('clamped');
+  button.classList.add('toolbox-opened');
+  hideScrollArrow(wrapper, lottie);
 
   setTimeout(() => {
-    $wrapper.classList.add('toolbox-opened');
+    wrapper.classList.add('toolbox-opened');
   }, 10);
 }
 
-export function initLottieArrow($lottieScrollButton, $floatButtonWrapper, $scrollAnchor, data) {
+export function initLottieArrow(lottieScrollButton, floatButtonWrapper, scrollAnchor, data) {
   let clicked = false;
-  $lottieScrollButton.addEventListener('click', () => {
+  lottieScrollButton.addEventListener('click', () => {
     clicked = true;
-    $floatButtonWrapper.classList.add('floating-button--clicked');
+    floatButtonWrapper.classList.add('floating-button--clicked');
     window.scrollTo({
-      top: $scrollAnchor.offsetTop,
+      top: scrollAnchor.offsetTop,
       behavior: 'smooth',
     });
     const checkIfScrollToIsFinished = setInterval(() => {
-      if ($scrollAnchor.offsetTop <= window.scrollY) {
+      if (scrollAnchor.offsetTop <= window.scrollY) {
         clicked = false;
-        $floatButtonWrapper.classList.remove('floating-button--clicked');
+        floatButtonWrapper.classList.remove('floating-button--clicked');
         clearInterval(checkIfScrollToIsFinished);
       }
     }, 200);
-    hideScrollArrow($floatButtonWrapper, $lottieScrollButton);
+    hideScrollArrow(floatButtonWrapper, lottieScrollButton);
   });
 
   window.addEventListener('scroll', () => {
-    data.scrollState = $floatButtonWrapper.classList.contains('floating-button--scrolled') ? 'withoutLottie' : 'withLottie';
-    const multiFunctionButtonOpened = $floatButtonWrapper.classList.contains('toolbox-opened');
+    data.scrollState = floatButtonWrapper.classList.contains('floating-button--scrolled') ? 'withoutLottie' : 'withLottie';
+    const multiFunctionButtonOpened = floatButtonWrapper.classList.contains('toolbox-opened');
     if (clicked) return;
-    if ($scrollAnchor.getBoundingClientRect().top < 100) {
-      hideScrollArrow($floatButtonWrapper, $lottieScrollButton);
+    if (scrollAnchor.getBoundingClientRect().top < 100) {
+      hideScrollArrow(floatButtonWrapper, lottieScrollButton);
     } else if (!multiFunctionButtonOpened) {
-      showScrollArrow($floatButtonWrapper, $lottieScrollButton);
+      showScrollArrow(floatButtonWrapper, lottieScrollButton);
     }
   }, { passive: true });
 }
 
-function makeCTAFromSheet($block, data) {
-  const audience = $block.querySelector(':scope > div').textContent.trim();
+function makeCTAFromSheet(block, data) {
+  const audience = block.querySelector(':scope > div').textContent.trim();
   const audienceSpecificUrl = audience && ['desktop', 'mobile'].includes(audience) ? data.mainCta[`${audience}Href`] : null;
-  const $buttonContainer = createTag('div', { class: 'button-container' });
+  const buttonContainer = createTag('div', { class: 'button-container' });
   const ctaFromSheet = createTag('a', { href: audienceSpecificUrl || data.mainCta.href, title: data.mainCta.text });
   ctaFromSheet.textContent = data.mainCta.text;
-  $buttonContainer.append(ctaFromSheet);
-  $block.append($buttonContainer);
+  buttonContainer.append(ctaFromSheet);
+  block.append(buttonContainer);
 
   return ctaFromSheet;
 }
 
-export async function createFloatingButton($block, audience, data) {
-  const $a = makeCTAFromSheet($block, data);
+function buildLottieArrow(wrapper, floatingBtn, data) {
+  const lottieScrollButton = createTag(
+    'button',
+    { class: 'floating-button-lottie' },
+    getLottie('purple-arrows', '/express/icons/purple-arrows.json'),
+  );
+
+  fetchPlaceholders().then((placeholders) => {
+    lottieScrollButton.setAttribute('aria-label', placeholders['see-more']);
+  });
+
+  floatingBtn.append(lottieScrollButton);
+
+  // Floating button scroll/click events
+  lazyLoadLottiePlayer();
+  const scrollAnchor = document.querySelector('.section:not(:nth-child(1)):not(:nth-child(2)) .template-list, .section:not(:nth-child(1)):not(:nth-child(2)) .layouts, .section:not(:nth-child(1)):not(:nth-child(2)) .steps-highlight-container') ?? document.querySelector('.section:nth-child(3)');
+  if (!scrollAnchor) {
+    hideScrollArrow(wrapper, lottieScrollButton);
+  } else {
+    initLottieArrow(lottieScrollButton, wrapper, scrollAnchor, data);
+  }
+
+  return lottieScrollButton;
+}
+
+export async function createFloatingButton(block, audience, data) {
+  const aTag = makeCTAFromSheet(block, data);
   const main = document.querySelector('main');
   loadCSS('/express/blocks/shared/floating-cta.css');
 
   // Floating button html
-  const $floatButtonLink = $a.cloneNode(true);
-  $floatButtonLink.className = '';
-  $floatButtonLink.classList.add('button', 'gradient', 'xlarge');
+  const floatButtonLink = aTag.cloneNode(true);
+  floatButtonLink.className = '';
+  floatButtonLink.classList.add('button', 'gradient', 'xlarge');
 
   // Hide CTAs with same url & text as the Floating CTA && is NOT a Floating CTA (in mobile/tablet)
   const sameUrlCTAs = Array.from(main.querySelectorAll('a.button:any-link'))
-    .filter((a) => (a.textContent.trim() === $a.textContent.trim() || a.href === $a.href)
+    .filter((a) => (a.textContent.trim() === aTag.textContent.trim() || a.href === aTag.href)
       && !a.parentElement.parentElement.classList.contains('floating-button'));
   sameUrlCTAs.forEach((cta) => {
     cta.classList.add('same-as-floating-button-CTA');
   });
 
-  const $floatButtonWrapperOld = $a.closest('.floating-button-wrapper');
-  const $floatButtonWrapper = createTag('div', { class: 'floating-button-wrapper' });
-  const $floatButton = createTag('div', {
+  const floatButtonWrapperOld = aTag.closest('.floating-button-wrapper');
+  const floatButtonWrapper = createTag('div', { class: 'floating-button-wrapper' });
+  const floatButton = createTag('div', {
     class: 'floating-button block',
     'data-block-name': 'floating-button',
     'data-block-status': 'loaded',
   });
-  const $floatButtonInnerWrapper = createTag('div', { class: 'floating-button-inner-wrapper' });
-  const $floatButtonBackground = createTag('div', { class: 'floating-button-background' });
-  const $lottieScrollButton = createTag('button', { class: 'floating-button-lottie' });
+  const floatButtonInnerWrapper = createTag('div', { class: 'floating-button-inner-wrapper' });
+  const floatButtonBackground = createTag('div', { class: 'floating-button-background' });
 
   if (audience) {
-    $floatButtonWrapper.dataset.audience = audience;
-    $floatButtonWrapper.dataset.sectionStatus = 'loaded';
+    floatButtonWrapper.dataset.audience = audience;
+    floatButtonWrapper.dataset.sectionStatus = 'loaded';
   }
 
-  $lottieScrollButton.innerHTML = getLottie('purple-arrows', '/express/icons/purple-arrows.json');
-  fetchPlaceholders().then((placeholders) => {
-    $lottieScrollButton.setAttribute('aria-label', placeholders['see-more']);
-  });
-
-  const linksPopulated = new CustomEvent('linkspopulated', { detail: [$floatButtonLink, $lottieScrollButton] });
-  document.dispatchEvent(linksPopulated);
-
-  $floatButtonInnerWrapper.append($floatButtonBackground, $floatButtonLink);
-  $floatButton.append($floatButtonInnerWrapper, $lottieScrollButton);
-  $floatButtonWrapper.append($floatButton);
-  main.append($floatButtonWrapper);
-  if ($floatButtonWrapperOld) {
-    const $parent = $floatButtonWrapperOld.parentElement;
-    if ($parent && $parent.children.length === 1) {
-      $parent.remove();
+  floatButtonInnerWrapper.append(floatButtonBackground, floatButtonLink);
+  floatButton.append(floatButtonInnerWrapper);
+  floatButtonWrapper.append(floatButton);
+  main.append(floatButtonWrapper);
+  if (floatButtonWrapperOld) {
+    const parent = floatButtonWrapperOld.parentElement;
+    if (parent && parent.children.length === 1) {
+      parent.remove();
     } else {
-      $floatButtonWrapperOld.remove();
+      floatButtonWrapperOld.remove();
     }
   }
 
-  // Floating button scroll/click events
-  lazyLoadLottiePlayer();
-  const $scrollAnchor = document.querySelector('.section:not(:nth-child(1)):not(:nth-child(2)) .template-list, .section:not(:nth-child(1)):not(:nth-child(2)) .layouts, .section:not(:nth-child(1)):not(:nth-child(2)) .steps-highlight-container') ?? document.querySelector('.section:nth-child(3)');
-  if (!$scrollAnchor) {
-    hideScrollArrow($floatButtonWrapper, $lottieScrollButton);
-  } else {
-    initLottieArrow($lottieScrollButton, $floatButtonWrapper, $scrollAnchor, data);
-  }
-
   const promoBar = BlockMediator.get('promobar');
-  const currentBottom = parseInt($floatButtonWrapper.style.bottom, 10);
+  const currentBottom = parseInt(floatButtonWrapper.style.bottom, 10);
   let promoBarHeight;
   if (promoBar) {
     const promoBarMargin = parseInt(window.getComputedStyle(promoBar.block).marginBottom, 10);
     promoBarHeight = promoBarMargin + promoBar.block.offsetHeight;
   }
 
-  if (promoBar && promoBar.rendered && $floatButtonWrapper.dataset.audience !== 'desktop') {
-    $floatButton.style.bottom = currentBottom ? `${currentBottom + promoBarHeight}px` : `${promoBarHeight}px`;
+  if (promoBar && promoBar.rendered && floatButtonWrapper.dataset.audience !== 'desktop') {
+    floatButton.style.bottom = currentBottom ? `${currentBottom + promoBarHeight}px` : `${promoBarHeight}px`;
   } else {
-    $floatButton.style.removeProperty('bottom');
+    floatButton.style.removeProperty('bottom');
   }
 
   BlockMediator.subscribe('promobar', (e) => {
-    if (!e.newValue.rendered && $floatButtonWrapper.dataset.audience !== 'desktop') {
-      $floatButton.style.bottom = currentBottom ? `${currentBottom - promoBarHeight}px` : '';
+    if (!e.newValue.rendered && floatButtonWrapper.dataset.audience !== 'desktop') {
+      floatButton.style.bottom = currentBottom ? `${currentBottom - promoBarHeight}px` : '';
     } else {
-      $floatButton.style.removeProperty('bottom');
+      floatButton.style.removeProperty('bottom');
     }
   });
 
   // Intersection observer - hide button when scrolled to footer
-  const $footer = document.querySelector('footer');
-  if ($footer) {
+  const footer = document.querySelector('footer');
+  if (footer) {
     const hideButtonWhenFooter = new IntersectionObserver((entries) => {
       const entry = entries[0];
       if (entry.intersectionRatio > 0 || entry.isIntersecting) {
-        $floatButtonWrapper.classList.add('floating-button--hidden');
-        $floatButton.style.bottom = '0px';
+        floatButtonWrapper.classList.add('floating-button--hidden');
+        floatButton.style.bottom = '0px';
       } else {
-        $floatButtonWrapper.classList.remove('floating-button--hidden');
+        floatButtonWrapper.classList.remove('floating-button--hidden');
         if (promoBar && promoBar.block) {
-          $floatButton.style.bottom = currentBottom ? `${currentBottom + promoBarHeight}px` : `${promoBarHeight}px`;
+          floatButton.style.bottom = currentBottom ? `${currentBottom + promoBarHeight}px` : `${promoBarHeight}px`;
         } else if (currentBottom) {
-          $floatButton.style.bottom = currentBottom;
+          floatButton.style.bottom = currentBottom;
         }
       }
     }, {
@@ -216,34 +223,34 @@ export async function createFloatingButton($block, audience, data) {
     });
 
     if (document.readyState === 'complete') {
-      hideButtonWhenFooter.observe($footer);
+      hideButtonWhenFooter.observe(footer);
     } else {
       window.addEventListener('load', () => {
-        hideButtonWhenFooter.observe($footer);
+        hideButtonWhenFooter.observe(footer);
       });
     }
   }
 
-  const $heroCTA = document.querySelector('a.button.same-as-floating-button-CTA');
-  if ($heroCTA) {
+  const heroCTA = document.querySelector('a.button.same-as-floating-button-CTA');
+  if (heroCTA) {
     const hideButtonWhenIntersecting = new IntersectionObserver((entries) => {
-      const $e = entries[0];
-      if ($e.boundingClientRect.top > window.innerHeight - 40 || $e.boundingClientRect.top === 0) {
-        $floatButtonWrapper.classList.remove('floating-button--below-the-fold');
-        $floatButtonWrapper.classList.add('floating-button--above-the-fold');
+      const e = entries[0];
+      if (e.boundingClientRect.top > window.innerHeight - 40 || e.boundingClientRect.top === 0) {
+        floatButtonWrapper.classList.remove('floating-button--below-the-fold');
+        floatButtonWrapper.classList.add('floating-button--above-the-fold');
       } else {
-        $floatButtonWrapper.classList.add('floating-button--below-the-fold');
-        $floatButtonWrapper.classList.remove('floating-button--above-the-fold');
+        floatButtonWrapper.classList.add('floating-button--below-the-fold');
+        floatButtonWrapper.classList.remove('floating-button--above-the-fold');
       }
-      if ($e.intersectionRatio > 0 || $e.isIntersecting) {
-        $floatButtonWrapper.classList.add('floating-button--intersecting');
-        $floatButton.style.bottom = '0px';
+      if (e.intersectionRatio > 0 || e.isIntersecting) {
+        floatButtonWrapper.classList.add('floating-button--intersecting');
+        floatButton.style.bottom = '0px';
       } else {
-        $floatButtonWrapper.classList.remove('floating-button--intersecting');
+        floatButtonWrapper.classList.remove('floating-button--intersecting');
         if (promoBar && promoBar.block) {
-          $floatButton.style.bottom = currentBottom ? `${currentBottom + promoBarHeight}px` : `${promoBarHeight}px`;
+          floatButton.style.bottom = currentBottom ? `${currentBottom + promoBarHeight}px` : `${promoBarHeight}px`;
         } else if (currentBottom) {
-          $floatButton.style.bottom = currentBottom;
+          floatButton.style.bottom = currentBottom;
         }
       }
     }, {
@@ -252,23 +259,30 @@ export async function createFloatingButton($block, audience, data) {
       threshold: 0,
     });
     if (document.readyState === 'complete') {
-      hideButtonWhenIntersecting.observe($heroCTA);
+      hideButtonWhenIntersecting.observe(heroCTA);
     } else {
       window.addEventListener('load', () => {
-        hideButtonWhenIntersecting.observe($heroCTA);
+        hideButtonWhenIntersecting.observe(heroCTA);
       });
     }
   } else {
-    $floatButtonWrapper.classList.add('floating-button--above-the-fold');
+    floatButtonWrapper.classList.add('floating-button--above-the-fold');
   }
 
   document.dispatchEvent(new CustomEvent('floatingbuttonloaded', {
     detail: {
-      block: $floatButtonWrapper,
+      block: floatButtonWrapper,
     },
   }));
 
-  return $floatButtonWrapper;
+  if (data.useLottieArrow !== 'no') {
+    const lottieScrollButton = buildLottieArrow(floatButtonWrapper, floatButton, data);
+    document.dispatchEvent(new CustomEvent('linkspopulated', { detail: [floatButtonLink, lottieScrollButton] }));
+  } else {
+    document.dispatchEvent(new CustomEvent('linkspopulated', { detail: [floatButtonLink] }));
+  }
+
+  return floatButtonWrapper;
 }
 
 export async function collectFloatingButtonData() {
@@ -340,12 +354,12 @@ export async function collectFloatingButtonData() {
       if (key === `cta ${i} icon`) {
         const [, href] = array[index + 1];
         const [, text] = array[index + 2];
-        const $icon = getIconElement(value);
-        const $a = createTag('a', { title: text, href });
-        $a.textContent = text;
+        const icon = getIconElement(value);
+        const aTag = createTag('a', { title: text, href });
+        aTag.textContent = text;
         data.tools.push({
-          icon: $icon,
-          anchor: $a,
+          icon,
+          anchor: aTag,
         });
       }
     }
@@ -355,82 +369,82 @@ export async function collectFloatingButtonData() {
 }
 
 export function decorateBadge() {
-  const $anchor = createTag('a');
+  const anchor = createTag('a');
   const OS = getMobileOperatingSystem();
 
-  if ($anchor) {
-    $anchor.textContent = '';
-    $anchor.classList.add('badge');
+  if (anchor) {
+    anchor.textContent = '';
+    anchor.classList.add('badge');
 
     if (OS === 'iOS') {
-      $anchor.append(getIconElement('apple-store'));
+      anchor.append(getIconElement('apple-store'));
     } else {
-      $anchor.append(getIconElement('google-store'));
+      anchor.append(getIconElement('google-store'));
     }
   }
 
-  return $anchor;
+  return anchor;
 }
 
-export function buildToolBoxStructure($wrapper, data) {
-  const $toolBox = createTag('div', { class: 'toolbox' });
-  const $toolBoxWrapper = createTag('div', { class: 'toolbox-inner-wrapper' });
-  const $notch = createTag('a', { class: 'notch' });
-  const $notchPill = createTag('div', { class: 'notch-pill' });
-  const $appStoreBadge = decorateBadge();
-  const $background = createTag('div', { class: 'toolbox-background' });
-  const $toggleButton = createTag('a', { class: 'toggle-button' });
-  const $toggleIcon = getIconElement('plus-icon-22');
-  const $boxTop = createTag('div', { class: 'toolbox-top' });
-  const $boxBottom = createTag('div', { class: 'toolbox-bottom' });
+export function buildToolBoxStructure(wrapper, data) {
+  const toolBox = createTag('div', { class: 'toolbox' });
+  const toolBoxWrapper = createTag('div', { class: 'toolbox-inner-wrapper' });
+  const notch = createTag('a', { class: 'notch' });
+  const notchPill = createTag('div', { class: 'notch-pill' });
+  const appStoreBadge = decorateBadge();
+  const background = createTag('div', { class: 'toolbox-background' });
+  const toggleButton = createTag('a', { class: 'toggle-button' });
+  const toggleIcon = getIconElement('plus-icon-22');
+  const boxTop = createTag('div', { class: 'toolbox-top' });
+  const boxBottom = createTag('div', { class: 'toolbox-bottom' });
 
-  const $floatingButton = $wrapper.querySelector('.floating-button');
+  const floatingButton = wrapper.querySelector('.floating-button');
 
-  $toggleButton.innerHTML = getLottie('plus-animation', '/express/icons/plus-animation.json');
-  $toolBoxWrapper.append($boxTop, $boxBottom);
-  $toolBox.append($toolBoxWrapper);
-  $toggleButton.append($toggleIcon);
-  $floatingButton.append($toggleButton);
-  $notch.append($notchPill);
-  $toolBox.append($notch, $appStoreBadge);
-  $wrapper.append($toolBox, $background);
+  toggleButton.innerHTML = getLottie('plus-animation', '/express/icons/plus-animation.json');
+  toolBoxWrapper.append(boxTop, boxBottom);
+  toolBox.append(toolBoxWrapper);
+  toggleButton.append(toggleIcon);
+  floatingButton.append(toggleButton);
+  notch.append(notchPill);
+  toolBox.append(notch, appStoreBadge);
+  wrapper.append(toolBox, background);
 
-  $appStoreBadge.href = data.appStore.href ? data.appStore.href : data.tools[0].anchor.href;
+  appStoreBadge.href = data.appStore.href ? data.appStore.href : data.tools[0].anchor.href;
 
-  $wrapper.classList.add('initial-load');
-  $wrapper.classList.add('clamped');
-  $wrapper.classList.add('toolbox-opened');
-  $floatingButton.classList.add('toolbox-opened');
+  wrapper.classList.add('initial-load');
+  wrapper.classList.add('clamped');
+  wrapper.classList.add('toolbox-opened');
+  floatingButton.classList.add('toolbox-opened');
 }
 
-export function initToolBox($wrapper, data, toggleFunction) {
-  const $floatingButton = $wrapper.querySelector('.floating-button');
-  const $cta = $floatingButton.querySelector('a');
-  const $toggleButton = $wrapper.querySelector('.toggle-button');
-  const $lottie = $wrapper.querySelector('.floating-button-lottie');
-  const $notch = $wrapper.querySelector('.notch');
-  const $background = $wrapper.querySelector('.toolbox-background');
+export function initToolBox(wrapper, data, toggleFunction) {
+  const floatingButton = wrapper.querySelector('.floating-button');
+  const cta = floatingButton.querySelector('a');
+  const toggleButton = wrapper.querySelector('.toggle-button');
+  const lottie = wrapper.querySelector('.floating-button-lottie');
+  const notch = wrapper.querySelector('.notch');
+  const background = wrapper.querySelector('.toolbox-background');
 
   setTimeout(() => {
-    if ($wrapper.classList.contains('initial-load')) {
-      toggleFunction($wrapper, $lottie, data, false);
+    if (wrapper.classList.contains('initial-load')) {
+      toggleFunction(wrapper, lottie, data, false);
     }
   }, data.delay * 1000);
 
-  $cta.addEventListener('click', (e) => {
-    if (!$wrapper.classList.contains('toolbox-opened')) {
+  cta.addEventListener('click', (e) => {
+    if (!wrapper.classList.contains('toolbox-opened')) {
       e.preventDefault();
       e.stopPropagation();
-      toggleFunction($wrapper, $lottie, data);
+      toggleFunction(wrapper, lottie, data);
     }
   });
 
-  [$toggleButton, $notch, $background].forEach(($element) => {
-    if ($element) {
-      $element.addEventListener('click', (e) => {
+  [toggleButton, notch, background].forEach((element) => {
+    if (element) {
+      element.addEventListener('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
-        toggleFunction($wrapper, $lottie, data);
+        toggleFunction(wrapper, lottie, data);
       });
     }
   });

--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -231,44 +231,6 @@ export async function createFloatingButton(block, audience, data) {
     }
   }
 
-  const heroCTA = document.querySelector('a.button.same-as-floating-button-CTA');
-  if (heroCTA) {
-    const hideButtonWhenIntersecting = new IntersectionObserver((entries) => {
-      const e = entries[0];
-      if (e.boundingClientRect.top > window.innerHeight - 40 || e.boundingClientRect.top === 0) {
-        floatButtonWrapper.classList.remove('floating-button--below-the-fold');
-        floatButtonWrapper.classList.add('floating-button--above-the-fold');
-      } else {
-        floatButtonWrapper.classList.add('floating-button--below-the-fold');
-        floatButtonWrapper.classList.remove('floating-button--above-the-fold');
-      }
-      if (e.intersectionRatio > 0 || e.isIntersecting) {
-        floatButtonWrapper.classList.add('floating-button--intersecting');
-        floatButton.style.bottom = '0px';
-      } else {
-        floatButtonWrapper.classList.remove('floating-button--intersecting');
-        if (promoBar && promoBar.block) {
-          floatButton.style.bottom = currentBottom ? `${currentBottom + promoBarHeight}px` : `${promoBarHeight}px`;
-        } else if (currentBottom) {
-          floatButton.style.bottom = currentBottom;
-        }
-      }
-    }, {
-      root: null,
-      rootMargin: '-40px 0px',
-      threshold: 0,
-    });
-    if (document.readyState === 'complete') {
-      hideButtonWhenIntersecting.observe(heroCTA);
-    } else {
-      window.addEventListener('load', () => {
-        hideButtonWhenIntersecting.observe(heroCTA);
-      });
-    }
-  } else {
-    floatButtonWrapper.classList.add('floating-button--above-the-fold');
-  }
-
   document.dispatchEvent(new CustomEvent('floatingbuttonloaded', {
     detail: {
       block: floatButtonWrapper,
@@ -276,9 +238,47 @@ export async function createFloatingButton(block, audience, data) {
   }));
 
   if (data.useLottieArrow !== 'no') {
+    const heroCTA = document.querySelector('a.button.same-as-floating-button-CTA');
+    if (heroCTA) {
+      const hideButtonWhenIntersecting = new IntersectionObserver(([e]) => {
+        if (e.boundingClientRect.top > window.innerHeight - 40 || e.boundingClientRect.top === 0) {
+          floatButtonWrapper.classList.remove('floating-button--below-the-fold');
+          floatButtonWrapper.classList.add('floating-button--above-the-fold');
+        } else {
+          floatButtonWrapper.classList.add('floating-button--below-the-fold');
+          floatButtonWrapper.classList.remove('floating-button--above-the-fold');
+        }
+        if (e.intersectionRatio > 0 || e.isIntersecting) {
+          floatButtonWrapper.classList.add('floating-button--intersecting');
+          floatButton.style.bottom = '0px';
+        } else {
+          floatButtonWrapper.classList.remove('floating-button--intersecting');
+          if (promoBar && promoBar.block) {
+            floatButton.style.bottom = currentBottom ? `${currentBottom + promoBarHeight}px` : `${promoBarHeight}px`;
+          } else if (currentBottom) {
+            floatButton.style.bottom = currentBottom;
+          }
+        }
+      }, {
+        root: null,
+        rootMargin: '-40px 0px',
+        threshold: 0,
+      });
+      if (document.readyState === 'complete') {
+        hideButtonWhenIntersecting.observe(heroCTA);
+      } else {
+        window.addEventListener('load', () => {
+          hideButtonWhenIntersecting.observe(heroCTA);
+        });
+      }
+    } else {
+      floatButtonWrapper.classList.add('floating-button--above-the-fold');
+    }
+
     const lottieScrollButton = buildLottieArrow(floatButtonWrapper, floatButton, data);
     document.dispatchEvent(new CustomEvent('linkspopulated', { detail: [floatButtonLink, lottieScrollButton] }));
   } else {
+    data.scrollState = 'withoutLottie';
     document.dispatchEvent(new CustomEvent('linkspopulated', { detail: [floatButtonLink] }));
   }
 
@@ -348,6 +348,10 @@ export async function collectFloatingButtonData() {
 
     if (key === 'bubble sheet') {
       data.bubbleSheet = value;
+    }
+
+    if (key === 'use lottie arrow') {
+      data.useLottieArrow = value;
     }
 
     for (let i = 1; i < 7; i += 1) {

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1,3 +1,5 @@
+import BlockMediator from './block-mediator.min.js';
+
 const AUTO_BLOCKS = [
   { faas: '/tools/faas' },
   { fragment: '/express/fragments/' },
@@ -1890,18 +1892,19 @@ async function buildAutoBlocks($main) {
   }
 
   if (['yes', 'true', 'on'].includes(getMetadata('show-floating-cta').toLowerCase()) || ['yes', 'true', 'on'].includes(getMetadata('show-multifunction-button').toLowerCase())) {
-    if (!window.floatingCtasLoaded) {
+    if (!BlockMediator.get('floatingCtasLoaded')) {
       const floatingCTAData = await fetchFloatingCta(window.location.pathname);
       const validButtonVersion = ['floating-button', 'multifunction-button', 'bubble-ui-button', 'floating-panel'];
       const device = document.body.dataset?.device;
       const blockName = floatingCTAData?.[device];
+
       if (validButtonVersion.includes(blockName) && $lastDiv) {
         const button = buildBlock(blockName, device);
         button.classList.add('spreadsheet-powered');
         $lastDiv.append(button);
       }
 
-      window.floatingCtasLoaded = true;
+      BlockMediator.set('floatingCtasLoaded', true);
     }
   }
 

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1,5 +1,3 @@
-import BlockMediator from './block-mediator.min.js';
-
 const AUTO_BLOCKS = [
   { faas: '/tools/faas' },
   { fragment: '/express/fragments/' },
@@ -1892,6 +1890,7 @@ async function buildAutoBlocks($main) {
   }
 
   if (['yes', 'true', 'on'].includes(getMetadata('show-floating-cta').toLowerCase()) || ['yes', 'true', 'on'].includes(getMetadata('show-multifunction-button').toLowerCase())) {
+    const { default: BlockMediator } = await import('./block-mediator.min.js');
     if (!BlockMediator.get('floatingCtasLoaded')) {
       const floatingCTAData = await fetchFloatingCta(window.location.pathname);
       const validButtonVersion = ['floating-button', 'multifunction-button', 'bubble-ui-button', 'floating-panel'];


### PR DESCRIPTION
Floating CTA's scroll arrow can now be disabled in floating-cta.xslx with the use lottie arrow column = 'no'

Resolves: 
Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/business?dev=on
- After: https://floating-cta-arrow-toggle--express--adobecom.hlx.page/express/business?dev=on&martech=off

Dev floating CTA sheet is [here](https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7BA4C0914C-88CB-4FE1-A5B8-11C6A6EC1621%7D&file=floating-cta-dev.xlsx&action=default&mobileredirect=true) if anyone wants to test with more pages. Editing this sheet will not have any effect on production pages