### PR TITLE
add audience specific cta text capability

### DIFF
--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -98,9 +98,10 @@ export function initLottieArrow(lottieScrollButton, floatButtonWrapper, scrollAn
 function makeCTAFromSheet(block, data) {
   const audience = block.querySelector(':scope > div').textContent.trim();
   const audienceSpecificUrl = audience && ['desktop', 'mobile'].includes(audience) ? data.mainCta[`${audience}Href`] : null;
+  const audienceSpecificText = audience && ['desktop', 'mobile'].includes(audience) ? data.mainCta[`${audience}Text`] : null;
   const buttonContainer = createTag('div', { class: 'button-container' });
-  const ctaFromSheet = createTag('a', { href: audienceSpecificUrl || data.mainCta.href, title: data.mainCta.text });
-  ctaFromSheet.textContent = data.mainCta.text;
+  const ctaFromSheet = createTag('a', { href: audienceSpecificUrl || data.mainCta.href, title: audienceSpecificText || data.mainCta.text });
+  ctaFromSheet.textContent = audienceSpecificText || data.mainCta.text;
   buttonContainer.append(ctaFromSheet);
   block.append(buttonContainer);
 
@@ -331,6 +332,14 @@ export async function collectFloatingButtonData() {
 
     if (key === 'mobile cta link') {
       data.mainCta.mobileHref = value;
+    }
+
+    if (key === 'desktop cta text') {
+      data.mainCta.desktopText = value;
+    }
+
+    if (key === 'mobile cta text') {
+      data.mainCta.mobileText = value;
     }
 
     if (key === 'main cta link') {


### PR DESCRIPTION
Floating CTA Sheet now has the ability to assign different text for different audience

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/entitled?martech=off
- After: https://cta-text-split--express--adobecom.hlx.page/express/entitled?martech=off
