### PR TITLE
Hotfix for incorrect eyebrow suppression

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -81,7 +81,7 @@ function handlePrice(placeholders, pricingArea, placeholderArr, specialPromo, le
       }
     }
 
-    if (specialPromo && !specialPromoPercentageEyeBrowTextReplaced && specialPromo.textContent.includes(`{{${SAVE_PERCENTAGE}}}`) ) {
+    if (specialPromo && !specialPromoPercentageEyeBrowTextReplaced && specialPromo.textContent.includes(`{{${SAVE_PERCENTAGE}}}`)) {
       const offerTextContent = specialPromo.textContent;
 
       const shouldSuppress = shallSuppressOfferEyebrowText(

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -80,7 +80,7 @@ function handlePrice(placeholders, pricingArea, placeholderArr, specialPromo, le
       }
     }
 
-    if (specialPromo && !specialPromoPercentageEyeBrowTextReplaced) {
+    if (specialPromo && !specialPromoPercentageEyeBrowTextReplaced && specialPromo.textContent.includes(`{{${SAVE_PERCENTAGE}}}`) ) {
       const offerTextContent = specialPromo.textContent;
 
       const shouldSuppress = shallSuppressOfferEyebrowText(response.savePer, offerTextContent,

--- a/express/scripts/utils/pricing.js
+++ b/express/scripts/utils/pricing.js
@@ -229,7 +229,7 @@ export function shallSuppressOfferEyebrowText(savePer, offerTextContent, isPremi
   let suppressOfferEyeBrowText = false;
   if (isPremiumCard) {
     if (isSpecialEyebrowText) {
-      suppressOfferEyeBrowText = savePer === '' && offerTextContent.includes('{{savePercentage}}');
+      suppressOfferEyeBrowText = !(savePer !== '' && offerTextContent.includes('{{savePercentage}}'));
     } else {
       suppressOfferEyeBrowText = true;
     }

--- a/express/scripts/utils/pricing.js
+++ b/express/scripts/utils/pricing.js
@@ -229,7 +229,7 @@ export function shallSuppressOfferEyebrowText(savePer, offerTextContent, isPremi
   let suppressOfferEyeBrowText = false;
   if (isPremiumCard) {
     if (isSpecialEyebrowText) {
-      suppressOfferEyeBrowText = !(savePer !== '' && offerTextContent.includes('{{savePercentage}}'));
+      suppressOfferEyeBrowText = savePer === '' && offerTextContent.includes('{{savePercentage}}');
     } else {
       suppressOfferEyeBrowText = true;
     }


### PR DESCRIPTION


Describe your specific features or fixes

Found the issue. In the legacy pricing-cards block, everything highlighted in picture 1 gets assigned to the variable "offerTextContent" in picture 2, which is then sent to the pricing logic and ends up suppressed because it found no savings plan. However, we never wanted that block of text to be considered in the first place, so I put the check in picture 2 to prevent that from happening. In cases where there is a savingsPercentage specified in offerTextContent it will be handled according to the regular pricing logic.
 

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After:  https://echen-pricing-card-hotfix--express--adobecom.hlx.page/express/pricing
- 
<img width="645" alt="Screenshot 2024-03-05 at 10 55 33 AM" src="https://github.com/adobecom/express/assets/159481679/bbc04e33-6fbf-400a-b75b-bd162eaefcca">
<img width="833" alt="Screenshot 2024-03-05 at 11 06 56 AM" src="https://github.com/adobecom/express/assets/159481679/852ca0e6-1299-4161-9c1a-a70d95081f7e">

