### PR TITLE
Fixing Sticky Promo Bar Wrapper Module 404

### DIFF
--- a/express/blocks/floating-panel/floating-panel.js
+++ b/express/blocks/floating-panel/floating-panel.js
@@ -1,7 +1,7 @@
 import {
   createTag,
   fetchPlaceholders,
-  fetchPlainBlockFromFragment,
+  fetchBlockFragDecorated,
   getLottie,
   lazyLoadLottiePlayer,
 } from '../../scripts/utils.js';
@@ -142,7 +142,7 @@ export default async function decorateBlock(block) {
   if (block.classList.contains('spreadsheet-powered')) {
     const audience = block.querySelector(':scope > div').textContent.trim();
     const data = await collectFloatingButtonData();
-    const container = await fetchPlainBlockFromFragment(block, `/express/fragments/floating-panel/${data.panelFragment}`, 'floating-panel');
+    const container = await fetchBlockFragDecorated(`/express/fragments/floating-panel/${data.panelFragment}`, 'floating-panel');
 
     if (container) {
       const $section = block.closest('.section');

--- a/express/blocks/plans-comparison/plans-comparison.js
+++ b/express/blocks/plans-comparison/plans-comparison.js
@@ -2,7 +2,7 @@ import {
   createTag,
   fixIcons,
   getIconElement,
-  fetchPlainBlockFromFragment,
+  fetchBlockFragDecorated,
 } from '../../scripts/utils.js';
 import { getOffer } from '../../scripts/utils/pricing.js';
 
@@ -309,7 +309,7 @@ export default async function decorate($block) {
     let payload;
     const $linkList = enclosingMain.querySelector('.link-list-container');
     const $oldSection = $block.closest('.section');
-    const $newSection = await fetchPlainBlockFromFragment('/express/fragments/plans-comparison', 'plans-comparison');
+    const $newSection = await fetchBlockFragDecorated('/express/fragments/plans-comparison', 'plans-comparison');
 
     if ($oldSection) {
       $oldSection.parentNode.replaceChild($newSection, $oldSection);

--- a/express/blocks/quick-action-card/quick-action-card.js
+++ b/express/blocks/quick-action-card/quick-action-card.js
@@ -2,7 +2,7 @@ import {
   createTag,
   getMobileOperatingSystem,
   getIconElement,
-  fetchPlainBlockFromFragment,
+  fetchBlockFragDecorated,
   fixIcons,
   readBlockConfig,
   toClassName,
@@ -95,7 +95,7 @@ function buildStandardPayload(block, payload) {
 
 async function buildBlockFromFragment($block) {
   const fragmentName = $block.querySelector('div').textContent.trim();
-  const section = await fetchPlainBlockFromFragment(`/express/fragments/quick-action-card/${fragmentName}`, 'quick-action-card');
+  const section = await fetchBlockFragDecorated(`/express/fragments/quick-action-card/${fragmentName}`, 'quick-action-card');
   if (!section) {
     return false;
   }

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -6,8 +6,10 @@ import {
   createTag,
   decorateMain,
   fetchPlaceholders,
-  fetchPlainBlockFromFragment,
-  fetchRelevantRows, fixIcons, getConfig,
+  fetchBlockFragDecorated,
+  fetchRelevantRows,
+  fixIcons,
+  getConfig,
   getIconElement,
   getLottie,
   getMetadata,
@@ -1859,7 +1861,7 @@ async function replaceRRTemplateList($block, props) {
     props.viewAllLink = relevantRowsData.viewAllLink || null;
 
     if (relevantRowsData.manualTemplates === 'Y') {
-      const $sectionFromFragment = await fetchPlainBlockFromFragment(`/express/fragments/relevant-rows/${relevantRowsData.templateFragment}`, 'template-list');
+      const $sectionFromFragment = await fetchBlockFragDecorated(`/express/fragments/relevant-rows/${relevantRowsData.templateFragment}`, 'template-list');
       const $newBlock = $sectionFromFragment.querySelector('.template-list');
 
       if ($newBlock) {

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1840,7 +1840,7 @@ export function normalizeHeadings(block, allowedHeadings) {
   });
 }
 
-export async function fetchPlainBlockFromFragment(url, blockName) {
+export async function fetchBlockFragDecorated(url, blockName) {
   const location = new URL(window.location);
   const { prefix } = getConfig().locale;
   const fragmentUrl = `${location.origin}${prefix}${url}`;
@@ -1925,8 +1925,8 @@ export async function fetchFloatingCta(path) {
   return floatingBtnData;
 }
 
-async function buildAutoBlocks($main) {
-  const lastDiv = $main.querySelector(':scope > div:last-of-type');
+async function buildAutoBlocks(main) {
+  const lastDiv = main.querySelector(':scope > div:last-of-type');
 
   // Load the branch.io banner autoblock...
   if (['yes', 'true', 'on'].includes(getMetadata('show-banner').toLowerCase())) {
@@ -1941,7 +1941,7 @@ async function buildAutoBlocks($main) {
       '.template-list.horizontal.fullwidth.mini',
       '.link-list.noarrows',
       '.collapsible-card',
-    ].every((block) => $main.querySelector(block));
+    ].every((block) => main.querySelector(block));
 
     if (!authoredRRFound && !window.relevantRowsLoaded) {
       const relevantRowsData = await fetchRelevantRows(window.location.pathname);
@@ -1951,7 +1951,7 @@ async function buildAutoBlocks($main) {
         const fragment = buildBlock('fragment', '/express/fragments/relevant-rows-default-v2');
         relevantRowsSection.dataset.audience = 'mobile';
         relevantRowsSection.append(fragment);
-        $main.prepend(relevantRowsSection);
+        main.prepend(relevantRowsSection);
         window.relevantRowsLoaded = true;
       }
     }
@@ -1966,11 +1966,30 @@ async function buildAutoBlocks($main) {
 
   async function loadPromoFrag() {
     if (document.querySelector('.sticky-promo-bar')) return;
-    const fragment = await fetchPlainBlockFromFragment(`/express/fragments/${getMetadata('ineligible-promo-frag') || 'rejected-beta-promo-bar'}`, 'sticky-promo-bar');
-    if (!fragment) return;
-    $main.append(fragment);
-    const block = fragment?.querySelector('.sticky-promo-bar.block');
-    if (block) await loadBlock(block);
+
+    let promoFrag;
+    const location = new URL(window.location);
+    const { prefix } = getConfig().locale;
+    const fragmentUrl = `${location.origin}${prefix}${`/express/fragments/${getMetadata('ineligible-promo-frag') || 'rejected-beta-promo-bar'}`}`;
+    const path = new URL(fragmentUrl).pathname.split('.')[0];
+    const resp = await fetch(`${path}.plain.html`);
+    if (resp.status === 404) {
+      return;
+    } else {
+      const html = await resp.text();
+      const htmlHolder = createTag('div');
+      htmlHolder.innerHTML = html;
+      promoFrag = htmlHolder.querySelector(':scope > div');
+
+      if (!promoFrag) return;
+
+      const img = promoFrag.querySelector('img');
+      if (img) {
+        img.setAttribute('loading', 'lazy');
+      }
+    }
+
+    main.append(promoFrag);
   }
 
   async function loadFloatingCTA(BlockMediator, decorated) {


### PR DESCRIPTION
We've found out that a helper function is misused in the utils.js during the auto-block generation process, which causes the sticky-promo-bar-wrapper related 404s. This should help resolve it.

Resolves Partially: [MWPW-143447](https://jira.corp.adobe.com/browse/MWPW-143447)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/drafts/qiyundai/homepage-v3-mobile-ga/flyer?martech=off
- After: https://sticky-promo-bar-error--express--adobecom.hlx.page/drafts/qiyundai/homepage-v3-mobile-ga/flyer?martech=off

Please test on mobile.