### PR TITLE
[MWPW-137051] Fix breadcrumbs CLS

### DIFF
--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -108,13 +108,9 @@ async function loadFEDS() {
     : 'adobe-express/ax-gnav-x-row';
 
   async function buildBreadCrumbArray() {
-    if (isHomepage || getMetadata('hide-breadcrumbs') === 'true') {
+    if (isHomepage || getMetadata('breadcrumbs') !== 'on') {
       return null;
     }
-    const capitalize = (word) => word.charAt(0).toUpperCase() + word.slice(1);
-    const buildBreadCrumb = (path, name, parentPath = '') => (
-      { title: capitalize(name), url: `${parentPath}/${path}` }
-    );
 
     const placeholders = await fetchPlaceholders();
     const validSecondPathSegments = ['create', 'feature'];
@@ -136,6 +132,10 @@ async function loadFEDS() {
       return null;
     }
 
+    const capitalize = (word) => word.charAt(0).toUpperCase() + word.slice(1);
+    const buildBreadCrumb = (path, name, parentPath = '') => (
+      { title: capitalize(name), url: `${parentPath}/${path}` }
+    );
     const secondBreadCrumb = buildBreadCrumb(secondPathSegment, capitalize(replacedCategory), `${localePath}/express`);
     const breadCrumbList = [secondBreadCrumb];
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -8,6 +8,7 @@ import {
   setConfig,
   loadStyle,
   getMetadata,
+  createTag,
 } from './utils.js';
 
 const locales = {
@@ -87,6 +88,10 @@ const showNotifications = () => {
 (async function loadPage() {
   if (window.hlx.init || window.isTestEnv) return;
   setConfig(config);
+  if (getMetadata('hide-breadcrumbs') !== 'true' && !getMetadata('breadcrumbs') && !window.location.pathname.endsWith('/express/')) {
+    const meta = createTag('meta', { name: 'breadcrumbs', content: 'on' });
+    document.head.append(meta);
+  }
   if (getMetadata('breadcrumbs') === 'on' && !!getMetadata('breadcrumbs-base') && (!!getMetadata('short-title') || !!getMetadata('breadcrumbs-page-title'))) document.body.classList.add('breadcrumbs-spacing');
   showNotifications();
   await loadArea();

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -106,7 +106,7 @@ const showNotifications = () => {
 (async function loadPage() {
   if (window.hlx.init || window.isTestEnv) return;
   setConfig(config);
-  if (hasBreadcrumbs()) document.querySelector('body').classList.add('breadcrumbs-spacing');
+  if (hasBreadcrumbs()) document.body.classList.add('breadcrumbs-spacing');
   showNotifications();
   await loadArea();
 }());

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -7,7 +7,27 @@ import {
   registerPerformanceLogger,
   setConfig,
   loadStyle,
+  getMetadata,
 } from './utils.js';
+
+function hasBreadcrumbs() {
+  // breadcrumbs on/off
+  const breadcrumbsMetadata = getMetadata('breadcrumbs');
+  if (breadcrumbsMetadata !== 'on') return false;
+
+  // page short-title exists
+  const pageName = getMetadata('short-title');
+  if (pageName === '') return false;
+
+  // crumbs too shallow
+  const pathSegments = window.location.pathname.split('/').filter((e) => e !== '');
+  if (pathSegments.length <= pathSegments.indexOf('express') + 1) return false;
+
+  // non english locale (temporary)
+  if (pathSegments.indexOf('express') > 0) return false;
+
+  return true;
+}
 
 const locales = {
   '': { ietf: 'en-US', tk: 'jdq5hay.css' },
@@ -86,6 +106,7 @@ const showNotifications = () => {
 (async function loadPage() {
   if (window.hlx.init || window.isTestEnv) return;
   setConfig(config);
+  if (hasBreadcrumbs()) document.querySelector('body').classList.add('breadcrumbs-spacing');
   showNotifications();
   await loadArea();
 }());

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -10,25 +10,6 @@ import {
   getMetadata,
 } from './utils.js';
 
-function hasBreadcrumbs() {
-  // breadcrumbs on/off
-  const breadcrumbsMetadata = getMetadata('breadcrumbs');
-  if (breadcrumbsMetadata !== 'on') return false;
-
-  // page short-title exists
-  const pageName = getMetadata('short-title');
-  if (pageName === '') return false;
-
-  // crumbs too shallow
-  const pathSegments = window.location.pathname.split('/').filter((e) => e !== '');
-  if (pathSegments.length <= pathSegments.indexOf('express') + 1) return false;
-
-  // non english locale (temporary)
-  if (pathSegments.indexOf('express') > 0) return false;
-
-  return true;
-}
-
 const locales = {
   '': { ietf: 'en-US', tk: 'jdq5hay.css' },
   br: { ietf: 'pt-BR', tk: 'inq1xob.css' },
@@ -106,7 +87,7 @@ const showNotifications = () => {
 (async function loadPage() {
   if (window.hlx.init || window.isTestEnv) return;
   setConfig(config);
-  if (hasBreadcrumbs()) document.body.classList.add('breadcrumbs-spacing');
+  if (getMetadata('breadcrumbs') === 'on' && !!getMetadata('breadcrumbs-base') && (!!getMetadata('short-title') || !!getMetadata('breadcrumbs-page-title'))) document.body.classList.add('breadcrumbs-spacing');
   showNotifications();
   await loadArea();
 }());

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -39,6 +39,7 @@
 
   /* header */
   --header-height: 65px;
+  --breadcrumbs-height: 43px;
   --brand-header-height: 79px;
 
   /* body */
@@ -119,8 +120,14 @@ body > header {
 }
 
 .feds-topnav-spacing,
-body > header:not(.feds-header-wrapper){
+body > header{
   height: var(--header-height);
+}
+@media (min-width:900px) {
+  body.banner-spacing > .feds-topnav-spacing,
+  body.banner-spacing > header{
+    height: calc(var(--header-height) + var(--banner-height));
+  }
 }
 
 body>footer[data-status='loading']{

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -123,7 +123,7 @@ body > header {
 body > header{
   height: var(--header-height);
 }
-@media (min-width:900px) {
+@media (min-width: 900px) {
   body.banner-spacing > .feds-topnav-spacing,
   body.banner-spacing > header{
     height: calc(var(--header-height) + var(--banner-height));
@@ -507,7 +507,7 @@ main .section:last-of-type>.default-content-wrapper {
   padding-bottom: 40px;
 }
 
-@media (min-width:600px) {
+@media (min-width: 600px) {
 
   main h2 {
     font-size: var(--heading-font-size-l);
@@ -541,7 +541,7 @@ main .section:last-of-type>.default-content-wrapper {
   }
 }
 
-@media (min-width:900px) {
+@media (min-width: 900px) {
 
   main h5+p,
   main .section p.button-container {
@@ -553,7 +553,7 @@ main .section:last-of-type>.default-content-wrapper {
   }
 }
 
-@media(min-width:1200px) {
+@media(min-width: 1200px) {
   main h1,
   h2,
   h3,
@@ -682,7 +682,7 @@ main .section div .block p.legal-copy {
   line-height: 1.5;
 }
 
-@media (min-width:600px) {
+@media (min-width: 600px) {
   main .hero h5 {
     font-size: 22px;
     font-weight: 400;
@@ -700,7 +700,7 @@ main .section div .block p.legal-copy {
   }
 }
 
-@media (min-width:900px) {
+@media (min-width: 900px) {
   main .hero {
     padding-left: 50px;
     padding-right: 50px;
@@ -713,7 +713,7 @@ main .section div .block p.legal-copy {
   }
 }
 
-@media (min-width:1200px) {
+@media (min-width: 1200px) {
   main .hero h1 {
     font-size: var(--heading-font-size-xxl);
     margin: 0;
@@ -849,13 +849,13 @@ body[data-device="mobile"] main [data-audience="mobile"][data-section-status="lo
   display: block;
 }
 
-@media (min-width:900px) {
+@media (min-width: 900px) {
   main .section>div {
     max-width: 830px;
   }
 }
 
-@media (min-width:1200px) {
+@media (min-width: 1200px) {
   main .section>div {
     max-width: 1024px;
   }

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -124,9 +124,9 @@ body > header{
   height: var(--header-height);
 }
 @media (min-width: 900px) {
-  body.banner-spacing > .feds-topnav-spacing,
-  body.banner-spacing > header{
-    height: calc(var(--header-height) + var(--banner-height));
+  body.breadcrumbs-spacing > .feds-topnav-spacing,
+  body.breadcrumbs-spacing > header{
+    height: calc(var(--header-height) + var(--breadcrumbs-height));
   }
 }
 

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -119,13 +119,13 @@ body > header {
   background-color: #FFF;
 }
 
-.feds-topnav-spacing,
-body > header{
+body > .feds-topnav-spacing,
+body > header:not(.feds-header-wrapper){
   height: var(--header-height);
 }
 @media (min-width: 900px) {
   body.breadcrumbs-spacing > .feds-topnav-spacing,
-  body.breadcrumbs-spacing > header{
+  body.breadcrumbs-spacing > header:not(.feds-header-wrapper){
     height: calc(var(--header-height) + var(--breadcrumbs-height));
   }
 }


### PR DESCRIPTION
- Added a function "hasBreadcrumbs" to scripts.js to evaluate if a page has breadcrumbs or not. And applies a new class "breadcrumbs-spacing" to the body if breadcrumbs exist.
- In gnav.js the metadata tag for toggling breadcrumbs has been switched to Milos metadata tag in buildBreadCrumbArray function. And a couple lines in that function have been moved below a potential return condition to where they are used.
- A new css variable was added for the breadcrumb height and a rule applying it with the new body class.

Resolves: [MWPW-137051](https://jira.corp.adobe.com/browse/MWPW-137051)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/feature/image/resize?martech=off
- After: https://mwpw-137051--express--wbstry.hlx.page/express/feature/image/resize?martech=off
