### PR TITLE
Safe Fail Template X Title Construction

### DIFF
--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-import { createTag, getIconElement } from '../../scripts/utils.js';
+import { createTag, getIconElement, getMetadata } from '../../scripts/utils.js';
 
 function containsVideo(pages) {
   return pages.some((page) => !!page?.rendition?.video?.thumbnail?.componentId);
@@ -10,7 +10,19 @@ function isVideo(iterator) {
 }
 
 function getTemplateTitle(template) {
-  return template['dc:title']?.['i-default'] || '';
+  if (template['dc:title']?.['i-default']) {
+    return template['dc:title']['i-default'];
+  }
+
+  if (template.moods?.length && template.task?.name) {
+    return `${template.moods.join(', ')} ${template.task.name}`;
+  }
+
+  if (getMetadata('tasks-x')?.trim() && getMetadata('topics-x')?.trim()) {
+    return `${getMetadata('topics-x').trim()} ${getMetadata('tasks-x').trim()}`;
+  }
+
+  return '';
 }
 
 function extractRenditionLinkHref(template) {

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -10,7 +10,7 @@ function isVideo(iterator) {
 }
 
 function getTemplateTitle(template) {
-  return template['dc:title']['i-default'];
+  return template['dc:title']?.['i-default'] || '';
 }
 
 function extractRenditionLinkHref(template) {

--- a/express/blocks/template-x/template-search-api-v3.js
+++ b/express/blocks/template-x/template-search-api-v3.js
@@ -215,7 +215,6 @@ function isValidBehaviors(behaviors) {
 export function isValidTemplate(template) {
   return !!(template.status === 'approved'
     && template.customLinks?.branchUrl
-    && template['dc:title']?.['i-default']
     && template.pages?.[0]?.rendition?.image?.thumbnail?.componentId
     && template._links?.['http://ns.adobe.com/adobecloud/rel/rendition']?.href?.replace
     && template._links?.['http://ns.adobe.com/adobecloud/rel/component']?.href?.replace


### PR DESCRIPTION
use other template attribute || page context to safe fail the template x rendering before filtering the template out entirely.

Resolves: [MWPW-142381](https://jira.corp.adobe.com/browse/MWPW-142381)
![Screenshot 2024-02-07 at 09 56 17](https://github.com/adobecom/express/assets/57737624/3e4f776b-c5c6-4b76-aa1e-980744aa6011)
![Screenshot 2024-02-07 at 09 56 33](https://github.com/adobecom/express/assets/57737624/b012e3fd-8f28-4af3-b8e1-9cc9d569595e)
![Screenshot 2024-02-07 at 09 56 52](https://github.com/adobecom/express/assets/57737624/26d8f10b-95cb-484b-8418-1ec11ffde501)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/templates/?martech=off
- After: https://safe-fail-template-x--express--adobecom.hlx.page/express/templates/?martech=off
