### PR TITLE
[MWPW-139925][Experimentation] Use default launch alloy sendEvent

### DIFF
--- a/express/scripts/experiment.js
+++ b/express/scripts/experiment.js
@@ -1,4 +1,8 @@
-import { getHelixEnv } from './utils.js';
+import {
+  getHelixEnv,
+  removeIrrelevantSections,
+  sampleRUM,
+} from './utils.js';
 
 export const DEFAULT_EXPERIMENT_OPTIONS = {
   // Generic properties
@@ -52,12 +56,50 @@ export const AUDIENCES = {
 };
 
 /**
+ * Generates a decision policy object which is understood by UED from an
+ * experiment configuration.
+ * @param {*} config Experiment configuration
+ * @returns Experiment decision policy object to be passed to UED.
+ */
+function getDecisionPolicy(config) {
+  const decisionPolicy = {
+    id: 'content-experimentation-policy',
+    rootDecisionNodeId: 'n1',
+    decisionNodes: [{
+      id: 'n1',
+      type: 'EXPERIMENTATION',
+      experiment: {
+        id: config.id,
+        identityNamespace: 'ECID',
+        randomizationUnit: 'DEVICE',
+        treatments: Object.entries(config.variants).map(([key, props]) => ({
+          id: key,
+          allocationPercentage: props.percentageSplit
+            ? parseFloat(props.percentageSplit) * 100
+            : 100 - Object.values(config.variants).reduce((result, variant) => {
+              const returnResult = result - (parseFloat(variant.percentageSplit || 0) * 100);
+              return returnResult;
+            }, 100),
+        })),
+      },
+    }],
+  };
+  return decisionPolicy;
+}
+
+/**
  * Checks if any of the configured audiences on the page can be resolved.
  * @param {string[]} applicableAudiences a list of configured audiences for the page
  * @param {object} options the plugin options
  * @returns Returns the names of the resolved audiences, or `null` if no audience is configured
  */
-export async function getResolvedAudiences(applicableAudiences, options) {
+export async function getResolvedAudiences(
+  applicableAudiences,
+  options = {
+    ...DEFAULT_EXPERIMENT_OPTIONS,
+    audiences: AUDIENCES,
+  },
+) {
   if (!applicableAudiences.length || !Object.keys(options.audiences).length) {
     return null;
   }
@@ -82,4 +124,74 @@ export async function getResolvedAudiences(applicableAudiences, options) {
       }),
   );
   return applicableAudiences.filter((_, i) => results[i]);
+}
+
+/**
+ * Replaces element with content from path
+ * @param {string} path
+ * @param {HTMLElement} element
+ */
+async function replaceInner(path, element) {
+  const plainPath = `${path}.plain.html`;
+  try {
+    const resp = await fetch(plainPath);
+    const html = await resp.text();
+    element.innerHTML = html;
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log(`error loading experiment content: ${plainPath}`, e);
+  }
+  return null;
+}
+
+export async function runExps(config, forcedExperiment, forcedVariant) {
+  config.resolvedAudiences = await getResolvedAudiences(config.audience.split(',').map((a) => a.trim()));
+  config.run = forcedExperiment
+    || !config.resolvedAudiences
+    || config.resolvedAudiences.length;
+
+  window.hlx = window.hlx || {};
+  if (config.run) {
+    window.hlx.experiment = config;
+    if (forcedVariant && config.variantNames.includes(forcedVariant)) {
+      config.selectedVariant = forcedVariant;
+    } else {
+      const ued = await import('./ued/ued-0.2.0.js');
+      const decision = ued.evaluateDecisionPolicy(getDecisionPolicy(config), {});
+      config.selectedVariant = decision.items[0].id;
+    }
+    sampleRUM('experiment', { source: config.id, target: config.selectedVariant });
+    // populate ttMETA with hlx experimentation details
+    window.ttMETA = window.ttMETA || [];
+    const experimentDetails = {
+      CampaignId: window.hlx.experiment.id,
+      CampaignName: window.hlx.experiment.experimentName,
+      OfferId: window.hlx.experiment.selectedVariant,
+      OfferName: window.hlx.experiment.variants[window.hlx.experiment.selectedVariant].label,
+    };
+    window.ttMETA.push(experimentDetails);
+    // add hlx experiment details as dynamic variables
+    // for Content Square integration
+    // eslint-disable-next-line no-underscore-dangle
+    if (window._uxa) {
+      for (const propName of Object.keys(experimentDetails)) {
+        // eslint-disable-next-line no-underscore-dangle
+        window._uxa.push(['trackDynamicVariable', { key: propName, value: experimentDetails[propName] }]);
+      }
+    }
+    if (config.selectedVariant !== 'control') {
+      const currentPath = window.location.pathname;
+      const pageIndex = config.variants.control.pages.indexOf(currentPath);
+      if (pageIndex >= 0) {
+        const page = config.variants[config.selectedVariant].pages[pageIndex];
+        if (page) {
+          const experimentPath = new URL(page, window.location.href).pathname.split('.')[0];
+          if (experimentPath && experimentPath !== currentPath) {
+            await replaceInner(experimentPath, document.querySelector('main'));
+            removeIrrelevantSections(document.querySelector('main'));
+          }
+        }
+      }
+    }
+  }
 }

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -1054,9 +1054,6 @@ const martechLoadedCB = () => {
     };
 
     await _satellite.alloyConfigurePromise;
-    // trigger alloyReady event so that experimentation will proceed
-    window.alloyLoaded = true;
-    document.dispatchEvent(new Event('alloyReady'));
     const data = await alloy('getIdentity');
     getSegments(data && data.identity ? data.identity.ECID : null);
   }

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1646,6 +1646,9 @@ async function decorateTesting() {
         window.addEventListener('alloy_sendEvent', (e) => {
           // fired by launch loaded by martech-main loaded by instrument
           if (e.detail.type === 'pageView') {
+            // eslint-disable-next-line no-console
+            console.log({ alloyResult: e.detail.result });
+            window.alloyLoaded = true;
             alloyLoadingResolver(e.detail.result);
           }
         });
@@ -1653,6 +1656,13 @@ async function decorateTesting() {
         const [{ DEFAULT_EXPERIMENT_OPTIONS, AUDIENCES, getResolvedAudiences }] = await Promise.all(
           [import('./experiment.js'), import('./block-mediator.min.js'), loadScript('/express/scripts/instrument.js', 'module')],
         );
+        setTimeout(() => {
+          if (!window.alloyLoaded) {
+            // eslint-disable-next-line no-console
+            console.error('Alloy failed to load');
+            alloyLoadingResolver();
+          }
+        }, 5000);
         const experimentOptions = {
           ...DEFAULT_EXPERIMENT_OPTIONS,
           ...{ audiences: AUDIENCES },

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1639,10 +1639,14 @@ async function decorateTesting() {
     if (experiment) {
       const config = await getExperimentConfig(experiment);
       if (config && (toCamelCase(config.status) === 'active' || forcedExperiment)) {
+        let alloyLoadingResolver;
+        window.alloyLoader = new Promise((resolve) => {
+          alloyLoadingResolver = resolve;
+        });
         window.addEventListener('alloy_sendEvent', (e) => {
+          // fired by launch loaded by martech-main loaded by instrument
           if (e.detail.type === 'pageView') {
-            console.log(e.detail);
-            console.log(e.detail.result);
+            alloyLoadingResolver(e.detail.result);
           }
         });
         // rush launch for alloy configuration

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1650,8 +1650,9 @@ async function decorateTesting() {
           }
         });
         // rush launch for alloy configuration
-        await loadScript('/express/scripts/instrument.js', 'module');
-        const { DEFAULT_EXPERIMENT_OPTIONS, AUDIENCES, getResolvedAudiences } = await import('./experiment.js');
+        const [{ DEFAULT_EXPERIMENT_OPTIONS, AUDIENCES, getResolvedAudiences }] = await Promise.all(
+          [import('./experiment.js'), import('./block-mediator.min.js'), loadScript('/express/scripts/instrument.js', 'module')],
+        );
         const experimentOptions = {
           ...DEFAULT_EXPERIMENT_OPTIONS,
           ...{ audiences: AUDIENCES },

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1654,7 +1654,7 @@ async function decorateTesting() {
         });
         // rush launch for alloy configuration
         const [{ DEFAULT_EXPERIMENT_OPTIONS, AUDIENCES, getResolvedAudiences }] = await Promise.all(
-          [import('./experiment.js'), import('./block-mediator.min.js'), loadScript('/express/scripts/instrument.js', 'module')],
+          [import('./experiment.js'), loadScript('/express/scripts/instrument.js', 'module')],
         );
         setTimeout(() => {
           if (!window.alloyLoaded) {

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1453,10 +1453,10 @@ export function toCamelCase(name) {
  */
 export function getExperiment() {
   let experiment = toClassName(getMetadata('experiment'));
-
-  if (!/adobe\.com/.test(window.location.hostname) && !/\.hlx\.live/.test(window.location.hostname)) {
+  const { hostname } = window.location;
+  if (!(/adobe\.com/.test(hostname) || /\.hlx\.live/.test(hostname) || hostname.includes('localhost'))) {
     experiment = '';
-    // reason = 'not prod host';
+    // reason = 'not prod host and not local';
   }
   if (window.location.hash) {
     experiment = '';


### PR DESCRIPTION
Remove separate alloy call and wait for the one fired by launch

Resolves: https://jira.corp.adobe.com/browse/MWPW-138913?filter=381833

This PR changes the way we rush alloy, and could make all experiments in PROD much slower (but more correctly). However, since we are not actively running any, this technically won't have any PROD impacts. We will still follow up to take care of performance issues before we launch any AEP experiments.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/experiments/ccx0167/home
- After: https://ccx_0167_4--express--adobecom.hlx.page/express/experiments/ccx0167/home
