### PR TITLE
Viewport Function Removal In BlogPosts.js

### DIFF
--- a/express/blocks/blog-posts/blog-posts.js
+++ b/express/blocks/blog-posts/blog-posts.js
@@ -336,7 +336,7 @@ async function decorateBlogPosts(blogPostsElements, config, offset = 0) {
 
   if (images.length) {
     const section = blogPostsElements.closest('.section');
-    section.style.display = 'block'; 
+    section.style.display = 'block';
     const imagePromises = images.map((img) => loadImage(img));
     await Promise.all(imagePromises);
     delete section.style.display;

--- a/express/blocks/blog-posts/blog-posts.js
+++ b/express/blocks/blog-posts/blog-posts.js
@@ -194,17 +194,6 @@ const loadImage = (img) => new Promise((resolve) => {
   }
 });
 
-// Load the bounding rect in async mode.
-async function isInViewport(element) {
-  const rect = await element.getBoundingClientRect();
-  return (
-    rect.top >= 0
-    && rect.left >= 0
-    && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight)
-    && rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-  );
-}
-
 // Translates the Read More string into the local language
 async function getReadMoreString() {
   const placeholders = await fetchPlaceholders();
@@ -347,9 +336,8 @@ async function decorateBlogPosts(blogPostsElements, config, offset = 0) {
 
   if (images.length) {
     const section = blogPostsElements.closest('.section');
-    section.style.display = 'block';
-    const filteredImages = images.filter(async (i) => isInViewport(i));
-    const imagePromises = filteredImages.map((img) => loadImage(img));
+    section.style.display = 'block'; 
+    const imagePromises = images.map((img) => loadImage(img));
     await Promise.all(imagePromises);
     delete section.style.display;
   }


### PR DESCRIPTION
Describe your specific features or fixes

Removes the isInViewport function from blog-posts.js, which was causing performance issues.
 
Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/learn/blog
- After:  https://echen-blog-optimization-viewport-removal--express--adobecom.hlx.page/express/learn/blog?martech=off
