### PR TITLE
[Business Phone Numbers] Added Empty Country Fallback

### DIFF
--- a/express/scripts/utils/pricing.js
+++ b/express/scripts/utils/pricing.js
@@ -231,7 +231,7 @@ export const formatSalesPhoneNumber = (() => {
     }
 
     if (!numbersMap?.data) return;
-    const country = getCountry();
+    const country = getCountry() || 'us';
     tags.forEach((a) => {
       const r = numbersMap.data.find((d) => d.country === country);
 


### PR DESCRIPTION
Add Country Fallback to US when filling in phone numbers

Resolves: https://jira.corp.adobe.com/browse/MWPW-143203

Test URLs:
- Before: https://stage--express--adobecom.hlx.live/express/business?martech=off
- After: https://fix-us-sales-number--express--adobecom.hlx.live/express/business?martech=off
