### PR TITLE
fix desktop missing floating CTA

### DIFF
--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -239,44 +239,44 @@ export async function createFloatingButton(block, audience, data) {
     },
   }));
 
-  if (document.body.dataset.device === 'desktop' || data.useLottieArrow) {
-    const heroCTA = document.querySelector('a.button.same-as-floating-button-CTA');
-    if (heroCTA) {
-      const hideButtonWhenIntersecting = new IntersectionObserver(([e]) => {
-        if (e.boundingClientRect.top > window.innerHeight - 40 || e.boundingClientRect.top === 0) {
-          floatButtonWrapper.classList.remove('floating-button--below-the-fold');
-          floatButtonWrapper.classList.add('floating-button--above-the-fold');
-        } else {
-          floatButtonWrapper.classList.add('floating-button--below-the-fold');
-          floatButtonWrapper.classList.remove('floating-button--above-the-fold');
-        }
-        if (e.intersectionRatio > 0 || e.isIntersecting) {
-          floatButtonWrapper.classList.add('floating-button--intersecting');
-          floatButton.style.bottom = '0px';
-        } else {
-          floatButtonWrapper.classList.remove('floating-button--intersecting');
-          if (promoBar && promoBar.block) {
-            floatButton.style.bottom = currentBottom ? `${currentBottom + promoBarHeight}px` : `${promoBarHeight}px`;
-          } else if (currentBottom) {
-            floatButton.style.bottom = currentBottom;
-          }
-        }
-      }, {
-        root: null,
-        rootMargin: '-40px 0px',
-        threshold: 0,
-      });
-      if (document.readyState === 'complete') {
-        hideButtonWhenIntersecting.observe(heroCTA);
+  const heroCTA = document.querySelector('a.button.same-as-floating-button-CTA');
+  if (heroCTA) {
+    const hideButtonWhenIntersecting = new IntersectionObserver(([e]) => {
+      if (e.boundingClientRect.top > window.innerHeight - 40 || e.boundingClientRect.top === 0) {
+        floatButtonWrapper.classList.remove('floating-button--below-the-fold');
+        floatButtonWrapper.classList.add('floating-button--above-the-fold');
       } else {
-        window.addEventListener('load', () => {
-          hideButtonWhenIntersecting.observe(heroCTA);
-        });
+        floatButtonWrapper.classList.add('floating-button--below-the-fold');
+        floatButtonWrapper.classList.remove('floating-button--above-the-fold');
       }
+      if (e.intersectionRatio > 0 || e.isIntersecting) {
+        floatButtonWrapper.classList.add('floating-button--intersecting');
+        floatButton.style.bottom = '0px';
+      } else {
+        floatButtonWrapper.classList.remove('floating-button--intersecting');
+        if (promoBar && promoBar.block) {
+          floatButton.style.bottom = currentBottom ? `${currentBottom + promoBarHeight}px` : `${promoBarHeight}px`;
+        } else if (currentBottom) {
+          floatButton.style.bottom = currentBottom;
+        }
+      }
+    }, {
+      root: null,
+      rootMargin: '-40px 0px',
+      threshold: 0,
+    });
+    if (document.readyState === 'complete') {
+      hideButtonWhenIntersecting.observe(heroCTA);
     } else {
-      floatButtonWrapper.classList.add('floating-button--above-the-fold');
+      window.addEventListener('load', () => {
+        hideButtonWhenIntersecting.observe(heroCTA);
+      });
     }
+  } else {
+    floatButtonWrapper.classList.add('floating-button--above-the-fold');
+  }
 
+  if (data.useLottieArrow) {
     const lottieScrollButton = buildLottieArrow(floatButtonWrapper, floatButton, data);
     document.dispatchEvent(new CustomEvent('linkspopulated', { detail: [floatButtonLink, lottieScrollButton] }));
   } else {

--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -239,7 +239,7 @@ export async function createFloatingButton(block, audience, data) {
     },
   }));
 
-  if (data.useLottieArrow) {
+  if (document.body.dataset.device === 'desktop' || data.useLottieArrow) {
     const heroCTA = document.querySelector('a.button.same-as-floating-button-CTA');
     if (heroCTA) {
       const hideButtonWhenIntersecting = new IntersectionObserver(([e]) => {


### PR DESCRIPTION
Desktop Floating CTA is missing on pages with useLottieArrow is toggled to off. This PR should fix it

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER) pending

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/entitled?martech=off
- After: https://missing-desktop-fcta-fix--express--adobecom.hlx.page/express/entitled?martech=off
