### PR TITLE
[PEP] Load FEDS After IMS

### DIFF
--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -46,7 +46,7 @@ async function checkGeo(userGeo, userLocale, geoCheckForce) {
   return checkRedirect(window.location, region);
 }
 
-function loadIMS() {
+async function loadIMS() {
   window.adobeid = {
     client_id: sessionStorage.getItem('imsclient'),
     scope: 'AdobeID,openid',
@@ -54,9 +54,9 @@ function loadIMS() {
     environment: 'prod',
   };
   if (!['www.stage.adobe.com'].includes(window.location.hostname)) {
-    loadScript('https://auth.services.adobe.com/imslib/imslib.min.js');
+    await loadScript('https://auth.services.adobe.com/imslib/imslib.min.js');
   } else {
-    loadScript('https://auth-stg1.services.adobe.com/imslib/imslib.min.js');
+    await loadScript('https://auth-stg1.services.adobe.com/imslib/imslib.min.js');
     window.adobeid.environment = 'stg1';
   }
 }
@@ -273,7 +273,7 @@ async function loadFEDS() {
 }
 
 if (!window.hlx || window.hlx.gnav) {
-  loadIMS();
+  await loadIMS();
   loadFEDS();
   setTimeout(() => {
     import('./google-yolo.js').then((mod) => {


### PR DESCRIPTION
One experiment idea from the GNAV team is that we can test out always load feds after ims is loaded. This could help make IMS and adobeProfile stabler and shouldn't have too much impact on our pages.

Resolves: https://jira.corp.adobe.com/browse/MWPW-137828?filter=381833

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/
- After: https://feds-after-ims--express--adobecom.hlx.page/express/
