### PR TITLE
Gdpr banner delay

### DIFF
--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -287,7 +287,7 @@ async function loadFEDS() {
       otDomainId: '7a5eb705-95ed-4cc4-a11d-0cc5760e93db',
     };
     loadScript('https://www.adobe.com/etc.clientlibs/globalnav/clientlibs/base/privacy-standalone.js');
-  }, 0);
+  }, 4000);
   const footer = document.querySelector('footer');
   footer?.addEventListener('click', (event) => {
     if (event.target.closest('a[data-feds-action="open-adchoices-modal"]')) {

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -283,8 +283,15 @@ async function loadFEDS() {
     script.id = 'feds-script';
   });
   setTimeout(() => {
+    const acom = '7a5eb705-95ed-4cc4-a11d-0cc5760e93db';
+    const ids = {
+      'hlx.page': '3a6a37fe-9e07-4aa9-8640-8f358a623271-test',
+      'hlx.live': '926b16ce-cc88-4c6a-af45-21749f3167f3-test',
+    };
+    // eslint-disable-next-line max-len
+    const otDomainId = ids?.[Object.keys(ids).find((domainId) => window.location.host.includes(domainId))] ?? acom;
     window.fedsConfig.privacy = {
-      otDomainId: '7a5eb705-95ed-4cc4-a11d-0cc5760e93db',
+      otDomainId,
     };
     loadScript('https://www.adobe.com/etc.clientlibs/globalnav/clientlibs/base/privacy-standalone.js');
   }, 4000);


### PR DESCRIPTION
Delays gdpr banner by four seconds. This has been cross-checked and validated by our legal team . 

Resolves: https://jira.corp.adobe.com/browse/MWPW-139363 

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://gdpr-banner--express--adobecom.hlx.page/express/