### PR TITLE
MWPW-138985 | Updating stage domain and IN mapping in locale mapping

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -17,7 +17,7 @@ const locales = {
   fi: { ietf: 'fi-FI', tk: 'aaz7dvd.css' },
   fr: { ietf: 'fr-FR', tk: 'vrk5vyv.css' },
   gb: { ietf: 'en-GB', tk: 'pps7abe.css' },
-  in: { ietf: 'en-GB', tk: 'pps7abe.css' },
+  in: { ietf: 'en-IN', tk: 'pps7abe.css' },
   it: { ietf: 'it-IT', tk: 'bbf5pok.css' },
   jp: { ietf: 'ja-JP', tk: 'dvg6awq' },
   kr: { ietf: 'ko-KR', tk: 'qjs5sfm' },

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -915,7 +915,7 @@ export function getHelixEnv() {
     stage: {
       commerce: 'commerce-stg.adobe.com',
       adminconsole: 'stage.adminconsole.adobe.com',
-      spark: 'express-stage.adobeprojectm.com',
+      spark: 'stage.projectx.corp.adobe.com',
     },
     prod: {
       commerce: 'commerce.adobe.com',

--- a/test/unit/blocks/block/expected/commerce-cta.block.html
+++ b/test/unit/blocks/block/expected/commerce-cta.block.html
@@ -2,7 +2,7 @@
   <p class="pricing-plan-title" data-id="0">Free for your first 30 days, then</p>
   <div class="pricing-plan">
     <p class="pricing-plan-price">US$9.99<span class="pricing-plan-cadence">/mo</span></p><a
-      href="https://commerce-stg.adobe.com/checkout/email/?items%5B0%5D%5Bid%5D=0EDBD95A29C6EE10FB2B323A041E3AEF&amp;items%5B0%5D%5Bcs%5D=0&amp;rUrl=https%3A%2F%2Fexpress-stage.adobeprojectm.com%2F&amp;cli=spark&amp;co=us&amp;lang=en"
+      href="https://commerce-stg.adobe.com/checkout/email/?items%5B0%5D%5Bid%5D=0EDBD95A29C6EE10FB2B323A041E3AEF&amp;items%5B0%5D%5Bcs%5D=0&amp;rUrl=https%3A%2F%2Fstage.projectx.corp.adobe.com%2F&amp;cli=spark&amp;co=us&amp;lang=en"
       class="large">Start your free trial</a>
   </div>
 </div>

--- a/test/unit/blocks/block/expected/commerce-cta.cadence.block.html
+++ b/test/unit/blocks/block/expected/commerce-cta.cadence.block.html
@@ -2,7 +2,7 @@
   <p class="pricing-plan-title" data-id="0">Free for your first 30 days, then</p>
   <div class="pricing-plan">
     <p class="pricing-plan-price">US$9.99<span class="pricing-plan-cadence">/semester</span></p><a
-      href="https://commerce-stg.adobe.com/checkout/email/?items%5B0%5D%5Bid%5D=0EDBD95A29C6EE10FB2B323A041E3AEF&amp;items%5B0%5D%5Bcs%5D=0&amp;rUrl=https%3A%2F%2Fexpress-stage.adobeprojectm.com%2F&amp;cli=spark&amp;co=us&amp;lang=en"
+      href="https://commerce-stg.adobe.com/checkout/email/?items%5B0%5D%5Bid%5D=0EDBD95A29C6EE10FB2B323A041E3AEF&amp;items%5B0%5D%5Bcs%5D=0&amp;rUrl=https%3A%2F%2Fstage.projectx.corp.adobe.com%2F&amp;cli=spark&amp;co=us&amp;lang=en"
       class="large">Start your free trial</a>
   </div>
 </div>


### PR DESCRIPTION
Updating stage domain and IN mapping in locale mapping

Attempt clicking sign in from both the links below.
Later one attempts a redirect from https://stage.projectx.corp.adobe.com/en-IN/sp/ to https://creativecloud.adobe.com/

Based on the email conversation with product team, modifying the domain for stage and for IN , the URL which needs to be attempted on click of sign-in needs to be en-IN instead of en-GB.

Resolves: [MWPW-138985](https://jira.corp.adobe.com/browse/MWPW-138985)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/in/express/create/banner/diwali?martech=off
- After: https://MWPW-138985-3--express--adobecom.hlx.page/in/express/create/banner/diwali?martech=off