### PR TITLE
More refactor and fix for pricing-cards generic click tracking

### DIFF
--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -352,56 +352,10 @@ const martechLoadedCB = () => {
   //------------------------------------------------------------------------------------
 
   // Fire the viewedPage event
-  _satellite.track('event', {
-    xdm: {},
-    data: {
-      eventType: 'web.webinteraction.linkClicks',
-      web: {
-        webInteraction: {
-          name: 'viewedPage',
-          linkClicks: {
-            value: 1,
-          },
-          type: 'other',
-        },
-      },
-      _adobe_corpnew: {
-        digitalData: {
-          primaryEvent: {
-            eventInfo: {
-              eventName: 'viewedPage',
-            },
-          },
-        },
-      },
-    },
-  });
+  sendEventToAdobeAnaltics('viewedPage');
 
   // Fire the landing:viewedPage event
-  _satellite.track('event', {
-    xdm: {},
-    data: {
-      eventType: 'web.webinteraction.linkClicks',
-      web: {
-        webInteraction: {
-          name: 'landing:viewedPage',
-          linkClicks: {
-            value: 1,
-          },
-          type: 'other',
-        },
-      },
-      _adobe_corpnew: {
-        digitalData: {
-          primaryEvent: {
-            eventInfo: {
-              eventName: 'landing:viewedPage',
-            },
-          },
-        },
-      },
-    },
-  });
+  sendEventToAdobeAnaltics('landing:viewedPage');
 
   // Fire the displayPurchasePanel event if it is the pricing site
   if (
@@ -557,7 +511,7 @@ const martechLoadedCB = () => {
       }
     } else if (a.closest('.template')) {
       adobeEventName = appendLinkText(adobeEventName, a);
-    } else if (a.closest('.tabs-ax')) {
+    } else if (a.closest('.tabs-ax .tab-list-container')) {
       adobeEventName += `${a.closest('.tabs-ax')?.id}:${a.id}`;
     // Default clicks
     } else {


### PR DESCRIPTION
This fixes an issue causing the normal links in pricing-cards block don't track the textContent in the last sector.

Resolves: [MWPW-141081](https://jira.corp.adobe.com/browse/MWPW-141081)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/drafts/jingle/one-plans-pricing?martech=off
- After: https://one-plans-tracking-fix--express--adobecom.hlx.page/drafts/jingle/one-plans-pricing?martech=off
