### PR TITLE
[MWPW-139305] - Marquee block : Allow CTA play button to be white

### DIFF
--- a/express/blocks/marquee/marquee.css
+++ b/express/blocks/marquee/marquee.css
@@ -182,6 +182,10 @@ body.no-desktop-brand-header header {
   content: url(/express/icons/play.svg);
 }
 
+.marquee.dark p.button-container a.primaryCTA::before {
+  filter: invert(100%) sepia(0%) saturate(1%) hue-rotate(172deg) brightness(110%) contrast(101%);
+}
+
 .marquee p.underline a {
   font-weight: normal;
   text-decoration: underline;


### PR DESCRIPTION
Resolves: [MWPW-139305](https://jira.corp.adobe.com/browse/MWPW-139305)

Description: 
- On the mobile version of the Marquee (dark) variant, the SVG color is black as it takes on the primaryCTA properties. This ticket is to make the SVG of the primaryCTA on mobile version take on the same SVG color properties of the secondary button as requested.

Test URLs:
- Before: https://main--express--adobecom.hlx.page/drafts/esallee/entitled-vimeo-test?martech=off
- After: https://mwpw-139305--express--adobecom.hlx.page/drafts/esallee/entitled-vimeo-test?martech=off
