### PR TITLE
PUF Left Card Allows NoReverse

### DIFF
--- a/express/blocks/puf/puf.js
+++ b/express/blocks/puf/puf.js
@@ -1,4 +1,4 @@
-import { addPublishDependencies, createTag } from '../../scripts/utils.js';
+import { addPublishDependencies, createTag, getMetadata } from '../../scripts/utils.js';
 import { buildUrl, fetchPlan } from '../../scripts/utils/pricing.js';
 import buildCarousel from '../shared/carousel.js';
 
@@ -176,7 +176,8 @@ async function decorateCard(block, cardClass = '') {
   const listItems = cardBottom.querySelectorAll('svg');
   const plans = buildPlans(plansElement);
 
-  if (cardClass === 'puf-left') {
+  if (cardClass === 'puf-left'
+    && !['off', 'no', 'false'].includes(getMetadata('puf-left-reverse')?.toLowerCase())) {
     cardCta.classList.add('reverse', 'accent');
   }
 
@@ -221,12 +222,7 @@ async function decorateCard(block, cardClass = '') {
 
   const ctaTextContainer = cardTop.querySelector('strong');
   if (ctaTextContainer) {
-    let ctaText = ctaTextContainer.textContent.trim();
-    if (/{{noreverse}}/.test(ctaText)) {
-      cardCta.classList.remove('reverse', 'accent');
-      ctaText = ctaText.replace(/{{noreverse}}/, '');
-    }
-    cardCta.textContent = ctaText;
+    cardCta.textContent = ctaTextContainer.textContent.trim();
     ctaTextContainer.parentNode.remove();
   } else {
     cardCta.textContent = 'Start your trial';

--- a/express/blocks/puf/puf.js
+++ b/express/blocks/puf/puf.js
@@ -221,7 +221,12 @@ async function decorateCard(block, cardClass = '') {
 
   const ctaTextContainer = cardTop.querySelector('strong');
   if (ctaTextContainer) {
-    cardCta.textContent = ctaTextContainer.textContent.trim();
+    let ctaText = ctaTextContainer.textContent.trim();
+    if (/{{noreverse}}/.test(ctaText)) {
+      cardCta.classList.remove('reverse', 'accent');
+      ctaText = ctaText.replace(/{{noreverse}}/, '');
+    }
+    cardCta.textContent = ctaText;
     ctaTextContainer.parentNode.remove();
   } else {
     cardCta.textContent = 'Start your trial';


### PR DESCRIPTION
A very temporary fix that allows the left card's main CTA to not be reversed. Usually a longer term solution would be to create a variant, but as PUF will be deprecated soon, we are going with the fastest route.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/pricing/plans?martech=off
- After: https://puf-left-noreverse--express--adobecom.hlx.page/express/pricing/plans?martech=off
