### PR TITLE
PEP Remove the 3 times Cooldown after Redirection

### DIFF
--- a/express/features/direct-path-to-product/direct-path-to-product.js
+++ b/express/features/direct-path-to-product/direct-path-to-product.js
@@ -92,9 +92,6 @@ export default async function loadLoginUserAutoRedirect() {
     const primaryCtaUrl = BlockMediator.get('primaryCtaUrl')
       || document.querySelector('a.button.xlarge.same-as-floating-button-CTA, a.primaryCTA')?.href;
 
-    // disable dptp to not annoy user when they come back to AX site.
-    localStorage.setItem(OPT_OUT_KEY, '3');
-
     track(`${adobeEventName}:redirect`);
 
     if (primaryCtaUrl) {


### PR DESCRIPTION
We now want to more greedily redirect users, even if they previously have been redirected and come back.

Resolves: https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=cclight&title=CCX0137-+Direct+Path+to+Product

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/feature/image/remove-background
- After: https://pep-always-prompt--express--adobecom.hlx.page/express/feature/image/remove-background
