### PR TITLE
Fix blog posts holding page load

### DIFF
--- a/express/blocks/blog-posts/blog-posts.css
+++ b/express/blocks/blog-posts/blog-posts.css
@@ -80,6 +80,7 @@ main .blog-posts .blog-hero-card .blog-card-image {
     line-height: 0;
     grid-area: image;
     margin: 0;
+    height: 276px;
 }
 
 main .blog-posts .blog-card .blog-card-image img {
@@ -90,9 +91,11 @@ main .blog-posts .blog-card .blog-card-image img {
 }
 
 main .blog-posts .blog-hero-card .blog-card-image img {
-    height: 276px;
+    height: 100%;
+    width: 100%;
     margin: auto;
     display: block;
+    object-fit: cover;
 }
 
 main .blog-posts .blog-card h3.blog-card-title {
@@ -201,14 +204,9 @@ main .blog-posts .card .card-body p {
     }
 
     main .blog-posts .blog-hero-card .blog-card-image {
-        height: unset;
-        width: unset;
-    }
-
-    main .blog-posts .blog-hero-card .blog-card-image img {
-        height: unset;
-        width: unset;
+        min-width: 488px;
         max-width: 488px;
+        height: 274px;
     }
 
     main .blog-posts .blog-card {
@@ -250,10 +248,11 @@ main .blog-posts .card .card-body p {
         max-width: 1200px;
     }
 
-    main .blog-posts .blog-hero-card .blog-card-image img {
+    main .blog-posts .blog-hero-card .blog-card-image {
+        min-width: 600px;
         max-width: 600px;
+        height: 338px;
     }
-
 
     .blog main .blog-posts-container > div > h2, main .blog-posts-container div.blog-posts-decoration {
         max-width: 1088px;

--- a/express/blocks/blog-posts/blog-posts.js
+++ b/express/blocks/blog-posts/blog-posts.js
@@ -185,15 +185,6 @@ async function getFilteredResults(config) {
   return (matchingResult);
 }
 
-const loadImage = (img) => new Promise((resolve) => {
-  if (img.complete && img.naturalHeight !== 0) resolve();
-  else {
-    img.onload = () => {
-      resolve();
-    };
-  }
-});
-
 // Translates the Read More string into the local language
 async function getReadMoreString() {
   const placeholders = await fetchPlaceholders();
@@ -337,8 +328,6 @@ async function decorateBlogPosts(blogPostsElements, config, offset = 0) {
   if (images.length) {
     const section = blogPostsElements.closest('.section');
     section.style.display = 'block';
-    const imagePromises = images.map((img) => loadImage(img));
-    await Promise.all(imagePromises);
     delete section.style.display;
   }
 }

--- a/express/blocks/blog-posts/blog-posts.js
+++ b/express/blocks/blog-posts/blog-posts.js
@@ -324,12 +324,6 @@ async function decorateBlogPosts(blogPostsElements, config, offset = 0) {
       decorateBlogPosts(blogPostsElements, config, pageEnd);
     });
   }
-
-  if (images.length) {
-    const section = blogPostsElements.closest('.section');
-    section.style.display = 'block';
-    delete section.style.display;
-  }
 }
 
 function checkStructure(element, querySelectors) {


### PR DESCRIPTION
Fixes the issue where the blog posts blocks page load while preserving the CLS gain with only CSS.

Resolves: [MWPW-143625](https://jira.corp.adobe.com/browse/MWPW-143625)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/create/video/tiktok?martech=off
- After: https://fix-blog-posts-holding-page-load--express--adobecom.hlx.page/express/create/video/tiktok?martech=off
- also: https://fix-blog-posts-holding-page-load--express--adobecom.hlx.page/express/learn/blog?martech=off
