### PR TITLE
Added All Locale Options to Sidekick Modal

### DIFF
--- a/express/blocks/locale-flow/locale-flow.js
+++ b/express/blocks/locale-flow/locale-flow.js
@@ -1,6 +1,6 @@
-import { createTag } from '../../scripts/utils.js';
+import { createTag, getConfig } from '../../scripts/utils.js';
 
-const locales = ['English', 'French', 'German', 'Japanese'];
+const locales = Object.keys(getConfig().locales).map((l) => l || 'en');
 
 const createForm = () => {
   let selectedLocales = [];


### PR DESCRIPTION
Followup to https://github.com/adobecom/express/pull/520 by adding all locales. They don't need to be in human friendly language names as the model can also recognize language code

Resolves: https://jira.corp.adobe.com/browse/MWPW-140777

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/
- After: https://locale-flow-all-locales--express--adobecom.hlx.page/express/?martech=off
