### PR TITLE
remove free plan injection on experiment marquee

### DIFF
--- a/express/blocks/marquee-exp-1/marquee-exp-1.js
+++ b/express/blocks/marquee-exp-1/marquee-exp-1.js
@@ -400,12 +400,6 @@ export default async function decorate(block) {
     }
   }
 
-  const button = block.querySelector('.button');
-  if (button) {
-    const { addFreePlanWidget } = await import('../../scripts/utils/free-plan.js');
-    await addFreePlanWidget(button.parentElement);
-  }
-
   const phoneNumberTags = block.querySelectorAll('a[title="{{business-sales-numbers}}"]');
   if (phoneNumberTags.length > 0) {
     const { formatSalesPhoneNumber } = await import('../../scripts/utils/pricing.js');


### PR DESCRIPTION
disabling free-plan-tag for experiment page by removing the injection code in the block

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/?experiment=ccx0167%2Fcontrol
- After: https://marquee-exp-fix--express--adobecom.hlx.page/express/?experiment=ccx0167%2Fchallenger-1
