### PR TITLE
MWPW-140535 allow for option to floating cta to stay closed

### DIFF
--- a/express/blocks/multifunction-button/multifunction-button.js
+++ b/express/blocks/multifunction-button/multifunction-button.js
@@ -12,15 +12,19 @@ import {
   closeToolBox,
 } from '../shared/floating-cta.js';
 
-function toggleMultifunctionToolBox($wrapper, $lottie, data, userInitiated = true) {
+function toggleMultifunctionToolBox(wrapper, $lottie, data, userInitiated = true) {
   if (userInitiated) {
-    $wrapper.classList.remove('initial-load');
+    wrapper.classList.remove('initial-load');
+  }
+  if (wrapper.classList.contains('initial-load') && wrapper.classList.contains('closed')) {
+    wrapper.classList.remove('closed');
+    return;
   }
 
-  if ($wrapper.classList.contains('toolbox-opened')) {
-    openToolBox($wrapper, $lottie, data, userInitiated);
+  if (wrapper.classList.contains('toolbox-opened')) {
+    openToolBox(wrapper, $lottie, data, userInitiated);
   } else {
-    closeToolBox($wrapper, $lottie);
+    closeToolBox(wrapper, $lottie);
   }
 }
 

--- a/express/blocks/shared/floating-cta.css
+++ b/express/blocks/shared/floating-cta.css
@@ -354,7 +354,6 @@ main .floating-button-wrapper.multifunction .toolbox-background {
     transform: unset;
     height: 200vh;
     width: 100vw;
-    background-color: var(--color-black);
     z-index: 0;
     opacity: 0;
     transition: opacity 0.5s;
@@ -362,6 +361,7 @@ main .floating-button-wrapper.multifunction .toolbox-background {
 
 main .floating-button-wrapper.multifunction.toolbox-opened .toolbox-background {
     pointer-events: auto;
+    background-color: var(--color-black);
     opacity: 0.75;
 }
 

--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -158,6 +158,7 @@ export async function createFloatingButton(block, audience, data) {
     'data-block-name': 'floating-button',
     'data-block-status': 'loaded',
   });
+  [...block.classList].filter((c) => c !== 'block').forEach((c) => floatButtonWrapper.classList.add(c));
   const floatButtonInnerWrapper = createTag('div', { class: 'floating-button-inner-wrapper' });
   const floatButtonBackground = createTag('div', { class: 'floating-button-background' });
 
@@ -420,8 +421,12 @@ export function buildToolBoxStructure(wrapper, data) {
 
   wrapper.classList.add('initial-load');
   wrapper.classList.add('clamped');
-  wrapper.classList.add('toolbox-opened');
-  floatingButton.classList.add('toolbox-opened');
+  if (wrapper.classList.contains('closed')) {
+    toolBox.classList.add('hidden');
+  } else {
+    wrapper.classList.add('toolbox-opened');
+    floatingButton.classList.add('toolbox-opened');
+  }
 }
 
 export function initToolBox(wrapper, data, toggleFunction) {

--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -158,7 +158,7 @@ export async function createFloatingButton(block, audience, data) {
     'data-block-name': 'floating-button',
     'data-block-status': 'loaded',
   });
-  [...block.classList].filter((c) => c !== 'block').forEach((c) => floatButtonWrapper.classList.add(c));
+  [...block.classList].filter((c) => c === 'closed').forEach((c) => floatButtonWrapper.classList.add(c));
   const floatButtonInnerWrapper = createTag('div', { class: 'floating-button-inner-wrapper' });
   const floatButtonBackground = createTag('div', { class: 'floating-button-background' });
 

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1875,11 +1875,13 @@ async function buildAutoBlocks($main) {
       const floatingCTAData = await fetchFloatingCta(window.location.pathname);
       const validButtonVersion = ['floating-button', 'multifunction-button', 'bubble-ui-button', 'floating-panel'];
       const device = document.body.dataset?.device;
-      const blockName = floatingCTAData?.[device];
+      const blockNameWithVariants = floatingCTAData?.[device] ? floatingCTAData?.[device].split(' ') : [];
+      const blockName = blockNameWithVariants.shift();
 
       if (validButtonVersion.includes(blockName) && $lastDiv) {
         const button = buildBlock(blockName, device);
         button.classList.add('spreadsheet-powered');
+        blockNameWithVariants.forEach((variant) => button.classList.add(variant));
         $lastDiv.append(button);
       }
 


### PR DESCRIPTION
Allow for option to not auto-open the floating cta toolbox

Resolves: [MWPW-140535](https://jira.corp.adobe.com/browse/MWPW-140535)

To test this, you'll need to override the object you get in the utils.js file on line 1875. The floatingCTAData?.[device] must contain the values 'multifunction-button closed'

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/create/flyer?experiment=ccx0098%2Fchallenger-1
- After: https://MWPW-140535-closed-option-floating-cta--express--adobecom.hlx.page/express/create/flyer?experiment=ccx0098%2Fchallenger-1
