### PR TITLE
GNAV disableRetractability Through Authoring

### DIFF
--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -192,6 +192,11 @@ async function loadFEDS() {
 
   window.addEventListener('feds.events.experience.loaded', async () => {
     document.querySelector('body').classList.add('feds-loaded');
+
+    if (['no', 'f', 'false', 'n', 'off'].includes(getMetadata('gnav-retract').toLowerCase())) {
+      window.feds.components.NavBar.disableRetractability();
+    }
+
     /* attempt to switch link */
     if (window.location.pathname.includes('/create/')
       || window.location.pathname.includes('/discover/')


### PR DESCRIPTION
Disable gnav retractability based on page authoring

Test URLs:
- Before: https://one-plans--express--adobecom.hlx.page/express/drafts/jingle/one-plans?martech=off
- After: https://one-plans-gnav--express--adobecom.hlx.page/drafts/jingle/one-plans?martech=off
