### PR TITLE
[Floating-CTA] Same as floating CTA matching criteria fix

### DIFF
--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -144,7 +144,8 @@ export async function createFloatingButton(block, audience, data) {
 
   // Hide CTAs with same url & text as the Floating CTA && is NOT a Floating CTA (in mobile/tablet)
   const sameUrlCTAs = Array.from(main.querySelectorAll('a.button:any-link'))
-    .filter((a) => (a.textContent.trim() === aTag.textContent.trim() || a.href === aTag.href)
+    .filter((a) => (a.textContent.trim() === aTag.textContent.trim()
+    || new URL(a.href).pathname === new URL(aTag.href).pathname)
       && !a.parentElement.parentElement.classList.contains('floating-button'));
   sameUrlCTAs.forEach((cta) => {
     cta.classList.add('same-as-floating-button-CTA');


### PR DESCRIPTION
Comparing these two pages:
Bouncing Arrow > https://www.adobe.com/uk/express/learn/students
No Bouncing Arrow > https://www.adobe.com/express/learn/students
We realize the code in floating-cta.js for matching existing button on the page is comparing url with no USP with url with USP, thus causing a false negative. This PR should fix it.

The telling sign is when you see on the UK desktop page the floating CTA doesn't have a boucing arrow anymore, like how it is on US page.

Resolves: [MWPW-139972](https://jira.corp.adobe.com/browse/MWPW-139972)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/uk/express/learn/students?martech=off
- After: https://desktop-floating-cta-arrow-fix--express--adobecom.hlx.page/uk/express/learn/students?martech=off
