### PR TITLE
[PEP] Get Profile via FEDS Interface

### DIFF
--- a/express/features/direct-path-to-product/direct-path-to-product.js
+++ b/express/features/direct-path-to-product/direct-path-to-product.js
@@ -7,6 +7,7 @@ import {
   loadStyle,
 } from '../../scripts/utils.js';
 import BlockMediator from '../../scripts/block-mediator.js';
+import { getProfile } from '../../scripts/express-delayed.js';
 
 const OPT_OUT_KEY = 'no-direct-path-to-product';
 
@@ -76,7 +77,7 @@ export default async function loadLoginUserAutoRedirect() {
     progressBg.append(progressBar);
     noticeWrapper.append(noticeText, noticeBtn);
     container.append(headerWrapper, progressBg);
-    const profile = window.adobeProfile?.getUserProfile();
+    const profile = getProfile();
     if (profile) {
       container.append(buildProfileWrapper(profile));
     }

--- a/express/scripts/express-delayed.js
+++ b/express/scripts/express-delayed.js
@@ -27,8 +27,18 @@ function getSegmentsFromAlloyResponse(response) {
   return ids;
 }
 
+export function getProfile() {
+  const { feds, adobeProfile, fedsConfig } = window;
+  if (fedsConfig?.universalNav) {
+    return feds?.services?.universalnav?.interface?.adobeProfile?.getUserProfile()
+    || adobeProfile?.getUserProfile();
+  }
+  return feds?.services?.profile?.interface?.adobeProfile?.getUserProfile()
+    || adobeProfile?.getUserProfile();
+}
+
 async function isSignedIn() {
-  if (window.adobeProfile?.getUserProfile()) return true;
+  if (getProfile()) return true;
   if (window.feds.events?.profile_data) return false; // data ready -> not signed in
   let resolve;
   const resolved = new Promise((r) => {
@@ -39,11 +49,11 @@ async function isSignedIn() {
   }, { once: true });
   // if not ready, abort
   await Promise.race([resolved, new Promise((r) => setTimeout(r, 5000))]);
-  if (window.adobeProfile?.getUserProfile() === null) {
+  if (getProfile() === null) {
     // retry after 1s
     await new Promise((r) => setTimeout(r, 1000));
   }
-  return window.adobeProfile?.getUserProfile();
+  return getProfile();
 }
 
 // product entry prompt


### PR DESCRIPTION
Try out getting profile via feds.services.profile.interface, as it could be more reliable than window.adobeProfile

Resolves: https://jira.corp.adobe.com/browse/MWPW-137828?filter=381833

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/
- After: https://pep-consistency--express--adobecom.hlx.page/express/?martech=off
