### PR TITLE
Color Columns SVG fix

### DIFF
--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -338,15 +338,15 @@ export default async function decorate(block) {
 
   // variant for the colors pages
   if (block.classList.contains('color')) {
-    const [primaryColor, accentColor] = rows[1].querySelector('div').textContent.trim().split(',');
-    const [textCol, svgCol] = Array.from((rows[0].querySelectorAll('div')));
+    const [primaryColor, accentColor] = rows[1].querySelector(':scope > div').textContent.trim().split(',');
+    const [textCol, svgCol] = Array.from((rows[0].querySelectorAll(':scope > div')));
     const svgId = svgCol.textContent.trim();
     const svg = createTag('div', { class: 'img-wrapper' });
 
     svgCol.remove();
     rows[1].remove();
     textCol.classList.add('text');
-    svg.innerHTML = `<svg class='color-svg-img'> <use href='/express/icons/color-sprite.svg#${svgId}'></use></svg>'`;
+    svg.innerHTML = `<svg class='color-svg-img'> <use href='/express/icons/color-sprite.svg#${svgId}'></use></svg>`;
     svg.style.backgroundColor = primaryColor;
     svg.style.fill = accentColor;
     rows[0].append(svg);


### PR DESCRIPTION
Fixes a typo in color columns block.
Fixes a querySelector scope issue that messes up the svg loading

Resolves: [MWPW-143794](https://jira.corp.adobe.com/browse/MWPW-143794)

Test URLs:
- Before: https://main--express--adobecom.hlx.live/express/colors/light-blue?martech=off
- After: https://color-svg-fix--express--adobecom.hlx.live/express/colors/light-blue?martech=off
