### PR TITLE
PEP back to depend on IMS

### DIFF
--- a/express/scripts/express-delayed.js
+++ b/express/scripts/express-delayed.js
@@ -51,10 +51,7 @@ async function canPEP() {
   if (!placeholders.cancel || !placeholders['pep-header'] || !placeholders['pep-cancel']) return false;
   const segments = getSegmentsFromAlloyResponse(await window.alloyLoader);
   if (!pepSegment.replace(/\s/g, '').split(',').some((pepSeg) => segments.includes(pepSeg))) return false;
-  // eslint-disable-next-line no-unused-vars
-  const profileReady = !!(await isSignedIn()); // TODO: keeping for debugging adobeProfile
-  return true;
-  // return profileReady;
+  return !!(await isSignedIn());
 }
 
 const PEP_DELAY = 3000;


### PR DESCRIPTION
Urgent rollback to continue relying on IMS

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://stage--express--adobecom.hlx.page/express/
