### PR TITLE
Remove Irrelevant Sections After Experiment Replaces DOM

### DIFF
--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2079,7 +2079,6 @@ function decorateSocialIcons($main) {
 function displayOldLinkWarning() {
   if (window.location.hostname.includes('localhost') || window.location.hostname.includes('.hlx.page')) {
     document.querySelectorAll('main a[href^="https://spark.adobe.com/"]').forEach(($a) => {
-      const url = new URL($a.href);
       $a.style.border = '10px solid red';
     });
   }

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1688,6 +1688,7 @@ async function decorateTesting() {
                 const experimentPath = new URL(page, window.location.href).pathname.split('.')[0];
                 if (experimentPath && experimentPath !== currentPath) {
                   await replaceInner(experimentPath, document.querySelector('main'));
+                  removeIrrelevantSections(document.querySelector('main'));
                 }
               }
             }

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1633,9 +1633,7 @@ async function decorateTesting() {
     const [forcedExperiment, forcedVariant] = usp.get('experiment') ? usp.get('experiment').split('/') : [];
 
     if (experiment) {
-      console.log('experiment', experiment);
       const config = await getExperimentConfig(experiment);
-      console.log('config -->', config);
       if (config && (toCamelCase(config.status) === 'active' || forcedExperiment)) {
         const { DEFAULT_EXPERIMENT_OPTIONS, AUDIENCES, getResolvedAudiences } = await import('./experiment.js');
         const experimentOptions = {
@@ -1646,7 +1644,6 @@ async function decorateTesting() {
         config.run = forcedExperiment
           || !config.resolvedAudiences
           || config.resolvedAudiences.length;
-        console.log('run', config.run, config.audience);
 
         window.hlx = window.hlx || {};
         if (config.run) {
@@ -1659,7 +1656,6 @@ async function decorateTesting() {
             config.selectedVariant = decision.items[0].id;
           }
           sampleRUM('experiment', { source: config.id, target: config.selectedVariant });
-          console.log(`running experiment (${window.hlx.experiment.id}) -> ${window.hlx.experiment.selectedVariant}`);
           // populate ttMETA with hlx experimentation details
           window.ttMETA = window.ttMETA || [];
           const experimentDetails = {
@@ -1681,7 +1677,6 @@ async function decorateTesting() {
           if (config.selectedVariant !== 'control') {
             const currentPath = window.location.pathname;
             const pageIndex = config.variants.control.pages.indexOf(currentPath);
-            console.log(pageIndex, config.variants.control.pages, currentPath);
             if (pageIndex >= 0) {
               const page = config.variants[config.selectedVariant].pages[pageIndex];
               if (page) {
@@ -2085,7 +2080,6 @@ function displayOldLinkWarning() {
   if (window.location.hostname.includes('localhost') || window.location.hostname.includes('.hlx.page')) {
     document.querySelectorAll('main a[href^="https://spark.adobe.com/"]').forEach(($a) => {
       const url = new URL($a.href);
-      console.log(`old link: ${url}`);
       $a.style.border = '10px solid red';
     });
   }


### PR DESCRIPTION
As of now removeIrrelevantSections is used to cleanup unused sections help us find the right LCP. However, during experiments, the entire DOM could get replaced with a variant. Thus we need to call that func again.

Using these links, 90% you'll see the challenger variant, where you'll see mobile content showing up on Desktop in the stage branch, but only desktop content in the feature branch.

Resolves: https://jira.corp.adobe.com/browse/MWPW-139438

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/experiments/expjingle/home
- After: https://rm-sections-experiment--express--adobecom.hlx.page/express/experiments/expjingle/home
