### PR TITLE
hotfix version of the floating CTA suppression fix

### DIFF
--- a/express/blocks/shared/floating-cta.css
+++ b/express/blocks/shared/floating-cta.css
@@ -160,10 +160,6 @@ main .floating-button--scrolled .floating-button-lottie {
     z-index: 0;
 }
 
-main > div:not(.banner-container) a.button.same-as-floating-button-CTA {
-    display: none;
-}
-
 main [data-audience].floating-button-wrapper {
     display: none;
 }
@@ -179,6 +175,10 @@ body[data-device="mobile"] main .floating-button-wrapper[data-audience="mobile"]
 
 main .floating-button-wrapper:first-of-type + .section {
     padding-top: 0;
+}
+
+main > div:not(.banner-container) .block:not(.pricing-summary, .pricing-cards, .pricing-table, .puf) a.button.same-as-floating-button-CTA {
+    display: none;
 }
 
 @media screen and (min-width: 900px) {
@@ -198,7 +198,7 @@ main .floating-button-wrapper:first-of-type + .section {
     }
 
     /* set desktop below/above the fold styles */
-    main > div:not(.banner-container) a.button.same-as-floating-button-CTA {
+    main > div:not(.banner-container) .block:not(.pricing-summary, .pricing-cards, .pricing-table, .puf) a.button.same-as-floating-button-CTA {
         display: inline-block;
     }
 


### PR DESCRIPTION
This fix removes the on-page CTA suppression feature from Floating CTA for pricing blocks

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER) Pending

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/spotlight/marketers?martech=off
- After: https://cta-suppression-hotfix--express--adobecom.hlx.page/express/spotlight/marketers?martech=off
