### PR TITLE
Multifunction button no-lottie fix

### DIFF
--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -419,6 +419,7 @@ export function decorateBadge() {
 }
 
 export function buildToolBoxStructure(wrapper, data) {
+  lazyLoadLottiePlayer();
   const toolBox = createTag('div', { class: 'toolbox' });
   const toolBoxWrapper = createTag('div', { class: 'toolbox-inner-wrapper' });
   const notch = createTag('a', { class: 'notch' });

--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -13,13 +13,15 @@ import BlockMediator from '../../scripts/block-mediator.min.js';
 
 export const hideScrollArrow = (floatButtonWrapper, lottieScrollButton) => {
   floatButtonWrapper.classList.add('floating-button--scrolled');
-  if (document.activeElement === lottieScrollButton) lottieScrollButton.blur();
-  lottieScrollButton.tabIndex = -1;
+  if (lottieScrollButton) {
+    if (document.activeElement === lottieScrollButton) lottieScrollButton.blur();
+    lottieScrollButton.tabIndex = -1;
+  }
 };
 
 export const showScrollArrow = (floatButtonWrapper, lottieScrollButton) => {
   floatButtonWrapper.classList.remove('floating-button--scrolled');
-  lottieScrollButton.removeAttribute('tabIndex');
+  if (lottieScrollButton) lottieScrollButton.removeAttribute('tabIndex');
 };
 
 export function openToolBox(wrapper, lottie, data, userInitiated) {


### PR DESCRIPTION
This PR fixes the issue where the multifunction button block can't retract on mobile pages since the lottie arrow was removed from all floating CTAs.

Resolves: [MWPW-142377](https://jira.corp.adobe.com/browse/MWPW-142377)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/create/logo/random?martech=off
- After: https://multifunction-button-no-lottie-fix--express--adobecom.hlx.page/express/create/logo/random?martech=off
