### PR TITLE
[TemplateX] Remove Temporary Workaround for Akamai Cache Collision

### DIFF
--- a/express/blocks/template-x/template-search-api-v3.js
+++ b/express/blocks/template-x/template-search-api-v3.js
@@ -105,7 +105,7 @@ async function fetchSearchUrl({
     'Oldest to Newest': '&orderBy=availabilityDate',
   }[sort] || sort || '';
   const qParam = q && q !== '{{q}}' ? `&q=${q}` : '';
-  let url = encodeURI(
+  const url = encodeURI(
     `${base}?${collectionIdParam}${queryParam}${qParam}${limitParam}${startParam}${sortParam}${filterStr}`,
   );
 
@@ -114,15 +114,12 @@ async function fetchSearchUrl({
     return memoizedFetch(url);
   }
 
-  // temporarily adding extra dummy queryParams to avoid cache collision
   const headers = {};
   const prefLang = getConfig().locales?.[langs[0] === 'en' ? '' : langs[0]]?.ietf;
   const [prefRegion] = extractRegions(filters.locales);
   headers['x-express-ims-region-code'] = prefRegion; // Region Boosting
-  url += `&regionHeader=${prefRegion}`; // TODO: remove once CDN includes headers when calculating cache key
   if (prefLang && supportedLanguages.includes(prefLang)) {
     headers['x-express-pref-lang'] = prefLang; // Language Boosting
-    url += `&prefLangHeader=${prefLang}`; // TODO: remove once CDN includes headers when calculating cache key
   }
 
   const res = await memoizedFetch(url, { headers });


### PR DESCRIPTION
After 12/12, our cache should start taking in the 2 header values as part of the cache key, so the workaround I added earlier can be removed.

Resolves: https://jira.corp.adobe.com/browse/MWPW-140074?filter=381833

After 12/12, you should see the branch link and PROD behaving the same, despite the branch link no longer having headers appended to its query params.

Test URLs:
- Before: https://main--express--adobecom.hlx.page/drafts/jingle/template-x-locales
- After: https://undo-template-header-workaround--express--adobecom.hlx.page/drafts/jingle/template-x-locales?martech=off&gnav=off
