### PR TITLE
Add nomodule for legacy-browser.js to save bytes

### DIFF
--- a/express/scripts/legacy-browser.js
+++ b/express/scripts/legacy-browser.js
@@ -1,5 +1,4 @@
 /* eslint-disable */
-console.log(window.fetch);
 if (Math.random() < 0.1) {
   var hashCode = function hashCode(s) {
     return s.split('').reduce(function (a, b) {

--- a/express/scripts/legacy-browser.js
+++ b/express/scripts/legacy-browser.js
@@ -1,21 +1,19 @@
 /* eslint-disable */
-if ((!window.fetch) || (window.location.href.indexOf('legacy=on') >= 0)) { 
-  console.log(window.fetch);
-  if (Math.random() < 0.1) {
-    var hashCode = function hashCode(s) {
-      return s.split('').reduce(function (a, b) {
-        return (a << 5) - a + b.charCodeAt(0) | 0;
-      }, 0);
-    };  
-    var id = ''.concat(hashCode(window.location.href), '-').concat(new Date().getTime(), '-').concat(Math.random().toString(16).substr(2, 14));
-    var data = JSON.stringify({ referer: window.location.href, checkpoint: 'unsupported', weight: 10, id: id }); var img = new Image(); img.src = 'https://rum.hlx3.page/.rum/10?data='+encodeURIComponent(data);  
-  }
-  var locale = window.location.href.split('/')[3];
-  var redirect = 'https://express.adobe.com/unsupported';
-  var redirects = { 
-    jp: 'https://express.adobe.com/ja-JP/unsupported',
-    kr: 'https://express.adobe.com/ko-KR/unsupported',
-  };
-  if (locale && redirects[locale]) redirect = redirects[locale];
-  setTimeout(window.location.href = redirect, 2000);
+console.log(window.fetch);
+if (Math.random() < 0.1) {
+  var hashCode = function hashCode(s) {
+    return s.split('').reduce(function (a, b) {
+      return (a << 5) - a + b.charCodeAt(0) | 0;
+    }, 0);
+  };  
+  var id = ''.concat(hashCode(window.location.href), '-').concat(new Date().getTime(), '-').concat(Math.random().toString(16).substr(2, 14));
+  var data = JSON.stringify({ referer: window.location.href, checkpoint: 'unsupported', weight: 10, id: id }); var img = new Image(); img.src = 'https://rum.hlx3.page/.rum/10?data='+encodeURIComponent(data);  
 }
+var locale = window.location.href.split('/')[3];
+var redirect = 'https://express.adobe.com/unsupported';
+var redirects = { 
+  jp: 'https://express.adobe.com/ja-JP/unsupported',
+  kr: 'https://express.adobe.com/ko-KR/unsupported',
+};
+if (locale && redirects[locale]) redirect = redirects[locale];
+setTimeout(window.location.href = redirect, 2000);

--- a/head.html
+++ b/head.html
@@ -1,5 +1,5 @@
 <link id="favicon" rel="icon" type="image/svg+xml" href="/express/icons/cc-express.svg">
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
+<script src="/express/scripts/legacy-browser.js" nomodule></script>
 <script src="/express/scripts/scripts.js" type="module"></script>
 <link rel="stylesheet" href="/express/styles/styles.css"/>
-<script src="/express/scripts/legacy-browser.js" defer></script>


### PR DESCRIPTION
As of now, our legacy-browser.js is always loaded and parsed as a defer script. Using the nomodule feature and reversing the logic inside legacy-browser.js, we can avoid downloading that file for modern browsers, while keeping our support for legacy browsers. On every page this can save 500+ bytes and 1 precious network request (huge when we are running experiments). This also complies more with milo projects.

You should see legacy-browser.js no longer getting downloaded in the branch link.

Resolves: https://jira.corp.adobe.com/browse/MWPW-139943

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/
- After: https://legacy-browser-nomodule--express--adobecom.hlx.page/express/templates/flyer?lighthouse=on
