### PR TITLE
MWPW-138985 | Removing temporary UK fix

### DIFF
--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -168,7 +168,7 @@ async function loadFEDS() {
         if (env && env.spark) {
           sparkLoginUrl = sparkLoginUrl.replace('express.adobe.com', env.spark);
         }
-        if (isHomepage || sparkPrefix.includes('en-GB')) {
+        if (isHomepage) {
           sparkLoginUrl = 'https://new.express.adobe.com/?showCsatOnExportOnce=True&promoid=GHMVYBFM&mv=other';
         }
         window.location.href = sparkLoginUrl;


### PR DESCRIPTION
Removing temporary UK fix since actual redirect from product team is applied for both en-GB and en-IN locales.

Resolves: [MWPW-138985](https://jira.corp.adobe.com/browse/MWPW-138985)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/?martech=off
- After: https://MWPW-138985-2--express--adobecom.hlx.page/express/?martech=off
