### PR TITLE
[Mobile Beta][Benchmark Gating] Fix Android Typo

### DIFF
--- a/express/scripts/mobile-beta-gating.js
+++ b/express/scripts/mobile-beta-gating.js
@@ -48,7 +48,7 @@ function runBenchmark() {
         cpuSpeedPass: e.data <= MAX_EXEC_TIME_ALLOWED,
       };
 
-      if (getMobileOperatingSystem() === 'android') {
+      if (getMobileOperatingSystem() === 'Android') {
         criterion.cpuCoreCountPass = (navigator.hardwareConcurrency
           && navigator.hardwareConcurrency >= 4)
         || false;


### PR DESCRIPTION
As of now, the matching for Android actually always fails due to a typo. This should fix taht

Resolves: https://jira.corp.adobe.com/browse/MWPW-140374

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/learn/students?gnav=off&martech=off
- After: https://mobile-gating-typo--express--adobecom.hlx.page/express/learn/students?gnav=off&martech=off
