### PR TITLE
Mwpw 137051 breadcrumb cls

### DIFF
--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -109,13 +109,9 @@ async function loadFEDS() {
     : 'adobe-express/ax-gnav-x-row';
 
   async function buildBreadCrumbArray() {
-    if (isHomepage || getMetadata('hide-breadcrumbs') === 'true') {
+    if (isHomepage || getMetadata('breadcrumbs') !== 'on') {
       return null;
     }
-    const capitalize = (word) => word.charAt(0).toUpperCase() + word.slice(1);
-    const buildBreadCrumb = (path, name, parentPath = '') => (
-      { title: capitalize(name), url: `${parentPath}/${path}` }
-    );
 
     const placeholders = await fetchPlaceholders();
     const validSecondPathSegments = ['create', 'feature'];
@@ -137,6 +133,10 @@ async function loadFEDS() {
       return null;
     }
 
+    const capitalize = (word) => word.charAt(0).toUpperCase() + word.slice(1);
+    const buildBreadCrumb = (path, name, parentPath = '') => (
+      { title: capitalize(name), url: `${parentPath}/${path}` }
+    );
     const secondBreadCrumb = buildBreadCrumb(secondPathSegment, capitalize(replacedCategory), `${localePath}/express`);
     const breadCrumbList = [secondBreadCrumb];
 

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -148,7 +148,6 @@ async function loadFEDS() {
     ? 'adobe-express/ax-gnav-x'
     : 'adobe-express/ax-gnav-x-row';
 
-  // eslint-disable-next-line import/prefer-default-export
   window.fedsConfig = {
     ...(window.fedsConfig || {}),
 

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -61,6 +61,46 @@ function loadIMS() {
   }
 }
 
+// eslint-disable-next-line import/prefer-default-export
+export async function buildBreadCrumbArray(prefix) {
+  if (isHomepage || getMetadata('breadcrumbs') !== 'on') {
+    return null;
+  }
+
+  const placeholders = await fetchPlaceholders();
+  const validSecondPathSegments = ['create', 'feature'];
+  const pathSegments = window.location.pathname
+    .split('/')
+    .filter((e) => e !== '')
+    .filter((e) => e !== prefix);
+  const localePath = prefix === '' ? '' : `${prefix}/`;
+  const secondPathSegment = pathSegments[1].toLowerCase();
+  const pagesShortNameElement = document.head.querySelector('meta[name="short-title"]');
+  const pagesShortName = pagesShortNameElement?.getAttribute('content') ?? null;
+  const replacedCategory = placeholders[`breadcrumbs-${secondPathSegment}`]?.toLowerCase();
+
+  if (!pagesShortName
+    || pathSegments.length <= 2
+    || !replacedCategory
+    || !validSecondPathSegments.includes(replacedCategory)
+    || prefix !== '') { // Remove this line once locale translations are complete
+    return null;
+  }
+
+  const capitalize = (word) => word.charAt(0).toUpperCase() + word.slice(1);
+  const buildBreadCrumb = (path, name, parentPath = '') => (
+    { title: capitalize(name), url: `${parentPath}/${path}` }
+  );
+  const secondBreadCrumb = buildBreadCrumb(secondPathSegment, capitalize(replacedCategory), `${localePath}/express`);
+  const breadCrumbList = [secondBreadCrumb];
+
+  if (pathSegments.length >= 3) {
+    const thirdBreadCrumb = buildBreadCrumb(pagesShortName, pagesShortName, secondBreadCrumb.url);
+    breadCrumbList.push(thirdBreadCrumb);
+  }
+  return breadCrumbList;
+}
+
 async function loadFEDS() {
   const config = getConfig();
   const prefix = config.locale.prefix.replaceAll('/', '');
@@ -108,45 +148,7 @@ async function loadFEDS() {
     ? 'adobe-express/ax-gnav-x'
     : 'adobe-express/ax-gnav-x-row';
 
-  async function buildBreadCrumbArray() {
-    if (isHomepage || getMetadata('breadcrumbs') !== 'on') {
-      return null;
-    }
-
-    const placeholders = await fetchPlaceholders();
-    const validSecondPathSegments = ['create', 'feature'];
-    const pathSegments = window.location.pathname
-      .split('/')
-      .filter((e) => e !== '')
-      .filter((e) => e !== prefix);
-    const localePath = prefix === '' ? '' : `${prefix}/`;
-    const secondPathSegment = pathSegments[1].toLowerCase();
-    const pagesShortNameElement = document.head.querySelector('meta[name="short-title"]');
-    const pagesShortName = pagesShortNameElement?.getAttribute('content') ?? null;
-    const replacedCategory = placeholders[`breadcrumbs-${secondPathSegment}`]?.toLowerCase();
-
-    if (!pagesShortName
-      || pathSegments.length <= 2
-      || !replacedCategory
-      || !validSecondPathSegments.includes(replacedCategory)
-      || prefix !== '') { // Remove this line once locale translations are complete
-      return null;
-    }
-
-    const capitalize = (word) => word.charAt(0).toUpperCase() + word.slice(1);
-    const buildBreadCrumb = (path, name, parentPath = '') => (
-      { title: capitalize(name), url: `${parentPath}/${path}` }
-    );
-    const secondBreadCrumb = buildBreadCrumb(secondPathSegment, capitalize(replacedCategory), `${localePath}/express`);
-    const breadCrumbList = [secondBreadCrumb];
-
-    if (pathSegments.length >= 3) {
-      const thirdBreadCrumb = buildBreadCrumb(pagesShortName, pagesShortName, secondBreadCrumb.url);
-      breadCrumbList.push(thirdBreadCrumb);
-    }
-    return breadCrumbList;
-  }
-
+  // eslint-disable-next-line import/prefer-default-export
   window.fedsConfig = {
     ...(window.fedsConfig || {}),
 
@@ -182,7 +184,7 @@ async function loadFEDS() {
       : {},
     breadcrumbs: {
       showLogo: true,
-      links: await buildBreadCrumbArray(),
+      links: await buildBreadCrumbArray(prefix),
     },
   };
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -91,7 +91,7 @@ const showNotifications = () => {
     const meta = createTag('meta', { name: 'breadcrumbs', content: 'on' });
     document.head.append(meta);
   }
-  if (getMetadata('breadcrumbs') === 'on' && !!getMetadata('breadcrumbs-base') && (!!getMetadata('short-title') || !!getMetadata('breadcrumbs-page-title'))) document.body.classList.add('breadcrumbs-spacing');
+  if (getMetadata('breadcrumbs') === 'on') document.body.classList.add('breadcrumbs-spacing');
   showNotifications();
   await loadArea();
   if (['yes', 'true', 'on'].includes(getMetadata('mobile-benchmark').toLowerCase()) && document.body.dataset.device === 'mobile') {

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -91,7 +91,7 @@ const showNotifications = () => {
     const meta = createTag('meta', { name: 'breadcrumbs', content: 'on' });
     document.head.append(meta);
   }
-  if (getMetadata('breadcrumbs') === 'on') document.body.classList.add('breadcrumbs-spacing');
+  if (getMetadata('breadcrumbs') === 'on' && (!!getMetadata('short-title') || !!getMetadata('breadcrumbs-page-title'))) document.body.classList.add('breadcrumbs-spacing');
   showNotifications();
   await loadArea();
   if (['yes', 'true', 'on'].includes(getMetadata('mobile-benchmark').toLowerCase()) && document.body.dataset.device === 'mobile') {

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -8,6 +8,7 @@ import {
   setConfig,
   loadStyle,
   createTag,
+  getConfig,
 } from './utils.js';
 
 const locales = {
@@ -87,11 +88,14 @@ const showNotifications = () => {
 (async function loadPage() {
   if (window.hlx.init || window.isTestEnv) return;
   setConfig(config);
+
   if (getMetadata('hide-breadcrumbs') !== 'true' && !getMetadata('breadcrumbs') && !window.location.pathname.endsWith('/express/')) {
     const meta = createTag('meta', { name: 'breadcrumbs', content: 'on' });
     document.head.append(meta);
-  }
-  if (getMetadata('breadcrumbs') === 'on' && (!!getMetadata('short-title') || !!getMetadata('breadcrumbs-page-title'))) document.body.classList.add('breadcrumbs-spacing');
+    import('./gnav.js').then((gnav) => gnav.buildBreadCrumbArray(getConfig().locale.prefix.replaceAll('/', ''))).then((breadcrumbs) => {
+      if (breadcrumbs && breadcrumbs.length) document.body.classList.add('breadcrumbs-spacing');
+    });
+  } else if (getMetadata('breadcrumbs') === 'on' && !!getMetadata('breadcrumbs-base') && (!!getMetadata('short-title') || !!getMetadata('breadcrumbs-page-title'))) document.body.classList.add('breadcrumbs-spacing');
   showNotifications();
   await loadArea();
   if (['yes', 'true', 'on'].includes(getMetadata('mobile-benchmark').toLowerCase()) && document.body.dataset.device === 'mobile') {

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -7,6 +7,7 @@ import {
   registerPerformanceLogger,
   setConfig,
   loadStyle,
+  createTag,
 } from './utils.js';
 
 const locales = {
@@ -86,6 +87,11 @@ const showNotifications = () => {
 (async function loadPage() {
   if (window.hlx.init || window.isTestEnv) return;
   setConfig(config);
+  if (getMetadata('hide-breadcrumbs') !== 'true' && !getMetadata('breadcrumbs') && !window.location.pathname.endsWith('/express/')) {
+    const meta = createTag('meta', { name: 'breadcrumbs', content: 'on' });
+    document.head.append(meta);
+  }
+  if (getMetadata('breadcrumbs') === 'on' && !!getMetadata('breadcrumbs-base') && (!!getMetadata('short-title') || !!getMetadata('breadcrumbs-page-title'))) document.body.classList.add('breadcrumbs-spacing');
   showNotifications();
   await loadArea();
   if (['yes', 'true', 'on'].includes(getMetadata('mobile-benchmark').toLowerCase()) && document.body.dataset.device === 'mobile') {

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -39,6 +39,7 @@
 
   /* header */
   --header-height: 65px;
+  --breadcrumbs-height: 43px;
   --brand-header-height: 79px;
 
   /* body */
@@ -535,6 +536,10 @@ main .section:last-of-type>.default-content-wrapper {
 }
 
 @media (min-width:900px) {
+  .breadcrumbs-spacing > .feds-topnav-spacing,
+  .breadcrumbs-spacing > header:not(.feds-header-wrapper){
+    height: calc(var(--header-height) + var(--breadcrumbs-height));
+  }
 
   main h5+p,
   main .section p.button-container {


### PR DESCRIPTION
Based on this PR - https://github.com/adobecom/express/pull/498
Reserves some extra spacing for pages with breadcrumbs to lower CLS on those pages

Resolves: [MWPW-137051](https://jira.corp.adobe.com/browse/MWPW-137051)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/?martech=off
- After: https://MWPW-137051-breadcrumb-cls--express--adobecom.hlx.page/express/?martech=off
