### PR TITLE
[MWPW-142523] Pricing Cards CSS Fix

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -94,10 +94,11 @@ Border style variants
   border-radius: 16px;
   overflow: hidden;
   background: var(--color-white);
-  margin-top: 0px !important;
+  margin-top: -4px !important;
   display: flex;
   flex-direction: column;
 }
+
 
 .pricing-cards .special-promo {
   border: 1px solid #FFE600;
@@ -137,6 +138,10 @@ Border style variants
 /*
 End border style variants
 */
+
+.pricing-cards .card-border {
+  margin-top: 44px;
+}
 
 .pricing-cards .card-border .hide {
   display: none;

--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -90,7 +90,7 @@ Border style variants
 
 .pricing-cards .gradient-promo {
   background: linear-gradient(90deg, #ff477b 0%, #5c5ce0 52%, #318fff 100%) !important;
-  padding: 12px 2px 2px 2px;
+  padding: 12px 2px 4px 2px;
   border-radius: 16px;
   overflow: hidden;
   background: var(--color-white);

--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -90,11 +90,13 @@ Border style variants
 
 .pricing-cards .gradient-promo {
   background: linear-gradient(90deg, #ff477b 0%, #5c5ce0 52%, #318fff 100%) !important;
-  padding: 12px 4px 4px 4px;
+  padding: 12px 2px 2px 2px;
   border-radius: 16px;
   overflow: hidden;
   background: var(--color-white);
   margin-top: 0px !important;
+  margin-left: -2px;
+  margin-right: -2px;
   display: flex;
   flex-direction: column;
 }

--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -94,7 +94,7 @@ Border style variants
   border-radius: 16px;
   overflow: hidden;
   background: var(--color-white);
-  margin-top: -4px !important;
+  margin-top: 0px !important;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
Describe your specific features or fixes

Fix for the gradient promo. If a user specifies a gradient promo in the pricing cards, then the tops of the cards will be misaligned without this fix. This fix sets a default margin-top for .card-border, which will only apply to new pricing cards authored. The gradient-promo will fill the new default margin completely, allowing for the tops of all cards to be aligned.


Resolves: [MWPW-142523](https://jira.corp.adobe.com/browse/MWPW-142523)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://echen-card-outline--express--adobecom.hlx.page/drafts/echen/pricing-cards-kitchen-sink-dev
 
<img width="1252" alt="Screenshot 2024-02-29 at 10 33 18 AM" src="https://github.com/adobecom/express/assets/159481679/629a2a60-ba94-41ec-96ae-0934e7bc1004">

