### PR TITLE
[HOTFIX] Template-X: Removing template title requirement to save templates fetch

### DIFF
--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -10,7 +10,7 @@ function isVideo(iterator) {
 }
 
 function getTemplateTitle(template) {
-  return template['dc:title']['i-default'];
+  return template['dc:title']?.['i-default'] || '';
 }
 
 function extractRenditionLinkHref(template) {

--- a/express/blocks/template-x/template-search-api-v3.js
+++ b/express/blocks/template-x/template-search-api-v3.js
@@ -215,7 +215,6 @@ function isValidBehaviors(behaviors) {
 export function isValidTemplate(template) {
   return !!(template.status === 'approved'
     && template.customLinks?.branchUrl
-    && template['dc:title']?.['i-default']
     && template.pages?.[0]?.rendition?.image?.thumbnail?.componentId
     && template._links?.['http://ns.adobe.com/adobecloud/rel/rendition']?.href?.replace
     && template._links?.['http://ns.adobe.com/adobecloud/rel/component']?.href?.replace


### PR DESCRIPTION
Our prod is suddenly broken because of an API response change. The template['dc:title']?.['i-default'] we used to check for validity is gone and we can't soft-fail the fetch because of it. This PR removes its dependency and allows images to load without alt-text as an interim fix.

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER) Pending

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/templates/?martech=off
- After: https://templates-hotfix--express--adobecom.hlx.page/express/templates/?martech=off
