### PR TITLE
Fix QA tool Issue with getDevice Being Retired

### DIFF
--- a/express/scripts/features/qa-guide/qa-guide.js
+++ b/express/scripts/features/qa-guide/qa-guide.js
@@ -1,7 +1,6 @@
 import {
   createTag,
   loadStyle,
-  getDevice,
 } from '../../utils.js';
 
 import {
@@ -185,7 +184,7 @@ const buildQAWidget = (index, payload) => {
 const loadQAStory = async (resp) => {
   const main = createTag('main');
   main.innerHTML = await resp.text();
-  const qaGuideEl = main.querySelector(`.qa-guide.${getDevice()}`);
+  const qaGuideEl = main.querySelector(`.qa-guide.${document.body.dataset.device}`);
 
   return qaGuideEl;
 };

--- a/express/scripts/features/qa-guide/utils/storage-controller.js
+++ b/express/scripts/features/qa-guide/utils/storage-controller.js
@@ -1,5 +1,3 @@
-import { getDevice } from '../../../utils.js';
-
 export function populateSessionStorage(payload) {
   let storagePackage = JSON.parse(sessionStorage.getItem('qa-record'));
 
@@ -7,12 +5,12 @@ export function populateSessionStorage(payload) {
     storagePackage = {
       configs: {
         host: window.location.host,
-        audience: getDevice(),
+        audience: document.body.dataset.device,
       },
     };
   } else {
     storagePackage.configs.host = window.location.host;
-    storagePackage.configs.audience = getDevice();
+    storagePackage.configs.audience = document.body.dataset.device;
   }
 
   payload.forEach((page) => {

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -46,8 +46,8 @@
       "containerId": "tools",
       "id": "qa-guide",
       "title": "QA Guide",
-      "event": "qa-guide",
-      "excludePaths": [ "**.docx**", "**/:x:**" ]
+      "environments": ["dev", "preview", "live"],
+      "event": "qa-guide"
     },
     {
       "containerId": "tools",


### PR DESCRIPTION
After merging the code to main it turns out a function being imported no longer exists. This PR quickly fixes the issue by switching to use the store data in DOM.

Tested locally. The issue is indeed fixed.

Resolves: [MWPW-139775](https://jira.corp.adobe.com/browse/MWPW-139775)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/?martech=off
- After: https://qa-console-error-fix--express--adobecom.hlx.page/express/?martech=off
