### PR TITLE
MWPW-141958 | Fixing color sitemap XML

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -194,6 +194,7 @@ sitemaps:
         destination: /nl/express/templates/sitemap.xml
         hreflang: nl
         alternate: /nl/{path}
+  
   colors:
     origin: https://www.adobe.com
     languages:


### PR DESCRIPTION
Fixing color sitemap XML

Resolves: [MWPW-141958](https://jira.corp.adobe.com/browse/MWPW-141958)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/colors/sitemap.xml
- After: https://stage--express--adobecom.hlx.page/express/colors/sitemap.xml