### PR TITLE
[One Plans] Update Breakpoints and Suppress H1 Top Padding

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -261,7 +261,7 @@
   }
 }
 
-@media screen and (min-width: 1440px) {
+@media screen and (min-width: 1250px) {
   :root {
     --card-width: 391px;
     --card-padding: 24px 16px;

--- a/express/blocks/tabs-ax/tabs-ax.js
+++ b/express/blocks/tabs-ax/tabs-ax.js
@@ -181,6 +181,12 @@ const init = (block) => {
     tabListItems[0].parentElement.remove();
   }
 
+  // as of now tabs-ax is used above the fold and it's usually h1 default wrapper before it
+  // TODO: develop consistent padding/margin patterns for block/section
+  if (parentSection.previousElementSibling.classList.contains('hero', 'hero-noimage')) {
+    parentSection.previousElementSibling.style.paddingTop = '0';
+  }
+
   // Tab Sections
   const allSections = Array.from(rootElem.querySelectorAll('div.section[data-tab]'));
   allSections.forEach((e) => {


### PR DESCRIPTION
Temporarily change the breakpoint only for desktop. Will update all pixel numbers for all components again when new design comes.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/pricing?martech=off
- After: https://pricing-cards-breakpoint--express--adobecom.hlx.page/express/pricing?martech=off
