### PR TITLE
[MWPW-138525][Block enhancement] - Enable full width on list icon block

### DIFF
--- a/express/blocks/icon-list/icon-list.css
+++ b/express/blocks/icon-list/icon-list.css
@@ -140,7 +140,7 @@ main .icon-list .icon-list-regular .icon-list-description {
   align-self: start;
 }
 
-main .icon-list.highlight .icon-list-regular .icon-list-image img, 
+main .icon-list.highlight .icon-list-regular .icon-list-image img,
 main .icon-list.highlight .icon-list-regular .icon-list-image svg {
   fill: currentColor;
   width: 73px;

--- a/express/blocks/icon-list/icon-list.css
+++ b/express/blocks/icon-list/icon-list.css
@@ -41,13 +41,12 @@ main .icon-list .icon-list-description > p:first-child {
   line-height: unset;
 }
 
-main .icon-list h3,
-main .icon-list h4 {
+main .icon-list h3, main .icon-list h4 {
   margin-top: 0;
   text-align: left;
 }
 
-@media (min-width: 600px) {
+@media (min-width:600px) {
   main .icon-list {
     margin-top: 56px;
   }
@@ -142,8 +141,7 @@ main .icon-list .icon-list-regular .icon-list-description {
   align-self: start;
 }
 
-main .icon-list.highlight .icon-list-regular .icon-list-image img,
-main .icon-list.highlight .icon-list-regular .icon-list-image svg {
+main .icon-list.highlight .icon-list-regular .icon-list-image img, main .icon-list.highlight .icon-list-regular .icon-list-image svg {
   fill: currentColor;
   width: 73px;
   height: 72px;
@@ -165,7 +163,7 @@ main .icon-list-center-container ~ .columns-highlight-container {
   margin-top: 120px;
 }
 
-@media (min-width: 900px) {
+@media (min-width:900px) {
   main .icon-list.two-column {
     flex-wrap: nowrap;
   }
@@ -183,13 +181,19 @@ main .icon-list-center-container ~ .columns-highlight-container {
   }
 }
 
-@media (min-width: 1200px) {
+@media (min-width:1200px) {
   main .section.icon-list-two-column-container > div {
     max-width: 1200px;
   }
 
+  main .icon-list.fullwidth {
+    max-width: 1024px;
+    margin: auto;
+  }
+  
   main .icon-list.fullwidth > div {
     width: 480px;
     margin: 16px 0 32px;
   }
+
 }

--- a/express/blocks/icon-list/icon-list.css
+++ b/express/blocks/icon-list/icon-list.css
@@ -52,7 +52,7 @@ main .icon-list h3, main .icon-list h4 {
   }
 }
 
-@media (min-width: 900px) {
+@media (min-width:900px) {
   main .icon-list {
     padding-bottom: 0;
   }
@@ -108,8 +108,7 @@ main .icon-list .icon-list-heading .icon-list-description {
   align-self: center;
 }
 
-main .icon-list .icon-list-heading .icon-list-image img,
-main .icon-list .icon-list-heading .icon-list-image svg {
+main .icon-list .icon-list-heading .icon-list-image img, main .icon-list .icon-list-heading .icon-list-image svg {
   fill: currentColor;
   width: 100px;
   height: 100px;
@@ -141,7 +140,8 @@ main .icon-list .icon-list-regular .icon-list-description {
   align-self: start;
 }
 
-main .icon-list.highlight .icon-list-regular .icon-list-image img, main .icon-list.highlight .icon-list-regular .icon-list-image svg {
+main .icon-list.highlight .icon-list-regular .icon-list-image img, 
+main .icon-list.highlight .icon-list-regular .icon-list-image svg {
   fill: currentColor;
   width: 73px;
   height: 72px;
@@ -179,10 +179,6 @@ main .icon-list-center-container ~ .columns-highlight-container {
   main .icon-list.fullwidth {
     justify-content: space-between;
   }
-
-  main .icon-list.fullwidth > div {
-    margin: 16px 4px 32px;
-  }
 }
 
 @media (min-width:1200px) {
@@ -191,7 +187,7 @@ main .icon-list-center-container ~ .columns-highlight-container {
   }
 
   main .icon-list.fullwidth > div {
-    margin: 16px 0 32px;
+    margin: 56px 0 auto;
   }
 
   main .icon-list.fullwidth {

--- a/express/blocks/icon-list/icon-list.css
+++ b/express/blocks/icon-list/icon-list.css
@@ -187,7 +187,7 @@ main .icon-list-center-container ~ .columns-highlight-container {
   }
 
   main .icon-list.fullwidth > div {
-    margin: 56px 0 auto;
+    margin: 56px auto 0;
   }
 
   main .icon-list.fullwidth {

--- a/express/blocks/icon-list/icon-list.css
+++ b/express/blocks/icon-list/icon-list.css
@@ -41,18 +41,19 @@ main .icon-list .icon-list-description > p:first-child {
   line-height: unset;
 }
 
-main .icon-list h3, main .icon-list h4 {
+main .icon-list h3,
+main .icon-list h4 {
   margin-top: 0;
   text-align: left;
 }
 
-@media (min-width:600px) {
+@media (min-width: 600px) {
   main .icon-list {
     margin-top: 56px;
   }
 }
 
-@media (min-width:900px) {
+@media (min-width: 900px) {
   main .icon-list {
     padding-bottom: 0;
   }
@@ -108,7 +109,8 @@ main .icon-list .icon-list-heading .icon-list-description {
   align-self: center;
 }
 
-main .icon-list .icon-list-heading .icon-list-image img, main .icon-list .icon-list-heading .icon-list-image svg {
+main .icon-list .icon-list-heading .icon-list-image img,
+main .icon-list .icon-list-heading .icon-list-image svg {
   fill: currentColor;
   width: 100px;
   height: 100px;
@@ -163,8 +165,7 @@ main .icon-list-center-container ~ .columns-highlight-container {
   margin-top: 120px;
 }
 
-
-@media (min-width:900px) {
+@media (min-width: 900px) {
   main .icon-list.two-column {
     flex-wrap: nowrap;
   }
@@ -176,11 +177,19 @@ main .icon-list-center-container ~ .columns-highlight-container {
   main .section.icon-list-two-column-container > div {
     max-width: 1122px;
   }
-}
 
-@media (min-width:1200px) {
-  main .section.icon-list-two-column-container > div {
-    max-width: 1200px;
+  main .icon-list.fullwidth {
+    justify-content: space-between;
   }
 }
 
+@media (min-width: 1200px) {
+  main .section.icon-list-two-column-container > div {
+    max-width: 1200px;
+  }
+
+  main .icon-list.fullwidth > div {
+    width: 480px;
+    margin: 16px 0 32px;
+  }
+}

--- a/express/blocks/icon-list/icon-list.css
+++ b/express/blocks/icon-list/icon-list.css
@@ -181,13 +181,17 @@ main .icon-list-center-container ~ .columns-highlight-container {
   }
 
   main .icon-list.fullwidth > div {
-    margin: 16px 0 32px;
+    margin: 16px 4px 32px;
   }
 }
 
 @media (min-width:1200px) {
   main .section.icon-list-two-column-container > div {
     max-width: 1200px;
+  }
+
+  main .icon-list.fullwidth > div {
+    margin: 16px 0 32px;
   }
 
   main .icon-list.fullwidth {

--- a/express/blocks/icon-list/icon-list.css
+++ b/express/blocks/icon-list/icon-list.css
@@ -175,9 +175,13 @@ main .icon-list-center-container ~ .columns-highlight-container {
   main .section.icon-list-two-column-container > div {
     max-width: 1122px;
   }
-
+  
   main .icon-list.fullwidth {
     justify-content: space-between;
+  }
+
+  main .icon-list.fullwidth > div {
+    margin: 16px 0 32px;
   }
 }
 
@@ -193,7 +197,5 @@ main .icon-list-center-container ~ .columns-highlight-container {
   
   main .icon-list.fullwidth > div {
     width: 480px;
-    margin: 16px 0 32px;
   }
-
 }


### PR DESCRIPTION
Resolves: [MWPW-138525](https://jira.corp.adobe.com/browse/MWPW-138525)

Description:
- Add a 'fullwidth' variant to enable authors to make the block full width and match the [XD](https://xd.adobe.com/view/387d1f22-662a-413f-92ff-457b25545c27-6d2e/screen/70822fef-324c-4b76-8702-09259042fde3)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/drafts/esallee/edu-icon-list?martech=off
- After: https://mwpw-138525--express--adobecom.hlx.page/drafts/sandra/edu-icon-list?martech=off
