### PR TITLE
[PEP] One Sec Retry When getUserProfile() returns null

### DIFF
--- a/express/scripts/express-delayed.js
+++ b/express/scripts/express-delayed.js
@@ -39,6 +39,10 @@ async function isSignedIn() {
   }, { once: true });
   // if not ready, abort
   await Promise.race([resolved, new Promise((r) => setTimeout(r, 5000))]);
+  if (window.adobeProfile?.getUserProfile() === null) {
+    // retry after 1s
+    await new Promise((r) => setTimeout(r, 1000));
+  }
   return window.adobeProfile?.getUserProfile();
 }
 


### PR DESCRIPTION
Sometimes for signed in users, after feds.events.profile_data.loaded, window.adobeProfile exists, but its getUserProfile() returns null. There's no event or way to know when userProfile is really ready, but even 1 arbitrary retry should help reduce false negatives to some extent.

Resolves: https://jira.corp.adobe.com/browse/MWPW-143098?filter=381833

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/
- After: https://pep-1s-profile-wait--express--adobecom.hlx.page/express/
