### PR TITLE
PUF Highlight Border Fix

### DIFF
--- a/express/blocks/puf/puf.css
+++ b/express/blocks/puf/puf.css
@@ -429,14 +429,15 @@ main .block.puf .carousel-container .carousel-platform .puf-card-container .puf-
         box-shadow: none;
     }
 
-    main .block.puf .puf-card-container .puf-card-border .puf-card.puf-left {
+    /* main .block.puf .puf-card-container .puf-card-border .puf-card.puf-left {
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
     }
 
     main .block.puf .puf-card-container .puf-card-border:has(.puf-left) {
         padding-right: 0;
-    }
+    } */
+    
 
     main .block.puf .carousel-container .carousel-platform .puf-card-container {
         align-self: stretch;

--- a/express/blocks/puf/puf.css
+++ b/express/blocks/puf/puf.css
@@ -429,16 +429,6 @@ main .block.puf .carousel-container .carousel-platform .puf-card-container .puf-
         box-shadow: none;
     }
 
-    /* main .block.puf .puf-card-container .puf-card-border .puf-card.puf-left {
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
-    }
-
-    main .block.puf .puf-card-container .puf-card-border:has(.puf-left) {
-        padding-right: 0;
-    } */
-    
-
     main .block.puf .carousel-container .carousel-platform .puf-card-container {
         align-self: stretch;
         max-width: 100%;


### PR DESCRIPTION
Now when highlighting cards other than the right one, we'll have proper "eyebrow". Note that this PR resolves the issue by treating 2 cards equally, thus you'll see the cards no longer being sticking together. This compromise is approved.

Resolves: https://jira.corp.adobe.com/browse/MWPW-141116

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/jinglhua/pricing?martech=off
- After: https://puf-recommend-left--express--adobecom.hlx.page/drafts/jinglhua/pricing?martech=off
