### PR TITLE
added initial view toggle author control

### DIFF
--- a/express/blocks/template-list/template-list.css
+++ b/express/blocks/template-list/template-list.css
@@ -69,12 +69,6 @@ main .template-list.fullwidth {
   justify-content: center;
 }
 
-main .template-list.fullwidth.sm-view,
-main .template-list.fullwidth.md-view,
-main .template-list.fullwidth.lg-view {
-  padding: 0 28px;
-}
-
 main .template-list-wrapper.with-categories-list .template-list.fullwidth {
   width: 100%;
   min-height: 600px;

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -1405,16 +1405,18 @@ function toggleMasonryView($block, $button, $toggleButtons, props) {
   }
 }
 
-function initViewToggle($block, $toolBar, props) {
-  const $toggleButtons = $toolBar.querySelectorAll('.view-toggle-button ');
+function initViewToggle(block, toolBar, props) {
+  const toggleButtons = toolBar.querySelectorAll('.view-toggle-button ');
+  const authoredViewIndex = ['sm', 'md', 'lg'].findIndex((size) => getMetadata('initial-template-view')?.toLowerCase().trim() === size);
+  const initViewIndex = authoredViewIndex === -1 ? 0 : authoredViewIndex;
 
-  $toggleButtons.forEach(($button, index) => {
-    if (index === 0) {
-      toggleMasonryView($block, $button, $toggleButtons, props);
+  toggleButtons.forEach((button, index) => {
+    if (index === initViewIndex && getMetadata('initial-template-view') !== 'no') {
+      toggleMasonryView(block, button, toggleButtons, props);
     }
 
-    $button.addEventListener('click', () => {
-      toggleMasonryView($block, $button, $toggleButtons, props);
+    button.addEventListener('click', () => {
+      toggleMasonryView(block, button, toggleButtons, props);
     }, { passive: true });
   });
 }
@@ -1427,7 +1429,7 @@ async function decorateBreadcrumbs(block) {
   if (breadcrumbs) parent.prepend(breadcrumbs);
 }
 
-function initToolbarShadow($block, $toolbar) {
+function initToolbarShadow($toolbar) {
   const $toolbarWrapper = $toolbar.parentElement;
   document.addEventListener('scroll', () => {
     if ($toolbarWrapper.getBoundingClientRect().top <= 0) {

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -1021,11 +1021,14 @@ function toggleMasonryView(block, props, button, toggleButtons) {
 
 function initViewToggle(block, props, toolBar) {
   const toggleButtons = toolBar.querySelectorAll('.view-toggle-button ');
-  block.classList.add('sm-view');
-  block.parentElement.classList.add('sm-view');
-  toggleButtons[0].classList.add('active');
+  const authoredViewIndex = ['sm', 'md', 'lg'].findIndex((size) => getMetadata('initial-template-view')?.toLowerCase().trim() === size);
+  const initViewIndex = authoredViewIndex === -1 ? 0 : authoredViewIndex;
 
-  toggleButtons.forEach((button) => {
+  toggleButtons.forEach((button, index) => {
+    if (index === initViewIndex) {
+      toggleMasonryView(block, props, button, toggleButtons);
+    }
+
     button.addEventListener('click', () => {
       toggleMasonryView(block, props, button, toggleButtons);
     }, { passive: true });


### PR DESCRIPTION
The SEO team wants to help us get the multi-image thumbnails on SERP:
![Screenshot 2024-02-15 at 11 49 12 AM](https://github.com/adobecom/express/assets/57737624/e827e6ec-bb7c-40d7-837c-1daddb5667e3)

Our current templates pages load the images too small. With this code change, the authors will have control over which size we render the templates initially on page load.

More details in ticket.

Please test using mobile viewport.

Resolves: [MWPW-141135](https://jira.corp.adobe.com/browse/MWPW-141135)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/templates/brochure/company?martech=off
- After: https://template-size-change--express--adobecom.hlx.page/express/templates/brochure/company?martech=off
