### PR TITLE
fixing FaaS form modal

### DIFF
--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1485,8 +1485,9 @@ function decoratePageStyle() {
  */
 
 export function decorateButtons(el = document) {
+  // FIXME: Different function from Milo.
   const noButtonBlocks = ['template-list', 'icon-list'];
-  el.querySelectorAll(':scope a:not(.faas.link-block, .fragment.link-block)').forEach(($a) => {
+  el.querySelectorAll(':scope a:not(.faas.link-block, .modal.link-block, .fragment.link-block)').forEach(($a) => {
     const originalHref = $a.href;
     const linkText = $a.textContent.trim();
     if ($a.children.length > 0) {


### PR DESCRIPTION
This PR fixes the FaaS form not loading issue on stage branch right now. It's fixed by adding the modal link-block in the no-op list of the decorateButtons function.

Note: this function is currently different from its counterpart in Milo and the way the no-op list is maintained is not very efficient. After the urgency we should look into a way to improve on this.

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER) pending

Test URLs:
- Before: https://www.stage.adobe.com/express/business?martech=off#sales-contact-form-1
- After: https://faas-fix--express--adobecom.hlx.page/express/business?martech=off#sales-contact-form-1
