### PR TITLE
MWPW-142705 start jarvis over same context

### DIFF
--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -104,11 +104,6 @@ export async function buildBreadCrumbArray(prefix) {
 async function loadFEDS() {
   const config = getConfig();
   const prefix = config.locale.prefix.replaceAll('/', '');
-  let jarvis = true;
-  // if metadata found jarvis must not be initialized in gnav because it will be initiated later
-  const jarvisMeta = getMetadata('jarvis-chat')?.toLowerCase();
-  if (!jarvisMeta || !['mobile', 'desktop', 'on'].includes(jarvisMeta)
-    || !config.jarvis?.id || !config.jarvis?.version) jarvis = false;
 
   async function showRegionPicker() {
     const { getModal } = await import('../blocks/modal/modal.js');
@@ -180,11 +175,11 @@ async function loadFEDS() {
         window.location.href = sparkLoginUrl;
       },
     },
-    jarvis: !jarvis ? {
+    jarvis: {
       surfaceName: config.jarvis.id,
       surfaceVersion: config.jarvis.version,
       onDemand: true,
-    } : {},
+    },
     breadcrumbs: {
       showLogo: true,
       links: await buildBreadCrumbArray(prefix),

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -33,13 +33,19 @@ const locales = {
   uk: { ietf: 'en-GB', tk: 'pps7abe.css' },
 };
 
+let jarvisImmediatelyVisible = false;
+const jarvisVisibleMeta = getMetadata('jarvis-immediately-visible')?.toLowerCase();
+const desktopViewport = window.matchMedia('(min-width: 900px)').matches;
+if (jarvisVisibleMeta && ['mobile', 'desktop', 'on'].includes(jarvisVisibleMeta) && (
+  (jarvisVisibleMeta === 'mobile' && !desktopViewport) || (jarvisVisibleMeta === 'desktop' && desktopViewport))) jarvisImmediatelyVisible = true;
+
 const config = {
   locales,
   codeRoot: '/express/',
   jarvis: {
     id: 'Acom_Express',
     version: '1.0',
-    onDemand: false,
+    onDemand: !jarvisImmediatelyVisible,
   },
   links: 'on',
 };


### PR DESCRIPTION
shift code to only use milo jarvis approach. More details in the task description

Resolves: [MWPW-142705](https://jira.corp.adobe.com/browse/MWPW-142705)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/drafts/vhargrave/jarvis-immediately-visible?martech=off
- After: https://jarvis--express--adobecom.hlx.page/drafts/vhargrave/jarvis-immediately-visible?martech=off

- Before: https://main--express--adobecom.hlx.page/drafts/vhargrave/jarvis-not-immediately-visible?martech=off
- After: https://jarvis--express--adobecom.hlx.page/drafts/vhargrave/jarvis-not-immediately-visible?martech=off
