### PR TITLE
Removing FAQ splitSection

### DIFF
--- a/express/blocks/faq/faq.js
+++ b/express/blocks/faq/faq.js
@@ -54,23 +54,6 @@ function decorateFAQBlocks(block) {
     });
     document.head.appendChild($schemaScript);
   }
-
-  // find previous h2 and move it in the FAQ
-  const section = block.closest('.section');
-  if (section && section.previousElementSibling) {
-    const previousSection = section.previousElementSibling;
-    const h2 = previousSection.querySelector('div > h2:last-of-type');
-    // make sure there is no other element
-    if (h2 && !h2.nextElementSibling) {
-      const previous = h2.previousElementSibling;
-      block.before(h2);
-
-      if (!previous) {
-        // remove empty previous section
-        previousSection.remove();
-      }
-    }
-  }
 }
 
 export default async function decorate(block) {

--- a/express/blocks/faq/faq.js
+++ b/express/blocks/faq/faq.js
@@ -7,15 +7,13 @@ function decorateFAQBlocks(block) {
   const showSchema = getMetadata('show-faq-schema');
   const faqs = [];
   const entities = [];
-  const $rows = Array.from(block.children);
-  $rows.forEach(($row) => {
-    const $cells = Array.from($row.children);
-    const $question = $cells[0];
-    const $answer = $cells[1];
-    const question = $question.textContent.trim();
-    const answer = $answer.innerHTML;
+  const rows = Array.from(block.children);
+  rows.forEach((row) => {
+    const cells = Array.from(row.children);
+    const question = cells[0];
+    const answer = cells[1];
     faqs.push({
-      question, answer,
+      question: question.textContent.trim(), answer: answer.innerHTML,
     });
   });
 

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2055,7 +2055,7 @@ function splitSections($main) {
   const multipleColumns = $main.querySelectorAll('.columns.fullsize-center').length > 1;
   $main.querySelectorAll(':scope > div > div').forEach(($block) => {
     const hasAppStoreBlocks = ['yes', 'true', 'on'].includes(getMetadata('show-standard-app-store-blocks').toLowerCase());
-    const blocksToSplit = ['template-list', 'layouts', 'banner', 'faq', 'promotion', 'app-store-highlight', 'app-store-blade', 'plans-comparison'];
+    const blocksToSplit = ['template-list', 'layouts', 'banner', 'promotion', 'app-store-highlight', 'app-store-blade', 'plans-comparison'];
     // work around for splitting columns and sixcols template list
     // add metadata condition to minimize impact on other use cases
     if (hasAppStoreBlocks && !multipleColumns) {


### PR DESCRIPTION
This fix is to remove the FAQ block from the splitSection whitelist, which was causing issue on the one-plans page.
We've manually inspected the FAQ block on some create, feature, pricing and business pages. So far no breakage is observed. But a sitewise QA should be performed to make sure no regression is caused by this change given the age of the block.

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER) pending

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/business?martech=off
- After: https://faq-debug--express--adobecom.hlx.page/express/business?martech=off
