### PR TITLE
Plan tag variants

### DIFF
--- a/express/blocks/carousel-card-mobile/carousel-card-mobile.js
+++ b/express/blocks/carousel-card-mobile/carousel-card-mobile.js
@@ -1,5 +1,5 @@
 import { createTag, fetchRelevantRows } from '../../scripts/utils.js';
-import { buildStaticFreePlanWidget } from '../../scripts/utils/free-plan.js';
+import { buildFreePlanWidget } from '../../scripts/utils/free-plan.js';
 import buildPaginatedCarousel from '../shared/paginated-carousel.js';
 import { buildAppStoreBadge } from '../shared/app-store-badge.js';
 
@@ -42,6 +42,6 @@ export default async function decorate($block) {
     }
   });
 
-  const freePlanTags = await buildStaticFreePlanWidget();
+  const freePlanTags = await buildFreePlanWidget('branded');
   $block.insertAdjacentElement('afterend', freePlanTags);
 }

--- a/express/blocks/marquee/marquee.css
+++ b/express/blocks/marquee/marquee.css
@@ -390,8 +390,11 @@ body.no-desktop-brand-header header {
   }
 
   .marquee .button-container.button-inline.free-plan-container .free-plan-widget {
-    color: var(--color-white);
     text-align: left;
+  }
+
+  .marquee.dark .button-container.button-inline.free-plan-container .free-plan-widget {
+    color: var(--color-white);
   }
 
   .marquee.short .button-container.free-plan-container .free-plan-widget {

--- a/express/blocks/marquee/marquee.css
+++ b/express/blocks/marquee/marquee.css
@@ -98,6 +98,7 @@ body.no-desktop-brand-header header {
   width: 100%;
   box-sizing: border-box;
   white-space: nowrap;
+  max-height: none;
 }
 
 .marquee .marquee-background {
@@ -143,8 +144,7 @@ body.no-desktop-brand-header header {
 .marquee .content-wrapper .button-container.free-plan-container {
   display: flex;
   justify-content: left;
-  align-items: flex-start;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
 }
 
 .marquee .marquee-foreground .content-wrapper .button-container .cta-sub-text {
@@ -154,21 +154,13 @@ body.no-desktop-brand-header header {
 .marquee .button-container.button-inline.free-plan-container .free-plan-widget {
   color: var(--body-color);
   background: unset;
-  margin: unset;
-}
-
-.marquee.dark .button-container.button-inline.free-plan-container .free-plan-widget {
-  color: var(--color-white);
+  margin: 0;
+  background-color: transparent;
+  white-space: unset;
 }
 
 .marquee .button-container.button-inline.free-plan-container + .button-container.button-inline > a {
   margin-left: 0;
-}
-
-.marquee .free-plan-widget {
-  margin: 0;
-  background-color: transparent;
-  padding-left: 0;
 }
 
 .marquee p.button-container a.video-link::before {
@@ -305,6 +297,7 @@ body.no-desktop-brand-header header {
   .marquee p.button-container a.button:any-link {
     width: auto;
     box-sizing: initial;
+    flex: none;
   }
 
   .marquee.dark,
@@ -392,7 +385,13 @@ body.no-desktop-brand-header header {
   }
 
   .marquee .content-wrapper .button-container.free-plan-container {
+    flex-direction: row;
     align-items: center;
+  }
+
+  .marquee .button-container.button-inline.free-plan-container .free-plan-widget {
+    color: var(--color-white);
+    text-align: left;
   }
 
   .marquee.short .button-container.free-plan-container .free-plan-widget {

--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -5,7 +5,7 @@ import {
   getMetadata,
   sampleRUM,
 } from '../../scripts/utils.js';
-import { buildStaticFreePlanWidget } from '../../scripts/utils/free-plan.js';
+import { buildFreePlanWidget } from '../../scripts/utils/free-plan.js';
 
 import buildCarousel from '../shared/carousel.js';
 import fetchAllTemplatesMetadata from '../../scripts/all-templates-metadata.js';
@@ -316,7 +316,7 @@ async function buildSearchDropdown(block) {
     suggestionsTitle.textContent = placeholders['search-suggestions-title'] ?? '';
     suggestionsContainer.append(suggestionsTitle, suggestionsList);
 
-    const freePlanTags = await buildStaticFreePlanWidget();
+    const freePlanTags = await buildFreePlanWidget('branded');
 
     freePlanContainer.append(freePlanTags);
     dropdownContainer.append(trendsContainer, suggestionsContainer, freePlanContainer);

--- a/express/scripts/utils/free-plan.js
+++ b/express/scripts/utils/free-plan.js
@@ -6,48 +6,80 @@ import {
   lazyLoadLottiePlayer,
 } from '../utils.js';
 
-export async function buildStaticFreePlanWidget() {
+const typeMap = {
+  branded: [
+    'free-plan-check-1',
+    'free-plan-check-2',
+  ],
+  features: [
+    'free-plan-features-1',
+    'free-plan-check-2',
+  ],
+  entitled: [
+    'entitled-plan-tag',
+  ],
+};
+
+export async function buildFreePlanWidget(typeKey) {
   const placeholders = await fetchPlaceholders();
   const widget = createTag('div', { class: 'free-plan-widget' });
-  for (let i = 1; i < 3; i += 1) {
-    const tagText = placeholders[`free-plan-check-${i}`];
-    const textDiv = createTag('div');
-    textDiv.textContent = tagText;
-    widget.append(textDiv);
-  }
+
+  typeMap[typeKey].forEach((tagKey) => {
+    const tagText = placeholders[tagKey];
+
+    if (tagText) {
+      const textDiv = createTag('span', { class: 'plan-widget-tag' });
+      textDiv.textContent = tagText;
+      widget.append(textDiv);
+    }
+  });
+
   return widget;
 }
 
 export async function addFreePlanWidget(elem) {
-  if (elem && ['yes', 'true', 'y', 'on'].includes(getMetadata('show-free-plan').toLowerCase())) {
-    const placeholders = await fetchPlaceholders();
-    const widget = await buildStaticFreePlanWidget();
+  const freePlanMeta = getMetadata('show-free-plan').toLowerCase();
 
-    document.addEventListener('planscomparisonloaded', () => {
-      const $learnMoreButton = createTag('a', {
-        class: 'learn-more-button',
-        href: '#plans-comparison-container',
-      });
-      const lottieWrapper = createTag('span', { class: 'lottie-wrapper' });
+  if (!freePlanMeta || ['no', 'false', 'n', 'off'].includes(freePlanMeta)) return;
+  const placeholders = await fetchPlaceholders();
+  let widget;
 
-      $learnMoreButton.textContent = placeholders['learn-more'];
-      lottieWrapper.innerHTML = getLottie('purple-arrows', '/express/icons/purple-arrows.json');
-      $learnMoreButton.append(lottieWrapper);
-      lazyLoadLottiePlayer();
-      widget.append($learnMoreButton);
-
-      $learnMoreButton.addEventListener('click', (e) => {
-        e.preventDefault();
-        // temporarily disabling smooth scroll for accurate location
-        const $html = document.querySelector('html');
-        $html.style.scrollBehavior = 'unset';
-        const $plansComparison = document.querySelector('.plans-comparison-container');
-        $plansComparison.scrollIntoView();
-        $html.style.removeProperty('scroll-behavior');
-      });
-    });
-
-    elem.append(widget);
-    elem.classList.add('free-plan-container');
+  if (elem && ['yes', 'true', 'y', 'on', 'branded'].includes(freePlanMeta)) {
+    widget = await buildFreePlanWidget('branded');
   }
+
+  if (elem && ['features'].includes(freePlanMeta)) {
+    widget = await buildFreePlanWidget('features');
+  }
+
+  if (elem && ['entitled'].includes(freePlanMeta)) {
+    widget = await buildFreePlanWidget('entitled');
+  }
+
+  document.addEventListener('planscomparisonloaded', () => {
+    const learnMoreButton = createTag('a', {
+      class: 'learn-more-button',
+      href: '#plans-comparison-container',
+    });
+    const lottieWrapper = createTag('span', { class: 'lottie-wrapper' });
+
+    learnMoreButton.textContent = placeholders['learn-more'];
+    lottieWrapper.innerHTML = getLottie('purple-arrows', '/express/icons/purple-arrows.json');
+    learnMoreButton.append(lottieWrapper);
+    lazyLoadLottiePlayer();
+    widget.append(learnMoreButton);
+
+    learnMoreButton.addEventListener('click', (e) => {
+      e.preventDefault();
+      // temporarily disabling smooth scroll for accurate location
+      const html = document.querySelector('html');
+      html.style.scrollBehavior = 'unset';
+      const $plansComparison = document.querySelector('.plans-comparison-container');
+      $plansComparison.scrollIntoView();
+      html.style.removeProperty('scroll-behavior');
+    });
+  });
+
+  elem.append(widget);
+  elem.classList.add('free-plan-container');
 }

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -930,30 +930,6 @@ main .block.center .free-plan-widget {
   margin: 32px auto;
 }
 
-main .block .free-plan-widget>div {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-}
-
-main .block .free-plan-widget>div>div:first-child {
-  position: relative;
-  margin-right: 6px;
-  width: 14px;
-  height: 14px;
-  background: #33AB84;
-  border-radius: 50%;
-}
-
-main .block .free-plan-widget .icon.icon-checkmark {
-  position: absolute;
-  top: 3px;
-  left: 3px;
-  fill: var(--color-white);
-  width: 8px;
-  max-height: 8px;
-}
-
 @media (min-width: 900px) {
   main .block .button-container.free-plan-container {
     width: max-content;
@@ -970,6 +946,10 @@ main .block .free-plan-widget .icon.icon-checkmark {
     display: flex;
     align-items: center;
     z-index: 4;
+  }
+
+  main .block .free-plan-widget .plan-widget-tag {
+    text-align: left;
   }
 }
 


### PR DESCRIPTION
Added 2 variants for the metadata invoked free-plan widget.

using either of `[branded, features, entitled]` in the show-free-plan metadata will make the free-plan-widget load different combinations of the placeholder value below:
![Screenshot 2024-01-30 at 15 37 40](https://github.com/adobecom/express/assets/57737624/8fc25ad1-b1a9-4a68-af8c-fd93e4163e6d)

The standard affirmative values: `[yes, true, Y, on]` will load the branded version: "free use forever + no credit card required" 

Resolves: [MWPW-141815](https://jira.corp.adobe.com/browse/MWPW-141815)

Test URLs:
- Before: 
-- https://main--express--adobecom.hlx.page/drafts/qiyundai/home-entitled-tag?martech=off
-- https://main--express--adobecom.hlx.page/drafts/qiyundai/home-features-tag?martech=off
-- https://main--express--adobecom.hlx.page/drafts/qiyundai/home-branded-tag?martech=off
- After: 
-- https://plan-tag-variants--express--adobecom.hlx.page/drafts/qiyundai/home-entitled-tag?martech=off
-- https://plan-tag-variants--express--adobecom.hlx.page/drafts/qiyundai/home-features-tag?martech=off
-- https://plan-tag-variants--express--adobecom.hlx.page/drafts/qiyundai/home-branded-tag?martech=off
