### PR TITLE
[MWPW-143576] Included colors in sitemap

### DIFF
--- a/express/sitemap-index.xml
+++ b/express/sitemap-index.xml
@@ -111,4 +111,31 @@
   <sitemap>
     <loc>https://www.adobe.com/express/colors/sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/br/express/colors/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/de/express/colors/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/es/express/colors/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/fr/express/colors/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/it/express/colors/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/jp/express/colors/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/kr/express/colors/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/nl/express/colors/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/tw/express/colors/sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -203,3 +203,48 @@ sitemaps:
         destination: /express/colors/sitemap.xml
         hreflang: en
         alternate: /{path}
+      brasil:
+        source: /br/express/colors/default/metadata.json?sheet=sitemap
+        destination: /br/express/colors/sitemap.xml
+        hreflang: pt
+        alternate: /br/{path}
+      france:
+        source: /fr/express/colors/default/metadata.json?sheet=sitemap
+        destination: /fr/express/colors/sitemap.xml
+        hreflang: fr
+        alternate: /fr/{path}
+      germany:
+        source: /de/express/colors/default/metadata.json?sheet=sitemap
+        destination: /de/express/colors/sitemap.xml
+        hreflang: de
+        alternate: /de/{path}
+      italy:
+        source: /it/express/colors/default/metadata.json?sheet=sitemap
+        destination: /it/express/colors/sitemap.xml
+        hreflang: it
+        alternate: /it/{path}
+      japan:
+        source: /jp/express/colors/default/metadata.json?sheet=sitemap
+        destination: /jp/express/colors/sitemap.xml
+        hreflang: ja
+        alternate: /jp/{path}
+      korea:
+        source: /kr/express/colors/default/metadata.json?sheet=sitemap
+        destination: /kr/express/colors/sitemap.xml
+        hreflang: ko
+        alternate: /kr/{path}
+      spain:
+        source: /es/express/colors/default/metadata.json?sheet=sitemap
+        destination: /es/express/colors/sitemap.xml
+        hreflang: es
+        alternate: /es/{path}
+      taiwan:
+        source: /tw/express/colors/default/metadata.json?sheet=sitemap
+        destination: /tw/express/colors/sitemap.xml
+        hreflang: zh-Hant
+        alternate: /tw/{path}
+      netherlands:
+        source: /nl/express/colors/default/metadata.json?sheet=sitemap
+        destination: /nl/express/colors/sitemap.xml
+        hreflang: nl
+        alternate: /nl/{path}


### PR DESCRIPTION
Describe your specific features or fixes

Updated the sitemap to include colors for international locales

Resolves: [MWPW-143576](https://jira.corp.adobe.com/browse/MWPW-1423576)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://echen-sitemap-rebuild--express--adobecom.hlx.page/
