### PR TITLE
Template-X Avoid Cache Collisions by Appending Headers to Queryparams

### DIFF
--- a/express/blocks/template-x/template-search-api-v3.js
+++ b/express/blocks/template-x/template-search-api-v3.js
@@ -116,11 +116,11 @@ async function fetchSearchUrl({
 
   // temporarily adding extra dummy queryParams to avoid cache collision
   const headers = {};
-  const prefLang = getConfig().locales[langs[0] === 'en' ? '' : langs[0]].ietf;
+  const prefLang = getConfig().locales?.[langs[0] === 'en' ? '' : langs[0]]?.ietf;
   const [prefRegion] = extractRegions(filters.locales);
   headers['x-express-ims-region-code'] = prefRegion; // Region Boosting
   url += `&regionHeader=${prefRegion}`; // TODO: remove once CDN includes headers when calculating cache key
-  if (supportedLanguages.includes(prefLang)) {
+  if (prefLang && supportedLanguages.includes(prefLang)) {
     headers['x-express-pref-lang'] = prefLang; // Language Boosting
     url += `&prefLangHeader=${prefLang}`; // TODO: remove once CDN includes headers when calculating cache key
   }

--- a/express/blocks/template-x/template-search-api-v3.js
+++ b/express/blocks/template-x/template-search-api-v3.js
@@ -74,7 +74,8 @@ function formatFilterString(filters) {
       .join(',');
     if (langFilter) str += `&filters=language==${langFilter}`;
 
-    // No Region Filter. We still have Region Boosting
+    // No Region Filter as template region tagging is still inconsistent.
+    // We still have Region Boosting via x-express-ims-region-code header
     // const regionFilter = extractRegions(locales).join(',');
     // if (regionFilter) str += `&filters=applicableRegions==${regionFilter}`;
   }
@@ -108,12 +109,12 @@ async function fetchSearchUrl({
     `${base}?${collectionIdParam}${queryParam}${qParam}${limitParam}${startParam}${sortParam}${filterStr}`,
   );
 
-  const headers = {};
-
   const langs = extractLangs(filters.locales);
   if (langs.length === 0) {
-    return memoizedFetch(url, { headers });
+    return memoizedFetch(url);
   }
+
+  const headers = {};
   const prefLang = getConfig().locales[langs[0] === 'en' ? '' : langs[0]].ietf;
   const [prefRegion] = extractRegions(filters.locales);
   headers['x-express-ims-region-code'] = prefRegion; // Region Boosting


### PR DESCRIPTION
We have potential cache collision issues for 2 requests with same queries but different header values, since our CDN doesn't yet take them into calculation of cache keys. We are unable to deploy the CDN fix before 12/11, so this PR should take care of potential collisions by forcefully appending the header values to query params. After 12/12, we should be able to revert the change.

Resolves: https://jira.corp.adobe.com/browse/MWPW-139829

I have polluted the cache with IN headers, so within 23 hr of this PR creation, you should still IN templates on stage, despite in the block locales is configured to be UK. On the branch link, you should be able to see different templates (it should fallback to US meaning that it doesn't hit the earlier IN cache entry)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/jingle/template-x-locales
- After: https://template-temp-append-header-in-query--express--adobecom.hlx.page/drafts/jingle/template-x-locales?martech=off
