### PR TITLE
Fix small pricing page visual + promo border suppression issues

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -418,7 +418,6 @@ End border style variants
   }
 
   .pricing-cards .cards-container:has(>.card:first-child:nth-last-child(3)) {
-    width: var(2 * --card-width);
     margin: auto;
     grid-template-columns: repeat(auto-fit, minmax(var(--card-width), calc((1200px - 32px) / 3)));
   }

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -18,6 +18,7 @@ function suppressOfferEyebrow(specialPromo, legacyVersion) {
   if (specialPromo.parentElement) {
     if (legacyVersion) {
       specialPromo.parentElement.classList.remove('special-promo');
+      specialPromo.remove();
     } else {
       specialPromo.className = 'hide';
       specialPromo.parentElement.className = '';
@@ -82,9 +83,13 @@ function handlePrice(placeholders, pricingArea, placeholderArr, specialPromo, le
     if (specialPromo && !specialPromoPercentageEyeBrowTextReplaced) {
       const offerTextContent = specialPromo.textContent;
 
-      const shouldSuppress = shallSuppressOfferEyebrowText(response.savePer, offerTextContent,
-
-        isPremiumCard, true, response.offerId);
+      const shouldSuppress = shallSuppressOfferEyebrowText(
+        response.savePer,
+        offerTextContent,
+        isPremiumCard,
+        true,
+        response.offerId,
+      );
       if (shouldSuppress) {
         suppressOfferEyebrow(specialPromo, legacyVersion);
       } else {

--- a/express/blocks/pricing-table/pricing-table.css
+++ b/express/blocks/pricing-table/pricing-table.css
@@ -188,7 +188,6 @@
 @media (max-width: 400px) {
   .pricing-table {
     margin: 0 2px;
-    min-width: 395px;
   }
 }
 
@@ -467,7 +466,7 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
 
 @media (max-width: 980px) {
   .pricing-table .row:not(.blank-row){
-    min-height: 66px;
+    min-height: 60px;
   }
 
   .pricing-table .row.row-heading {
@@ -546,6 +545,7 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
     display: flex;
     align-items: center;
     gap: 4px;
+    text-align: left;
   }
 
   .pricing-table .row.section-row .col .col-heading .icon { 


### PR DESCRIPTION
For the US version, the pricing cards looks correct but this is breaking for any geo were we don't have a localized Express site, the eyebrow text isn't appearing correctly.
pricing tables features don't look quite right on small mobile screens either.
This PR should address these issues

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER) Pending

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/pricing?tab=3&country=eg
- After: https://pricing-page-fix--express--adobecom.hlx.page/express/pricing?tab=3&country=eg
