### PR TITLE
[Due Diligence] Missing analytics fix

### DIFF
--- a/express/blocks/cta-carousel/cta-carousel.js
+++ b/express/blocks/cta-carousel/cta-carousel.js
@@ -155,9 +155,11 @@ async function decorateCards(block, payload) {
       }
 
       if ((block.classList.contains('quick-action') || block.classList.contains('gen-ai')) && cta.ctaLinks.length === 1) {
-        cta.ctaLinks[0].textContent = '';
-        cta.ctaLinks[0].classList.add('clickable-overlay');
-        cta.ctaLinks[0].removeAttribute('title');
+        const a = cta.ctaLinks[0];
+        a.removeAttribute('title');
+        a.setAttribute('aria-label', `quick action: ${cta.text.toLowerCase().trim()}`);
+        a.textContent = '';
+        a.classList.add('clickable-overlay');
       }
 
       cta.ctaLinks.forEach((a) => {
@@ -169,6 +171,7 @@ async function decorateCards(block, payload) {
             a.href = decodeURIComponent(btnUrl.toString());
           }
           a.removeAttribute('title');
+          a.setAttribute('aria-label', `${cta.text.toLowerCase().trim()} ${a.text.toLowerCase().trim()}`);
         }
         linksWrapper.append(a);
       });

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -1517,6 +1517,7 @@ async function buildTemplateList(block, props, type = []) {
     const templatesWrapper = block.querySelector('.template-x-inner-wrapper');
     const textWrapper = block.querySelector('.template-title .text-wrapper > div');
     const tabsWrapper = createTag('div', { class: 'template-tabs' });
+    const tabBtns = [];
 
     const promises = [];
 
@@ -1531,6 +1532,7 @@ async function buildTemplateList(block, props, type = []) {
         const tabBtn = createTag('button', { class: 'template-tab-button' });
         tabBtn.textContent = tabs[index];
         tabsWrapper.append(tabBtn);
+        tabBtns.push(tabBtn);
 
         const [[task]] = taskObj;
 
@@ -1575,6 +1577,8 @@ async function buildTemplateList(block, props, type = []) {
           }
         }, { passive: true });
       });
+
+      document.dispatchEvent(new CustomEvent('linkspopulated', { detail: tabBtns }));
     }
 
     textWrapper.append(tabsWrapper);

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -588,7 +588,6 @@ const martechLoadedCB = () => {
       adobeEventName = prefix + adobeEventName;
     }
 
-    console.log(adobeEventName);
     _satellite.track('event', {
       xdm: {},
       data: {
@@ -629,7 +628,6 @@ const martechLoadedCB = () => {
   // Frictionless Quick Actions tracking events
 
   function sendEventToAdobeAnaltics(eventName) {
-    console.log(eventName);
     _satellite.track('event', {
       xdm: {},
       data: {

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -5,7 +5,8 @@ import {
   getAssetDetails,
   getMetadata,
   checkTesting,
-  fetchPlaceholders, getConfig,
+  fetchPlaceholders,
+  getConfig,
 } from './utils.js';
 
 function getPlacement(btn) {
@@ -866,6 +867,32 @@ const martechLoadedCB = () => {
               },
             },
           });
+        });
+      });
+    }
+
+    const toggleBar = d.querySelector('.toggle-bar.block');
+    if (toggleBar) {
+      const tgBtns = toggleBar.querySelectorAll('button.toggle-bar-button');
+
+      tgBtns.forEach((btn) => {
+        const textEl = btn.querySelector('.text-wrapper');
+        let texts = [];
+
+        if (textEl) {
+          let child = textEl.firstChild;
+          while (child) {
+            if (child.nodeType === 3) {
+              texts.push(child.data);
+            }
+            child = child.nextSibling;
+          }
+        }
+
+        texts = texts.join('') || textEl.textContent.trim();
+        const eventName = `adobe.com:express:homepage:intentToggle:${textToName(texts)}`;
+        btn.addEventListener('click', () => {
+          sendEventToAdobeAnaltics(eventName);
         });
       });
     }

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -414,7 +414,7 @@ const martechLoadedCB = () => {
   }
 
   function appendLinkText(eventName, a) {
-    let $img;
+    let img;
     let alt;
 
     if (!a) return eventName;
@@ -426,8 +426,8 @@ const martechLoadedCB = () => {
     } else if (a.textContent?.trim()) {
       return eventName + textToName(a.textContent.trim());
     } else {
-      $img = a.querySelector('img');
-      alt = $img && $img.getAttribute('alt');
+      img = a.querySelector('img');
+      alt = img && img.getAttribute('alt');
       if (alt) {
         return eventName + textToName(alt);
       } else {

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -413,24 +413,27 @@ const martechLoadedCB = () => {
     return (camelCase);
   }
 
-  function appendLinkText(eventName, $a) {
+  function appendLinkText(eventName, a) {
     let $img;
     let alt;
-    let newEventName;
 
-    if ($a?.textContent?.trim()) {
-      newEventName = eventName + textToName($a.textContent.trim());
+    if (!a) return eventName;
+
+    if (a.getAttribute('title')?.trim()) {
+      return eventName + textToName(a.getAttribute('title').trim());
+    } else if (a.getAttribute('aria-label')?.trim()) {
+      return eventName + textToName(a.getAttribute('aria-label').trim());
+    } else if (a.textContent?.trim()) {
+      return eventName + textToName(a.textContent.trim());
     } else {
-      $img = $a?.querySelector('img');
+      $img = a.querySelector('img');
       alt = $img && $img.getAttribute('alt');
       if (alt) {
-        newEventName = eventName + textToName(alt);
+        return eventName + textToName(alt);
       } else {
-        newEventName = eventName;
+        return eventName;
       }
     }
-
-    return newEventName;
   }
 
   function trackButtonClick(a) {
@@ -585,6 +588,7 @@ const martechLoadedCB = () => {
       adobeEventName = prefix + adobeEventName;
     }
 
+    console.log(adobeEventName);
     _satellite.track('event', {
       xdm: {},
       data: {
@@ -625,6 +629,7 @@ const martechLoadedCB = () => {
   // Frictionless Quick Actions tracking events
 
   function sendEventToAdobeAnaltics(eventName) {
+    console.log(eventName);
     _satellite.track('event', {
       xdm: {},
       data: {
@@ -833,8 +838,7 @@ const martechLoadedCB = () => {
     if ($columnVideos.length) {
       $columnVideos.forEach(($columnVideo) => {
         const $parent = $columnVideo.closest('.columns');
-        const $a = $columnVideo.querySelector('a');
-
+        const $a = $parent.querySelector('a');
         const adobeEventName = appendLinkText(`adobe.com:express:cta:learn:columns:${sparkLandingPageType}:`, $a);
 
         $parent.addEventListener('click', (e) => {


### PR DESCRIPTION
This PR fixes some of the newly observed analytics issue we are having including:
buttons/links with missing tail keywords in event names (i.e. adobe.com:express:cta:, adobe.com:express:cta:learn:columns:seo:)
buttons with event names too generic (i.e. adobe.com:express:cta:createNow)
toggle-bar block doesn't have analytics.

Resolves: [MWPW-142106](https://jira.corp.adobe.com/browse/MWPW-142106)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/?martech=off
- After: https://analytics-missing-text-fix--express--adobecom.hlx.page/express/?martech=off
