### PR TITLE
Fix for floating CTA replacing MAU cta in split action

### DIFF
--- a/express/blocks/shared/floating-cta.css
+++ b/express/blocks/shared/floating-cta.css
@@ -177,7 +177,7 @@ main .floating-button-wrapper:first-of-type + .section {
     padding-top: 0;
 }
 
-main > div:not(.banner-container) .block:not(.pricing-summary, .pricing-cards, .pricing-table, .puf) a.button.same-as-floating-button-CTA {
+main > div:not(.banner-container) .block:not(.pricing-summary, .pricing-cards, .pricing-table, .puf, .split-action) a.button.same-as-floating-button-CTA {
     display: none;
 }
 

--- a/express/blocks/split-action/split-action.css
+++ b/express/blocks/split-action/split-action.css
@@ -96,7 +96,7 @@ main .split-action > .buttons-wrapper > a.button:last-of-type {
     margin: 8px 0 0 0;
 }
 
-main .split-action > .buttons-wrapper > a.button[target="_self"] {
+main .split-action > .buttons-wrapper > a.button:first-of-type {
     padding: 14px 11px;
     display: unset;
     background-color: transparent;


### PR DESCRIPTION
Floating CTA replacing buttons on the page has caused another issue. Here is the fix to add split action to not be a victim of it.

Resolves: [MWPW-143147](https://jira.corp.adobe.com/browse/MWPW-143147)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/feature/image/remove-background?martech=off
- After: https://fix-split-action--express--adobecom.hlx.page/express/feature/image/remove-background?martech=off
