### PR TITLE
[PEP] Fix using loadStyle from loadCSS

### DIFF
--- a/express/features/direct-path-to-product/direct-path-to-product.js
+++ b/express/features/direct-path-to-product/direct-path-to-product.js
@@ -14,14 +14,14 @@ import {
   createTag,
   fetchPlaceholders,
   getIconElement,
-  loadCSS,
+  loadStyle,
 } from '../../scripts/utils.js';
 import BlockMediator from '../../scripts/block-mediator.js';
 
 export default async function loadLoginUserAutoRedirect() {
   let followThrough = true;
   const placeholders = await fetchPlaceholders();
-  loadCSS('/express/features/direct-path-to-product/direct-path-to-product.css');
+  loadStyle('/express/features/direct-path-to-product/direct-path-to-product.css');
 
   const buildRedirectAlert = async (profile) => {
     const container = createTag('div', { class: 'bmtp-container' });


### PR DESCRIPTION
Fix a fn naming issue caused by code conflicts

Resolves: [[Desktop] RTP CCX0137- Direct Path to Product](https://jira.corp.adobe.com/browse/MWPW-137828)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/create/advertisement/cyber-monday
- After: https://pep-css--express--adobecom.hlx.page/express/create/advertisement/cyber-monday?martech=off
