### PR TITLE
[PEP] Wait for AdobeProfile after Alloy

### DIFF
--- a/express/scripts/express-delayed.js
+++ b/express/scripts/express-delayed.js
@@ -27,7 +27,7 @@ function getSegmentsFromAlloyResponse(response) {
   return ids;
 }
 
-async function checkSignedIn() {
+async function isSignedIn() {
   if (window.adobeProfile?.getUserProfile()) return true;
   if (window.feds.events?.profile_data) return false; // data ready -> not signed in
   let resolve;
@@ -49,10 +49,9 @@ async function canPEP() {
   if (!pepSegment) return false;
   const placeholders = await fetchPlaceholders();
   if (!placeholders.cancel || !placeholders['pep-header'] || !placeholders['pep-cancel']) return false;
-  const [alloyRes, isSignedIn] = await Promise.all([window.alloyLoader, checkSignedIn()]);
-  if (!isSignedIn) return false;
-  const segments = getSegmentsFromAlloyResponse(alloyRes);
-  return pepSegment.replace(/\s/g, '').split(',').some((pepSeg) => segments.includes(pepSeg));
+  const segments = getSegmentsFromAlloyResponse(await window.alloyLoader);
+  if (!pepSegment.replace(/\s/g, '').split(',').some((pepSeg) => segments.includes(pepSeg))) return false;
+  return !!(await isSignedIn());
 }
 
 const PEP_DELAY = 3000;

--- a/express/scripts/express-delayed.js
+++ b/express/scripts/express-delayed.js
@@ -38,7 +38,7 @@ async function isSignedIn() {
     resolve();
   }, { once: true });
   // if not ready, abort
-  await Promise.race([resolved, new Promise((r) => setTimeout(r, 2000))]);
+  await Promise.race([resolved, new Promise((r) => setTimeout(r, 5000))]);
   return window.adobeProfile?.getUserProfile();
 }
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -107,6 +107,7 @@ const listenAlloy = () => {
   });
   window.addEventListener('alloy_sendEvent', (e) => {
     if (e.detail.type === 'pageView') {
+      console.log('alloy back!');
       // eslint-disable-next-line no-console
       if (usp.has('debug-alloy')) console.log(`Alloy loaded in ${performance.now() - t1}`);
       loaded = true;
@@ -122,8 +123,14 @@ const listenAlloy = () => {
 };
 
 (async function loadPage() {
-  window.addEventListener('adobeGNav:ImsReady', () => {
-    console.log('ha');
+  window.addEventListener('feds.events.profile_data.loaded', () => {
+    console.log('profile_data.loaded');
+  });
+  window.addEventListener('feds.events.profileDataReady', () => {
+    console.log('profileDataReady');
+  });
+  window.addEventListener('feds.events.experience.loaded', () => {
+    console.log('experience.loaded');
   });
   if (window.hlx.init || window.isTestEnv) return;
   setConfig(config);

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -122,15 +122,6 @@ const listenAlloy = () => {
 };
 
 (async function loadPage() {
-  window.addEventListener('feds.events.profile_data.loaded', () => {
-    console.log('profile_data.loaded', performance.now(), window.adobeProfile, window.feds.events.profile_data);
-  });
-  window.addEventListener('feds.events.profileDataReady', () => {
-    console.log('profileDataReady', performance.now(), window.adobeProfile, window.feds.events.profile_data);
-  });
-  window.addEventListener('feds.events.experience.loaded', () => {
-    console.log('experience.loaded', performance.now(), window.adobeProfile, window.feds.events.profile_data);
-  });
   if (window.hlx.init || window.isTestEnv) return;
   setConfig(config);
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -122,7 +122,7 @@ const listenAlloy = () => {
 };
 
 (async function loadPage() {
-  window.addEventListener('adobeGNav:ProfileReady', () => {
+  window.addEventListener('adobeGNav:ImsReady', () => {
     console.log('ha');
   });
   if (window.hlx.init || window.isTestEnv) return;

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -122,6 +122,9 @@ const listenAlloy = () => {
 };
 
 (async function loadPage() {
+  window.addEventListener('adobeGNav:ProfileReady', () => {
+    console.log('ha');
+  });
   if (window.hlx.init || window.isTestEnv) return;
   setConfig(config);
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -124,13 +124,13 @@ const listenAlloy = () => {
 
 (async function loadPage() {
   window.addEventListener('feds.events.profile_data.loaded', () => {
-    console.log('profile_data.loaded');
+    console.log('profile_data.loaded', performance.now());
   });
   window.addEventListener('feds.events.profileDataReady', () => {
-    console.log('profileDataReady');
+    console.log('profileDataReady', performance.now());
   });
   window.addEventListener('feds.events.experience.loaded', () => {
-    console.log('experience.loaded');
+    console.log('experience.loaded', performance.now());
   });
   if (window.hlx.init || window.isTestEnv) return;
   setConfig(config);

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -107,7 +107,6 @@ const listenAlloy = () => {
   });
   window.addEventListener('alloy_sendEvent', (e) => {
     if (e.detail.type === 'pageView') {
-      console.log('alloy back!');
       // eslint-disable-next-line no-console
       if (usp.has('debug-alloy')) console.log(`Alloy loaded in ${performance.now() - t1}`);
       loaded = true;
@@ -124,13 +123,13 @@ const listenAlloy = () => {
 
 (async function loadPage() {
   window.addEventListener('feds.events.profile_data.loaded', () => {
-    console.log('profile_data.loaded', performance.now());
+    console.log('profile_data.loaded', performance.now(), window.adobeProfile, window.feds.events.profile_data);
   });
   window.addEventListener('feds.events.profileDataReady', () => {
-    console.log('profileDataReady', performance.now());
+    console.log('profileDataReady', performance.now(), window.adobeProfile, window.feds.events.profile_data);
   });
   window.addEventListener('feds.events.experience.loaded', () => {
-    console.log('experience.loaded', performance.now());
+    console.log('experience.loaded', performance.now(), window.adobeProfile, window.feds.events.profile_data);
   });
   if (window.hlx.init || window.isTestEnv) return;
   setConfig(config);


### PR DESCRIPTION
Sometimes adobeProfile is slower than Alloy. This give profile extra 2 seconds after alloy. If it's still not ready, we abort PEP.

Resolves: https://jira.corp.adobe.com/browse/MWPW-137828

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/
- After: https://pep-wait-adobeprofile--express--adobecom.hlx.page/express/
