### PR TITLE
add additional condition so free plans don't appear on all pages

### DIFF
--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -263,7 +263,8 @@ export default async function decorate(block) {
   }
 
   // add free plan widget to first columns block on every page except blog
-  if (!(getMetadata('theme') === 'blog' || getMetadata('template') === 'blog') && document.querySelector('main .columns') === block) {
+  if (!(getMetadata('theme') === 'blog' || getMetadata('template') === 'blog') && document.querySelector('main .columns') === block
+    && document.querySelector('main .block') === block) {
     addFreePlanWidget(block.querySelector('.button-container') || block.querySelector(':scope .column:not(.hero-animation-overlay,.columns-picture)'));
   }
 


### PR DESCRIPTION
Fixes free plans appearing in columns everywhere

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/learn/students
- After: https://fix-free-plans-appearing--express--adobecom.hlx.page/express/learn/students
