### PR TITLE
Removed underlines from gradient-promo styling in pricing-cards

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -84,7 +84,6 @@ Border style variants
   margin-left: 4px;
   color: var(--color-white);
   font-weight: 400;
-  text-decoration: underline;
   padding-bottom: 12px;
 }
 


### PR DESCRIPTION
Describe your specific features or fixes

Removed the underlined text from gradient promo styling in pricing cards. 

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://echen-pricing-card-url-fix--express--adobecom.hlx.page/express/
