### PR TITLE
MWPW-141311 give fixed width to video to prevent cls

### DIFF
--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -528,6 +528,7 @@ main .columns.fullsize .hero-animation-overlay {
 main .columns.fullsize .hero-animation-overlay video {
   max-height: 40vh;
   margin-bottom: 40px;
+  max-width: 370px;
 }
 
 main .columns.fullsize .has-brand > div:not(.column-picture):not(.hero-animation-overlay) {


### PR DESCRIPTION
Fixes cls on videos loading in. To see the improvement change your browser width to between 900 - 1200px
Note: I checked the usage of this block to see if setting this width would be an issue an the variant I'm changing is only used for quick actions from what I could see. 

Resolves: [MWPW-141311](https://jira.corp.adobe.com/browse/MWPW-141311)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/feature/image/convert/png-to-jpg?martech=off
- After: https://MWPW-141311-cls-video--express--adobecom.hlx.page/express/feature/image/convert/png-to-jpg?martech=off
