### PR TITLE
[MWPW-143165] Create Documentation Block

### DIFF
--- a/express/blocks/documentation/documentation.css
+++ b/express/blocks/documentation/documentation.css
@@ -1,0 +1,15 @@
+.documentation {
+    text-align: initial;
+    border-bottom: 2px solid grey;
+}
+
+.documentation-row {
+    border-top: 2px solid grey;
+    border-right: 2px solid grey;
+    border-left: 2px solid grey;
+    padding: 20px;
+}
+
+p {
+    margin: 0px
+}

--- a/express/blocks/documentation/documentation.js
+++ b/express/blocks/documentation/documentation.js
@@ -1,10 +1,10 @@
-// Block for displaying documentation. What this does is 
+// Block for displaying documentation. What this does is
 // display a table similar to the one in sharepoint for a list
-// of elements. This can be useful if you are documenting 
+// of elements. This can be useful if you are documenting
 // the structure of a block and choose to use a table to do so
 export default async function decorate(block) {
-    const children = block.querySelectorAll(':scope > div')
-    children.forEach((c) => {
-        c.classList.add("documentation-row")
-    })
+  const children = block.querySelectorAll(':scope > div');
+  children.forEach((c) => {
+    c.classList.add('documentation-row');
+  });
 }

--- a/express/blocks/documentation/documentation.js
+++ b/express/blocks/documentation/documentation.js
@@ -1,0 +1,10 @@
+// Block for displaying documentation. What this does is 
+// display a table similar to the one in sharepoint for a list
+// of elements. This can be useful if you are documenting 
+// the structure of a block and choose to use a table to do so
+export default async function decorate(block) {
+    const children = block.querySelectorAll(':scope > div')
+    children.forEach((c) => {
+        c.classList.add("documentation-row")
+    })
+}


### PR DESCRIPTION

Block for displaying documentation. This allows a user to display a table on an express page that is visually similar to a table constructed in sharepoint. Since all blocks are tables in sharepoint, users can annotate the content of a table and render that table to the page in order to show what is suppose to go inside each table cell. This can be useful for documenting blocks.


<img width="748" alt="Screenshot 2024-02-22 at 11 55 59 AM" src="https://github.com/adobecom/express/assets/159481679/f66643fc-ab9f-49ab-8567-439f370e1840">

Resolves [MWPW-143165](https://jira.corp.adobe.com/browse/MWPW-143165)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://echen-documentation-block--express--adobecom.hlx.page/drafts/echen/pricing-cards-kitchen-sink-dev
