### PR TITLE
[Template-X] Fail Start More than 9999

### DIFF
--- a/express/blocks/template-x/template-search-api-v3.js
+++ b/express/blocks/template-x/template-search-api-v3.js
@@ -234,6 +234,10 @@ export async function fetchTemplatesCategoryCount(props, tasks) {
 }
 
 export async function fetchTemplates(props) {
+  // api rejects 10000+
+  if (props.start > 9999) {
+    return { response: null, fallbackMsg: await getFallbackMsg() };
+  }
   // different strategies w/o toolBar
   if (props.toolBar) return fetchTemplatesWithToolbar(props);
   return fetchTemplatesNoToolbar(props);


### PR DESCRIPTION
API will reject queries with big start. Instead of getting rejected at the API side, we should fail earlier in the frontend.

Resolves: https://jira.corp.adobe.com/browse/MWPW-143566

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/templates/?martech=off
- After: https://template-search-start-constraint--express--adobecom.hlx.page/express/templates/?martech=off
