### PR TITLE
Fix preflight img path 404 issue

### DIFF
--- a/express/blocks/preflight/preflight.js
+++ b/express/blocks/preflight/preflight.js
@@ -4,7 +4,7 @@ import General from './panels/general.js';
 import SEO from './panels/seo.js';
 
 const HEADING = 'Milo Preflight';
-const IMG_PATH = '/blocks/preflight/img';
+const IMG_PATH = 'blocks/preflight/img';
 
 const tabs = signal([
   { title: 'General', selected: true },


### PR DESCRIPTION
Not sure what changes caused our preflight BG to start 404ing (possibly the link localisation thing?). With the upcoming SEO lifts, I suggest that we keep our own preflight functional until we get the preflight from Milo out of box hopefully by EoQ4.

Resolves: [MWPW-143588](https://jira.corp.adobe.com/browse/MWPW-143588)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/?martech=off
- After: https://fix-preflight-404--express--adobecom.hlx.page/express/?martech=off
