### PR TITLE
MWPW-143002 cleanup jarvis in gnav

### DIFF
--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -175,11 +175,7 @@ async function loadFEDS() {
         window.location.href = sparkLoginUrl;
       },
     },
-    jarvis: {
-      surfaceName: config.jarvis.id,
-      surfaceVersion: config.jarvis.version,
-      onDemand: true,
-    },
+    jarvis: {},
     breadcrumbs: {
       showLogo: true,
       links: await buildBreadCrumbArray(prefix),


### PR DESCRIPTION
code cleanup so that jarvis can only be started using the milo implementation. 

Resolves: [MWPW-143002](https://jira.corp.adobe.com/browse/MWPW-143002)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/business?martech=off
- After: https://jarvis--express--adobecom.hlx.page/express/business?martech=off

- Before: https://main--express--adobecom.hlx.page/express/?martech=off
- After: https://jarvis--express--adobecom.hlx.page/express/?martech=off