### PR TITLE
Update color how to carousel to support leaner content

### DIFF
--- a/express/blocks/color-how-to-carousel/color-how-to-carousel.css
+++ b/express/blocks/color-how-to-carousel/color-how-to-carousel.css
@@ -210,6 +210,10 @@
         margin-top: 24px;
     }
 
+    .color-how-to-carousel.top-align > .img-wrapper {
+        margin-top: unset;
+    }
+
     .color-how-to-carousel > .img-wrapper .color-graph-text-overlay .color-name {
         font-size: var(--heading-font-size-m);
     }

--- a/express/blocks/color-how-to-carousel/color-how-to-carousel.js
+++ b/express/blocks/color-how-to-carousel/color-how-to-carousel.js
@@ -76,7 +76,9 @@ function buildColorHowToCarousel(block, payload) {
   carousel.prepend(numbers);
   const tips = createTag('div', { class: 'tips' });
   carousel.append(tips);
-  carouselDivs.append(payload.icon, payload.heading, carousel, payload.cta);
+  if (payload.icon) carouselDivs.append(payload.icon);
+  carouselDivs.append(payload.heading, carousel);
+  if (payload.cta) carouselDivs.append(payload.icon);
 
   if (includeSchema) {
     buildSchema(rows, payload);
@@ -210,6 +212,27 @@ export default async function decorate(block) {
       imgWrapper.prepend(colorTextOverlay);
       block.prepend(imgWrapper);
       colorDataDiv.remove();
+    }
+
+    if (colorDataRows.length === 4) {
+      [payload.heading] = colorDataRows;
+      payload.colorName = colorDataRows[1].textContent.trim();
+      [payload.primaryHex, payload.secondaryHex] = colorDataRows[2].textContent.split(',');
+      payload.colorGraphName = colorDataRows[3].textContent.trim();
+      const imgWrapper = createTag('div', { class: 'img-wrapper' });
+      imgWrapper.innerHTML = getColorSVG(payload.colorGraphName);
+
+      const colorTextOverlay = createTag('div', { class: 'color-graph-text-overlay' });
+      const colorName = createTag('p', { class: 'color-name' });
+      const colorHex = createTag('p', { class: 'color-hex' });
+      colorName.textContent = payload.colorName;
+      colorHex.textContent = payload.primaryHex;
+
+      colorTextOverlay.append(colorName, colorHex);
+      imgWrapper.prepend(colorTextOverlay);
+      block.prepend(imgWrapper);
+      colorDataDiv.remove();
+      block.classList.add('top-align');
     }
 
     rows.forEach((step) => {

--- a/test/unit/blocks/color-how-to-carousel/color-how-to-carousel.test.js
+++ b/test/unit/blocks/color-how-to-carousel/color-how-to-carousel.test.js
@@ -2,25 +2,58 @@ import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 
 const { default: decorate } = await import('../../../../express/blocks/color-how-to-carousel/color-how-to-carousel.js');
-const testBody = await readFile({ path: './mocks/body.html' });
+const redBody = await readFile({ path: './mocks/body.html' });
+const blackBody = await readFile({ path: './mocks/body-dark.html' });
 
 describe('Color How To Carousel', () => {
-  beforeEach(() => {
-    window.isTestEnv = true;
-    document.body.innerHTML = testBody;
+  describe('with 6 lines in the first row', () => {
+    beforeEach(() => {
+      window.isTestEnv = true;
+      document.body.innerHTML = redBody;
+    });
+
+    it('block exists', async () => {
+      const block = document.querySelector('.color-how-to-carousel');
+      await decorate(block);
+      expect(block).to.exist;
+    });
+
+    it('schema variant builds schema', async () => {
+      const block = document.querySelector('.color-how-to-carousel');
+      block.classList.add('schema');
+      await decorate(block);
+      const schema = document.querySelector('head script[type="application/ld+json"]');
+      expect(schema).to.exist;
+    });
   });
 
-  it('block exists', async () => {
-    const block = document.querySelector('.color-how-to-carousel');
-    await decorate(block);
-    expect(block).to.exist;
-  });
+  describe('with only 4 lines in the first row + is dark', () => {
+    beforeEach(() => {
+      window.isTestEnv = true;
+      document.body.innerHTML = blackBody;
+    });
 
-  it('schema variant builds schema', async () => {
-    const block = document.querySelector('.color-how-to-carousel');
-    block.classList.add('schema');
-    await decorate(block);
-    const schema = document.querySelector('head script[type="application/ld+json"]');
-    expect(schema).to.exist;
+    it('block has a dark class', async () => {
+      const block = document.querySelector('.color-how-to-carousel');
+      await decorate(block);
+      expect(block.classList.contains('dark')).to.be.true;
+    });
+
+    it('schema variant builds schema', async () => {
+      const block = document.querySelector('.color-how-to-carousel');
+      block.classList.add('schema');
+      await decorate(block);
+      const schema = document.querySelector('head script[type="application/ld+json"]');
+      expect(schema).to.exist;
+    });
+
+    it('the missing 2 rows are icon and CTA', async () => {
+      const block = document.querySelector('.color-how-to-carousel');
+      await decorate(block);
+      const icon = block.querySelector('.icon-color-how-to-icon');
+      const cta = block.querySelector('.contnt-wrapper a.button.accent');
+      expect(icon).to.not.exist;
+      expect(cta).to.not.exist;
+    });
   });
 });

--- a/test/unit/blocks/color-how-to-carousel/mocks/body-dark.html
+++ b/test/unit/blocks/color-how-to-carousel/mocks/body-dark.html
@@ -1,0 +1,30 @@
+<div class="color-how-to-carousel">
+    <div>
+        <div>
+            <h2 id="how-to-use-red">How to use black.</h2>
+            <p>Black</p>
+            <p>#000000,#ffffff</p>
+            <p>color-how-to-graph</p>
+        </div>
+    </div>
+    <div>
+        <div>Get started for free.</div>
+        <div>Open Adobe <strong>Express</strong> for free on your desktop or mobile device to start creating your poster.</div>
+    </div>
+    <div>
+        <div>Explore professionally designed templates.</div>
+        <div>Browse through thousands of standout poster templates or create from a blank canvas.</div>
+    </div>
+    <div>
+        <div>Feature eye-catching imagery.</div>
+        <div>Upload your own photos or add stock images and designs from our libraries.</div>
+    </div>
+    <div>
+        <div>Brand your poster.</div>
+        <div>Make your poster on-brand by uploading your logo and using fonts and colors that match your aesthetic. With a premium plan, you can even auto-apply your branded elements to save time and create more.</div>
+    </div>
+    <div>
+        <div>Share your poster.</div>
+        <div>Hit that publish button and instantly download your poster right to your device. Print it out, or share it online.</div>
+    </div>
+</div>


### PR DESCRIPTION
A new requirement came that the color how to carousel shouldn't use icon and cta anymore. This PR will give the block exactly the flexibility to do that.

Resolves: [MWPW-143134](https://jira.corp.adobe.com/browse/MWPW-143134)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/br/express/colors/purple?martech=off
- After: https://color-how-to-update--express--adobecom.hlx.page/br/express/colors/purple?martech=off
