### PR TITLE
[MWPW-140339] fix pricing page carousel

### DIFF
--- a/express/blocks/puf/puf.css
+++ b/express/blocks/puf/puf.css
@@ -373,7 +373,8 @@ main .block.puf .puf-card-container {
 
 main .block.puf .carousel-container .carousel-fader-left,
 main .block.puf .carousel-container .carousel-fader-right {
-    margin-top: 100px;
+    margin-top: 86px;
+    height: calc(100% - 172px);
 }
 
 main .block.puf .carousel-container .carousel-fader-left a.button.carousel-arrow,

--- a/express/blocks/puf/puf.js
+++ b/express/blocks/puf/puf.js
@@ -407,7 +407,7 @@ async function build2ColDesign(block) {
   const options = {
     root: document.querySelector('.carousel-platform'),
     rootMargin: '0px',
-    threshold: 0.75,
+    threshold: 0.55,
   };
   const carouselContainer = block.querySelector('.carousel-container');
   const callback = (entries) => {

--- a/express/blocks/puf/puf.js
+++ b/express/blocks/puf/puf.js
@@ -407,7 +407,7 @@ async function build2ColDesign(block) {
   const options = {
     root: document.querySelector('.carousel-platform'),
     rootMargin: '0px',
-    threshold: 1,
+    threshold: 0.75,
   };
   const carouselContainer = block.querySelector('.carousel-container');
   const callback = (entries) => {
@@ -417,9 +417,6 @@ async function build2ColDesign(block) {
         carouselContainer.style.maxHeight = 'none';
       } else {
         carouselContainer.style.maxHeight = `${entry.target.clientHeight}px`;
-        alert('intersecting');
-        alert(entry.target.clientHeight);
-        alert(carouselContainer.style.maxHeight);
       }
     });
   };

--- a/express/blocks/puf/puf.js
+++ b/express/blocks/puf/puf.js
@@ -417,6 +417,9 @@ async function build2ColDesign(block) {
         carouselContainer.style.maxHeight = 'none';
       } else {
         carouselContainer.style.maxHeight = `${entry.target.clientHeight}px`;
+        alert('intersecting');
+        alert(entry.target.clientHeight);
+        alert(carouselContainer.style.maxHeight);
       }
     });
   };

--- a/express/blocks/puf/puf.js
+++ b/express/blocks/puf/puf.js
@@ -410,12 +410,6 @@ async function build2ColDesign(block) {
     threshold: 1,
   };
   const carouselContainer = block.querySelector('.carousel-container');
-  const carouselLeftControlContainer = carouselContainer.querySelector(
-    '.carousel-fader-left',
-  );
-  const carouselRightControlContainer = carouselContainer.querySelector(
-    '.carousel-fader-right',
-  );
   const callback = (entries) => {
     entries.forEach((entry) => {
       if (!entry.isIntersecting) return;
@@ -424,12 +418,6 @@ async function build2ColDesign(block) {
       } else {
         carouselContainer.style.maxHeight = `${entry.target.clientHeight}px`;
       }
-      carouselLeftControlContainer.style.maxHeight = `${
-        entry.target.clientHeight - 125
-      }px`;
-      carouselRightControlContainer.style.maxHeight = `${
-        entry.target.clientHeight - 125
-      }px`;
     });
   };
 

--- a/express/blocks/shared/carousel.js
+++ b/express/blocks/shared/carousel.js
@@ -164,12 +164,12 @@ export function onCarouselCSSLoad(selector, parent, options) {
       platform.classList.add('left-fader', 'right-fader');
     }
 
+    if (!opts.infinityScrollEnabled) initToggleTriggers(container);
     const onIntersect = ([entry], observer) => {
       if (!entry.isIntersecting) return;
 
       if (opts.centerAlign) correctCenterAlignment(scrollable);
       if (opts.startPosition === 'right') moveCarousel(-scrollable.scrollWidth);
-      if (!opts.infinityScrollEnabled) initToggleTriggers(container);
 
       observer.unobserve(scrollable);
     };


### PR DESCRIPTION
Lowered the intersection threshold to account for the small additional width of faders/triggers preventing the carousel cards from intersecting their parent container 100%. 

In my tests, this corrects the issue of carousel container height not being updated on mobile (for android) on the pricing page when switching between pricing plans.

I also updated the height of the arrow faders to be more symmetrical when it comes to where the sticky arrow icons stop at the top and bottom of the cards.

---HOW TO TEST---
- Open inspector on the pricing page
     - View on a virtual device (issue was found using Pixel 5)
     - In the performance tab **throttle the CPU** as much as possible (6x)
     - Refresh the page
- Identify if the issues are present (**refresh the page multiple times to ensure that the result is consistent**)
     - Before test URL 
          - You should see the left/right arrows are not visible (occasionally they do showed up even throttled, refresh)
          - Scroll to the bottom of the price card carousel and swipe between the tall and short price cards 
             You *may* see the container height does not adjust and content on the tall card is cut off 
             (I only saw this part of the issue on an actual mobile android device)
     - After test URL
          - You should see the left/right arrows are visible every time the page is loaded
          - Scroll to the bottom of the price card carousel and swipe between the tall and short price cards
             You should see the container height adjusts to match the card when the card enters ~50% into the container

Resolves: [MWPW-140339](https://jira.corp.adobe.com/browse/MWPW-140339)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/pricing?martech=off
- After: https://mwpw-140339-fix-pricing-page--express--wbstry.hlx.page/express/pricing?martech=off
