### PR TITLE
[MWPW-136443] Removed "| Adobe Express" from blog post titles

### DIFF
--- a/express/blocks/blog-posts/blog-posts.js
+++ b/express/blocks/blog-posts/blog-posts.js
@@ -248,7 +248,7 @@ async function decorateBlogPosts($blogPosts, config, offset = 0) {
       timeZone: 'UTC',
     });
 
-    const filteredTitle = title.replace('｜ Adobe Express', '').replace('|Adobe Express', '').replace('| Adobe Express', '').replace('｜Adobe Express', '');
+    const filteredTitle = title.replace(/(\s?)(｜|\|)(\s?Adobe\sExpress\s?)$/g, '');
     const imagePath = image.split('?')[0].split('_')[1];
     const cardPicture = createOptimizedPicture(`./media_${imagePath}?format=webply&optimize=medium&width=750`, title, false, [{ width: '750' }]);
     const heroPicture = createOptimizedPicture(`./media_${imagePath}?format=webply&optimize=medium&width=750`, title, false);


### PR DESCRIPTION
Filtered the blog post title to remove the undesired substring using string replace. 
There seemed to be two distinct "|" pipe  characters, that and combinations of spaces led to requiring 4 replace statements. (could be replaced with a regex)

Resolves: [MWPW-136443](https://jira.corp.adobe.com/browse/MWPW-136443)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/jp/express/learn/blog?martech=off
- After: https://mwpw-136443--express--wbstry.hlx.page/jp/express/learn/blog?martech=off