### PR TITLE
Fixing some business page bugs

### DIFF
--- a/express/blocks/floating-buttons/floating-buttons.css
+++ b/express/blocks/floating-buttons/floating-buttons.css
@@ -11,6 +11,7 @@ div[class='section section-wrapper floating-buttons-container'] {
   padding-bottom: 24px;
   transition: bottom 0.4s;
   z-index: 99;
+  max-width: none;
 }
 
 .block.floating-buttons > div > div {

--- a/express/blocks/floating-buttons/floating-buttons.css
+++ b/express/blocks/floating-buttons/floating-buttons.css
@@ -20,18 +20,20 @@ div[class='section section-wrapper floating-buttons-container'] {
   display: flex;
   align-items: stretch;
   justify-content: center;
+  flex-wrap: wrap;
 }
 
 .block.floating-buttons.hidden {
-  bottom: -150px;
+  bottom: -200px;
 }
 
 .block.floating-buttons > div > div > a.button:any-link {
-  flex: 1 1 0;
+  flex: 1 0 auto;
   border-radius: 100px;
   display: flex;
   align-items: center;
   justify-content: center;
+  margin: 4px 8px;
 }
 
 @media screen and (min-width: 900px) {

--- a/express/blocks/floating-buttons/floating-buttons.js
+++ b/express/blocks/floating-buttons/floating-buttons.js
@@ -15,7 +15,12 @@ function initScrollWatcher(block) {
     threshold: 0,
   });
 
+  const footer = document.querySelector('footer');
+  if (footer) hideOnIntersect.observe(footer);
+
   const primaryCta = BlockMediator.get('primaryCtaUrl');
+  if (!primaryCta) return;
+
   const primaryUrl = new URL(primaryCta);
 
   const pageCta = Array.from(document.querySelectorAll(
@@ -23,11 +28,8 @@ function initScrollWatcher(block) {
     '.section:first-of-type a.cta',
     '.section:first-of-type a.button',
   )).find((a) => a.href === primaryUrl.href);
-
-  const footer = document.querySelector('footer');
-
+  
   if (pageCta) hideOnIntersect.observe(pageCta);
-  if (footer) hideOnIntersect.observe(footer);
 }
 
 export default async function decorate(block) {

--- a/express/blocks/floating-buttons/floating-buttons.js
+++ b/express/blocks/floating-buttons/floating-buttons.js
@@ -16,8 +16,14 @@ function initScrollWatcher(block) {
   });
 
   const primaryCta = BlockMediator.get('primaryCtaUrl');
+  const primaryUrl = new URL(primaryCta);
 
-  const pageCta = document.querySelector(`.section a.primaryCTA[href='${primaryCta}']`, `.section. a.cta[href='${primaryCta}']`, `.section. a.button[href='${primaryCta}']`);
+  const pageCta = Array.from(document.querySelectorAll(
+    '.section:first-of-type a.primaryCTA',
+    '.section:first-of-type a.cta',
+    '.section:first-of-type a.button',
+  )).find((a) => a.href === primaryUrl.href);
+
   const footer = document.querySelector('footer');
 
   if (pageCta) hideOnIntersect.observe(pageCta);

--- a/express/blocks/floating-buttons/floating-buttons.js
+++ b/express/blocks/floating-buttons/floating-buttons.js
@@ -28,7 +28,7 @@ function initScrollWatcher(block) {
     '.section:first-of-type a.cta',
     '.section:first-of-type a.button',
   )).find((a) => a.href === primaryUrl.href);
-  
+
   if (pageCta) hideOnIntersect.observe(pageCta);
 }
 

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -1220,3 +1220,7 @@ main .block .app-store-aTag .app-store-wrapper {
 main > div[class="section section-wrapper sticky-promo-bar-loadinbody-rounded-container firefly-card-container"] {
   padding-top: 0;
 }
+
+main > div[class="section section-wrapper columns-container"][id^="column-"] {
+  padding: 0;
+}


### PR DESCRIPTION
- Is there a way to set the anchor link position of the toggle box such that it leaves some white space margin above the Columns block pod? Right now a click brings the corresponding pod right to the top of the viewport, it looks awkward.
- The Floating-CTA block should hide itself while the marquee block is in view, but it isn't.
https://adobe-mwp.slack.com/archives/C04UH0M1CRG/p1709659646425559?thread_ts=1709657919.233879&cid=C04UH0M1CRG

Resolves: [MWPW-140626](https://jira.corp.adobe.com/browse/MWPW-140626) & [MWPW-142522](https://jira.corp.adobe.com/browse/MWPW-142522) follow up fix

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/business?martech=off
- After: https://fix-floating-buttons--express--adobecom.hlx.page/express/business?martech=off
