### PR TITLE
Update columns block video hero max-height

### DIFF
--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -525,6 +525,11 @@ main .columns.fullsize .hero-animation-overlay {
   padding-bottom: 4px;
 }
 
+main .columns.fullsize .hero-animation-overlay video {
+  max-height: 40vh;
+  margin-bottom: 40px;
+}
+
 main .columns.fullsize .has-brand > div:not(.column-picture):not(.hero-animation-overlay) {
   padding-top: 16px;
 }
@@ -714,6 +719,11 @@ main .columns.fullsize.top .column .columns-iconlist .columns-iconlist-descripti
     padding-top: 0;
     padding-bottom: 0;
     order: unset;
+  }
+
+  main .columns.fullsize .hero-animation-overlay video {
+    max-height: unset;
+    margin-bottom: unset;
   }
 
   main .columns.fullsize > div > div {


### PR DESCRIPTION
Adding a max-height of 40vh to hero video of columns block

Resolves: [MWPW-139783](https://jira.corp.adobe.com/browse/MWPW-139783)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/create/video/tiktok?martech=off
- After: https://column-hero-height-limit--express--adobecom.hlx.page/express/create/video/tiktok?martech=off
- After: https://column-hero-height-limit--express--adobecom.hlx.page/express/create/video/instagram/reel?martech=off
