### PR TITLE
added inline button support for marquee

### DIFF
--- a/express/blocks/marquee/marquee.css
+++ b/express/blocks/marquee/marquee.css
@@ -63,6 +63,15 @@ body.no-desktop-brand-header header {
   align-items: flex-start;
 }
 
+.marquee .marquee-foreground .with-inline-ctas.buttons-wrapper {
+  align-items: center;
+  gap: 8px;
+}
+
+.marquee .marquee-foreground .with-inline-ctas.buttons-wrapper a.button.accent {
+  margin: 0;
+}
+
 .marquee .content-wrapper h1 {
   font-size: clamp(var(--heading-font-size-l), 4vw, var(--heading-font-size-xxl));
   margin: 0 0 8px 0;
@@ -324,6 +333,11 @@ body.no-desktop-brand-header header {
 
   .marquee .marquee-foreground .buttons-wrapper {
     flex-direction: row;
+  }
+
+  .marquee .marquee-foreground .with-inline-ctas.buttons-wrapper {
+    margin-top: 24px;
+    gap: 24px;
   }
 
   .marquee.narrow .marquee-foreground .content-wrapper {

--- a/express/blocks/marquee/marquee.js
+++ b/express/blocks/marquee/marquee.js
@@ -334,22 +334,32 @@ export default async function decorate(block) {
       }
 
       const contentButtons = [...div.querySelectorAll('a.button.accent')];
-      const primaryBtn = contentButtons[0];
-      const secondaryButton = contentButtons[1];
-      const buttonAsLink = contentButtons[2];
-      buttonAsLink?.classList.remove('button');
-      primaryBtn?.classList.add('primaryCTA');
-      BlockMediator.set('primaryCtaUrl', primaryBtn?.href);
-      secondaryButton?.classList.add('secondary');
-      const buttonContainers = [...div.querySelectorAll('p.button-container')];
-      const buttonsWrapper = createTag('div', { class: 'buttons-wrapper' });
-      buttonContainers[0]?.before(buttonsWrapper);
-      buttonContainers.forEach((btnContainer) => {
-        handleSubCTAText(btnContainer);
-        btnContainer.classList.add('button-inline');
-        btnContainer.querySelector('a.button')?.classList.add('xlarge');
-        buttonsWrapper.append(btnContainer);
-      });
+      if (contentButtons.length) {
+        const primaryBtn = contentButtons[0];
+        const secondaryButton = contentButtons[1];
+        const buttonAsLink = contentButtons[2];
+        buttonAsLink?.classList.remove('button');
+        primaryBtn?.classList.add('primaryCTA');
+        BlockMediator.set('primaryCtaUrl', primaryBtn?.href);
+        secondaryButton?.classList.add('secondary');
+        const buttonContainers = [...div.querySelectorAll('p.button-container')];
+        const buttonsWrapper = createTag('div', { class: 'buttons-wrapper' });
+        buttonContainers[0]?.before(buttonsWrapper);
+        buttonContainers.forEach((btnContainer) => {
+          handleSubCTAText(btnContainer);
+          btnContainer.classList.add('button-inline');
+          btnContainer.querySelector('a.button')?.classList.add('xlarge');
+          buttonsWrapper.append(btnContainer);
+        });
+      } else {
+        const inlineButtons = [...div.querySelectorAll('p:last-of-type > a:not(.button.accent)')];
+        if (inlineButtons.length) {
+          const primaryCta = inlineButtons[0];
+          primaryCta.classList.add('button', 'accent', 'primaryCTA', 'xlarge');
+          BlockMediator.set('primaryCtaUrl', primaryCta.href);
+          primaryCta.parentElement.classList.add('buttons-wrapper', 'with-inline-ctas');
+        }
+      }
     }
 
     if (rowType === 'option') {


### PR DESCRIPTION
Added a way of authoring CTAs in the marquee block to support inline style secondary button.
![Screenshot 2024-02-20 at 09 21 21](https://github.com/adobecom/express/assets/57737624/3fdff487-cfae-4e6e-a734-9843f552295d)

Resolves: [MWPW-142936](https://jira.corp.adobe.com/browse/MWPW-142936)
for more details, please see the parent ticket linked wiki.

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/?martech=off
- After: https://marquee-inline-secondary-cta--express--adobecom.hlx.page/express/?martech=off
