### PR TITLE
[MWPW-138913][Experimentation] Rush GNAV For Personalization

### DIFF
--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1553,7 +1553,8 @@ export async function getExperimentConfig(experimentId) {
 async function loadAndRunExp(config, forcedExperiment, forcedVariant, usp) {
   const promises = [import('./experiment.js')];
   if (getMetadata('aepaudience') === 'on') {
-    // only aep exps: rush alloy thru launch
+    // need gnav ims asap: alloy waits on primaryProfileInfo
+    loadGnav();
     promises.push(loadScript('/express/scripts/instrument.js', 'module'));
     const t1 = performance.now();
     let alloyLoadingResolver;


### PR DESCRIPTION
Try also rushing GNAV during experimentation. Since alloy waits for IMS's primaryProfile, we had a deadlock as GNAV and IMS don't get loaded until page is rendered, which won't happen until alloy gets back (or reach 5s timeout). You should see that things load much faster once merged. Note that you won't see this in branch links, since we don't run experiments on branch links.

Resolves: https://jira.corp.adobe.com/browse/MWPW-138913

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/experiments/ccx0167/home
- After: https://alloy-rush-gnav--express--adobecom.hlx.page/express/experiments/ccx0167/home
