### PR TITLE
[DOTCOM-108489] - Editor Choice icon is broken on sticky footer (design-app page)

### DIFF
--- a/express/blocks/sticky-footer/sticky-footer.css
+++ b/express/blocks/sticky-footer/sticky-footer.css
@@ -97,10 +97,19 @@ main .sticky-footer .rating-stars {
 
 main .sticky-footer .rating-stars svg {
     color: var(--color-premium);
+
 }
 
 main .sticky-footer .rating-stars .rating-votes {
     margin-left: 4px;
+}
+
+main .sticky-footer .icon-icon-editor-choice {
+    width: auto;
+}
+
+main .sticky-footer .rating-stars {
+    margin-left: 5px;
 }
 
 @media not (min-width: 900px) {

--- a/express/blocks/sticky-footer/sticky-footer.css
+++ b/express/blocks/sticky-footer/sticky-footer.css
@@ -97,7 +97,6 @@ main .sticky-footer .rating-stars {
 
 main .sticky-footer .rating-stars svg {
     color: var(--color-premium);
-
 }
 
 main .sticky-footer .rating-stars .rating-votes {


### PR DESCRIPTION
Resolves: [DOTCOM-108489](https://jira.corp.adobe.com/browse/DOTCOM-108489)

**Description:** 
- The live page is rendering an img instead of an icon. Changed the authoring page to target the right icon. Then added margin to add spacing between the icons.

**Test URLs:**
- Live site with broken img: https://www.adobe.com/in/express/design-app
- Before: https://main--express--adobecom.hlx.page/in/express/design-app?martech=off
- After: https://dotcom-108489--express--adobecom.hlx.page/in/express/design-app?martech=off
