### PR TITLE
MWPW-141761 | Adding logic of setting visitor country and updating offer override based on oo from offer-new sheet

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -82,7 +82,7 @@ function createPricingSection(placeholders, pricingArea, ctaGroup) {
     if (a.parentNode.tagName.toLowerCase() === 'p') {
       a.parentNode.remove();
     }
-    fetchPlan(a?.href).then((response) => {
+    fetchPlan(a.href).then((response) => {
       a.href = buildUrl(response.url, response.country, response.language, response.offerId);
     });
     ctaGroup.append(a);

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -1,5 +1,7 @@
 import { createTag, fetchPlaceholders } from '../../scripts/utils.js';
-import { fetchPlan, buildUrl, formatSalesPhoneNumberReplace } from '../../scripts/utils/pricing.js';
+import {
+  fetchPlan, buildUrl, formatSalesPhoneNumberReplace, setVisitorCountry,
+} from '../../scripts/utils/pricing.js';
 import BlockMediator from '../../scripts/block-mediator.min.js';
 
 const blockKeys = ['header', 'explain', 'mPricingRow', 'mCtaGroup', 'yPricingRow', 'yCtaGroup', 'featureList', 'compare'];
@@ -40,9 +42,6 @@ function handlePrice(pricingArea, priceSuffixContext) {
     } else {
       priceSuffix.textContent = priceSuffixContext;
     }
-
-    const planCTA = pricingArea.querySelector(':scope > .button-container:last-of-type a.button');
-    if (planCTA) planCTA.href = buildUrl(response.url, response.country, response.language);
   });
 
   priceParent?.remove();
@@ -83,6 +82,9 @@ function createPricingSection(placeholders, pricingArea, ctaGroup) {
     if (a.parentNode.tagName.toLowerCase() === 'p') {
       a.parentNode.remove();
     }
+    fetchPlan(a?.href).then((response) => {
+      a.href = buildUrl(response.url, response.country, response.language, response.offerId);
+    });
     ctaGroup.append(a);
   });
   pricingSection.append(pricingArea);
@@ -186,6 +188,7 @@ export default async function init(el) {
   el.querySelectorAll(':scope > div:not(:last-of-type)').forEach((d) => d.remove());
   const cardsContainer = createTag('div', { class: 'cards-container' });
   const placeholders = await fetchPlaceholders();
+  setVisitorCountry();
   cards
     .map((card) => decorateCard(card, el, placeholders))
     .forEach((card) => cardsContainer.append(card));

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -82,8 +82,10 @@ function createPricingSection(placeholders, pricingArea, ctaGroup) {
     if (a.parentNode.tagName.toLowerCase() === 'p') {
       a.parentNode.remove();
     }
-    fetchPlan(a.href).then((response) => {
-      a.href = buildUrl(response.url, response.country, response.language, response.offerId);
+    fetchPlan(a.href).then(({
+      url, country, language, offerId,
+    }) => {
+      a.href = buildUrl(url, country, language, offerId);
     });
     ctaGroup.append(a);
   });

--- a/express/blocks/pricing-summary/pricing-summary.js
+++ b/express/blocks/pricing-summary/pricing-summary.js
@@ -1,5 +1,5 @@
 import { createTag } from '../../scripts/utils.js';
-import { fetchPlan, buildUrl } from '../../scripts/utils/pricing.js';
+import { fetchPlan, buildUrl, setVisitorCountry } from '../../scripts/utils/pricing.js';
 import buildCarousel from '../shared/carousel.js';
 
 function handleHeader(column) {
@@ -48,7 +48,7 @@ function handlePrice(block, column) {
     }
 
     const planCTA = column.querySelector(':scope > .button-container:last-of-type a.button');
-    if (planCTA) planCTA.href = buildUrl(response.url, response.country, response.language);
+    if (planCTA) planCTA.href = buildUrl(response.url, response.country, response.language, response.offerId);
   });
 
   priceParent?.remove();
@@ -171,6 +171,7 @@ function alignContent(block) {
 }
 
 export default async function decorate(block) {
+  setVisitorCountry();
   const pricingContainer = block.classList.contains('feature') ? block.children[2] : block.children[1];
   const featureColumns = block.classList.contains('feature') ? Array.from(block.children[3].children) : null;
   const eyeBrows = block.classList.contains('feature') ? Array.from(block.children[1].children) : null;

--- a/express/blocks/pricing-summary/pricing-summary.js
+++ b/express/blocks/pricing-summary/pricing-summary.js
@@ -29,10 +29,12 @@ function handlePrice(block, column) {
   priceWrapper.append(basePrice, price, priceSuffix);
   pricePlan.append(priceWrapper, plan);
 
-  fetchPlan(priceEl?.href).then((response) => {
+  fetchPlan(priceEl?.href).then(({
+    url, country, language, offerId, formatted, formattedBP, suffix,
+  }) => {
     const parentP = priceEl.parentElement;
-    price.innerHTML = response.formatted;
-    basePrice.innerHTML = response.formattedBP || '';
+    price.innerHTML = formatted;
+    basePrice.innerHTML = formattedBP || '';
 
     if (parentP.children.length > 1) {
       Array.from(parentP.childNodes).forEach((node) => {
@@ -44,11 +46,11 @@ function handlePrice(block, column) {
         }
       });
     } else {
-      priceSuffix.textContent = response.suffix;
+      priceSuffix.textContent = suffix;
     }
 
     const planCTA = column.querySelector(':scope > .button-container:last-of-type a.button');
-    if (planCTA) planCTA.href = buildUrl(response.url, response.country, response.language, response.offerId);
+    if (planCTA) planCTA.href = buildUrl(url, country, language, offerId);
   });
 
   priceParent?.remove();

--- a/express/blocks/puf/puf.js
+++ b/express/blocks/puf/puf.js
@@ -1,5 +1,5 @@
 import { addPublishDependencies, createTag, getMetadata } from '../../scripts/utils.js';
-import { buildUrl, fetchPlan } from '../../scripts/utils/pricing.js';
+import { buildUrl, fetchPlan, setVisitorCountry } from '../../scripts/utils/pricing.js';
 import buildCarousel from '../shared/carousel.js';
 
 let invisContainer;
@@ -75,7 +75,7 @@ async function selectPlan(card, planUrl, sendAnalyticEvent) {
     if (pricingVat) pricingVat.textContent = plan.vatInfo || '';
 
     if (pricingCta) {
-      pricingCta.href = buildUrl(plan.url, plan.country, plan.language);
+      pricingCta.href = buildUrl(plan.url, plan.country, plan.language, plan.offerId);
       pricingCta.dataset.planUrl = planUrl;
       pricingCta.id = plan.stringId;
     }
@@ -445,5 +445,6 @@ async function buildPUF(block) {
 }
 
 export default async function decorate(block) {
+  setVisitorCountry();
   await buildPUF(block);
 }

--- a/express/scripts/utils/pricing.js
+++ b/express/scripts/utils/pricing.js
@@ -4,6 +4,8 @@ import {
   createTag, getConfig,
 } from '../utils.js';
 
+let countrySessionVal;
+
 function replaceUrlParam(url, paramName, paramValue) {
   const params = url.searchParams;
   params.set(paramName, paramValue);
@@ -20,7 +22,7 @@ export function buildUrl(optionUrl, country, language, offerId = '') {
   }
   planUrl = replaceUrlParam(planUrl, 'co', country);
   planUrl = replaceUrlParam(planUrl, 'lang', language);
-  if (offerId.length) {
+  if (offerId) {
     planUrl.searchParams.set(decodeURIComponent('items%5B0%5D%5Bid%5D'), offerId);
   }
   let rUrl = planUrl.searchParams.get('rUrl');
@@ -83,8 +85,6 @@ function getCurrencyDisplay(currency) {
   }
   return 'symbol';
 }
-
-let countrySessionVal;
 
 export async function setVisitorCountry() {
   countrySessionVal = sessionStorage.getItem('visitorCountry');
@@ -289,7 +289,7 @@ export async function getOffer(offerId, countryOverride) {
     const lang = getConfig().locale.ietf.split('-')[0];
     const unitPrice = offer.p;
     const unitPriceCurrencyFormatted = formatPrice(unitPrice, currency);
-    const customOfferId = offer.oo ? offer.oo : offerId;
+    const customOfferId = offer.oo || offerId;
     const commerceURL = `https://commerce.adobe.com/checkout?cli=spark&co=${country}&items%5B0%5D%5Bid%5D=${customOfferId}&items%5B0%5D%5Bcs%5D=0&rUrl=https%3A%2F%express.adobe.com%2Fsp%2F&lang=${lang}`;
     const vatInfo = offer.vat;
     const prefix = offer.pre;


### PR DESCRIPTION
Adding logic of setting visitor country and updating offer override based on oo from offer-new sheet

Going with the sequence of country coming from URL params and then on international cookie and then on session value visitorCountry and then the fallback with path.

Resolves: [MWPW-141761](https://jira.corp.adobe.com/browse/MWPW-141761)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://mwpw-141761-oo--express--adobecom.hlx.page/drafts/apganapa/index-feb

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/jingle/one-plans-pricing
- After: https://mwpw-141761-oo--express--adobecom.hlx.page/drafts/jingle/one-plans-pricing

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/pricing
- After: https://mwpw-141761-oo--express--adobecom.hlx.page/drafts/apganapa/pricing-feb

<img width="1058" alt="excel-oo" src="https://github.com/adobecom/express/assets/37915358/cc2c3aee-8fff-4edd-b92c-7cc5e05790f8">
<img width="1512" alt="one-plans" src="https://github.com/adobecom/express/assets/37915358/31f838d9-5d64-4456-aa13-d279cc1a6e60">
<img width="1554" alt="pricing-summary" src="https://github.com/adobecom/express/assets/37915358/bb74f1a8-0483-45ae-8c00-b6a2f2f9ccf3">
<img width="1580" alt="puf-cta" src="https://github.com/adobecom/express/assets/37915358/0103a063-3ae2-4042-a184-dff7233ee2ca">
