### PR TITLE
Jarvis in Gnav

### DIFF
--- a/express/blocks/merch/merch.js
+++ b/express/blocks/merch/merch.js
@@ -34,6 +34,7 @@ export function polyfills() {
  */
 export async function initService() {
   await polyfills();
+  // eslint-disable-next-line import/no-unresolved
   const commerce = await import('https://www.adobe.com/libs/deps/commerce.js');
   return commerce.init(() => ({
     ...getConfig(),

--- a/express/blocks/tabs-ax/tabs-ax.js
+++ b/express/blocks/tabs-ax/tabs-ax.js
@@ -2,7 +2,7 @@
  * tabs - consonant v6
  * https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role
  */
-import { createTag, MILO_EVENTS } from '../../utils/utils.js';
+import { createTag, MILO_EVENTS } from '../../scripts/utils.js';
 
 const isElementInContainerView = (targetEl) => {
   const rect = targetEl.getBoundingClientRect();

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -65,6 +65,12 @@ async function loadFEDS() {
   const config = getConfig();
   const prefix = config.locale.prefix.replaceAll('/', '');
 
+  // we're going to initialize jarvis later
+  let jarvis = true;
+  const jarvisMeta = getMetadata('jarvis-chat')?.toLowerCase();
+  if (!jarvisMeta || !['mobile', 'desktop', 'on'].includes(jarvisMeta)
+    || !config.jarvis?.id || !config.jarvis?.version) jarvis = false;
+
   async function showRegionPicker() {
     const { getModal } = await import('../blocks/modal/modal.js');
     const details = {
@@ -174,12 +180,11 @@ async function loadFEDS() {
         window.location.href = sparkLoginUrl;
       },
     },
-    jarvis: getMetadata('enable-chat') === 'yes'
-      ? {
-        surfaceName: 'AdobeExpressEducation',
-        surfaceVersion: '1',
-      }
-      : {},
+    jarvis: !jarvis ? {
+      surfaceName: config.jarvis.id,
+      surfaceVersion: config.jarvis.version,
+      onDemand: true,
+    } : {},
     breadcrumbs: {
       showLogo: true,
       links: await buildBreadCrumbArray(),
@@ -257,7 +262,7 @@ async function loadFEDS() {
       otDomainId,
     };
     loadScript('https://www.adobe.com/etc.clientlibs/globalnav/clientlibs/base/privacy-standalone.js');
-  }, 4000);
+  }, 0);
   const footer = document.querySelector('footer');
   footer?.addEventListener('click', (event) => {
     if (event.target.closest('a[data-feds-action="open-adchoices-modal"]')) {

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -262,7 +262,7 @@ async function loadFEDS() {
       otDomainId,
     };
     loadScript('https://www.adobe.com/etc.clientlibs/globalnav/clientlibs/base/privacy-standalone.js');
-  }, 0);
+  }, 4000);
   const footer = document.querySelector('footer');
   footer?.addEventListener('click', (event) => {
     if (event.target.closest('a[data-feds-action="open-adchoices-modal"]')) {

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -64,9 +64,8 @@ function loadIMS() {
 async function loadFEDS() {
   const config = getConfig();
   const prefix = config.locale.prefix.replaceAll('/', '');
-
-  // we're going to initialize jarvis later
   let jarvis = true;
+  // if metadata found jarvis must not be initialized in gnav because it will be initiated later
   const jarvisMeta = getMetadata('jarvis-chat')?.toLowerCase();
   if (!jarvisMeta || !['mobile', 'desktop', 'on'].includes(jarvisMeta)
     || !config.jarvis?.id || !config.jarvis?.version) jarvis = false;


### PR DESCRIPTION
jarvis in gnav

Resolves: [MWPW-141633](https://jira.corp.adobe.com/browse/MWPW-141633)

Test URLs:
**Jarvis initiated over the metadata directly here**
- Before: https://main--express--adobecom.hlx.page/drafts/vhargrave/jarvis?martech=off
- After: https://jarvis--express--adobecom.hlx.page/drafts/vhargrave/jarvis?martech=off

**To test that jarvis can get initiated from the gnav instead, you'll need to override the gnav.js on line 186 to be onDemand: false** 
- Before: https://main--express--adobecom.hlx.page/express/?martech=off
- After: https://jarvis--express--adobecom.hlx.page/express/?martech=off
