### PR TITLE
Pricing Cards Compare All Plans CTA

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -347,7 +347,7 @@ End border style variants
   font-weight: 400;
 }
 
-.pricing-cards>div:last-of-type {
+.pricing-cards>.footer {
   padding: 12px 8px;
   margin: 16px auto;
   border-radius: 4px;
@@ -355,6 +355,11 @@ End border style variants
   font-size: var(--body-font-size-xs);
   max-width: 1200px;
   box-sizing: border-box;
+}
+
+.pricing-cards> .compare-all-plans>a {
+  width: fit-content;
+  margin: auto;
 }
 
 

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -9,7 +9,7 @@ import {
   fetchPlanOnePlans,
 } from '../../scripts/utils/pricing.js';
 
-const blockKeys = ['header', 'borderParams', 'explain', 'mPricingRow', 'mCtaGroup', 'yPricingRow', 'yCtaGroup', 'featureList', 'compare'];
+const blockKeys = ['header', 'borderParams', 'explain', 'mPricingRow', 'mCtaGroup', 'yPricingRow', 'yCtaGroup', 'featureList', 'compare', 'footer','comparePlans'];
 const plans = ['monthly', 'yearly']; // authored order should match with billing-radio
 const BILLING_PLAN = 'billing-plan';
 const SAVE_PERCENTAGE = 'savePercentage';
@@ -104,6 +104,31 @@ function handlePrice(placeholders, pricingArea, placeholderArr, specialPromo, le
   return priceRow;
 }
 
+function createCTA( ctaGroup,pricingSection, additionalStyle) {
+  if (! ctaGroup) return
+  ctaGroup.classList.add('card-cta-group');
+  additionalStyle && ctaGroup.classList.add(additionalStyle);
+  ctaGroup.querySelectorAll('a').forEach((a, i) => {
+    a.classList.add('large');
+    if (i === 1) a.classList.add('secondary');
+    if (a.parentNode.tagName.toLowerCase() === 'strong') {
+      a.classList.add('button', 'primary');
+      a.parentNode.remove();
+    }
+    if (a.parentNode.tagName.toLowerCase() === 'p') {
+      a.parentNode.remove();
+    }
+    fetchPlanOnePlans(a.href).then(({
+      url, country, language, offerId,
+    }) => {
+      a.href = buildUrl(url, country, language, offerId);
+    });
+    ctaGroup.append(a);
+  });
+  pricingSection.append(ctaGroup);
+  
+}
+
 function createPricingSection(placeholders, pricingArea, ctaGroup, specialPromo, legacyVersion) {
   const pricingSection = createTag('div', { class: 'pricing-section' });
   pricingArea.classList.add('pricing-area');
@@ -123,26 +148,9 @@ function createPricingSection(placeholders, pricingArea, ctaGroup, specialPromo,
       pricingSuffixTextElem?.remove();
     }
   }
-  ctaGroup.classList.add('card-cta-group');
-  ctaGroup.querySelectorAll('a').forEach((a, i) => {
-    a.classList.add('large');
-    if (i === 1) a.classList.add('secondary');
-    if (a.parentNode.tagName.toLowerCase() === 'strong') {
-      a.classList.add('button', 'primary');
-      a.parentNode.remove();
-    }
-    if (a.parentNode.tagName.toLowerCase() === 'p') {
-      a.parentNode.remove();
-    }
-    fetchPlanOnePlans(a.href).then(({
-      url, country, language, offerId,
-    }) => {
-      a.href = buildUrl(url, country, language, offerId);
-    });
-    ctaGroup.append(a);
-  });
+  createCTA(ctaGroup, pricingSection);
   pricingSection.append(pricingArea);
-  pricingSection.append(ctaGroup);
+  
   return pricingSection;
 }
 
@@ -281,6 +289,8 @@ function decorateCard({
   yCtaGroup,
   featureList,
   compare,
+  footer,
+  comparePlans
 }, el, placeholders, legacyVersion) {
   const card = createTag('div', { class: 'card' });
   const cardBorder = createTag('div', { class: 'card-border' });
@@ -299,6 +309,8 @@ function decorateCard({
   subscribeToBlockMediator(mPricingSection, yPricingSection);
   decorateBasicTextSection(featureList, 'card-feature-list', card);
   decorateCompareSection(compare, el, card);
+  footer && decorateBasicTextSection(footer,'footer', el)
+  createCTA(comparePlans, el, 'compare-all-plans')
   return cardWrapper;
 }
 

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -9,7 +9,7 @@ import {
   fetchPlanOnePlans,
 } from '../../scripts/utils/pricing.js';
 
-const blockKeys = ['header', 'borderParams', 'explain', 'mPricingRow', 'mCtaGroup', 'yPricingRow', 'yCtaGroup', 'featureList', 'compare', 'footer','comparePlans'];
+const blockKeys = ['header', 'borderParams', 'explain', 'mPricingRow', 'mCtaGroup', 'yPricingRow', 'yCtaGroup', 'featureList', 'compare', 'footer', 'comparePlans'];
 const plans = ['monthly', 'yearly']; // authored order should match with billing-radio
 const BILLING_PLAN = 'billing-plan';
 const SAVE_PERCENTAGE = 'savePercentage';
@@ -104,8 +104,8 @@ function handlePrice(placeholders, pricingArea, placeholderArr, specialPromo, le
   return priceRow;
 }
 
-function createCTA( ctaGroup,pricingSection, additionalStyle) {
-  if (! ctaGroup) return
+function createCTA(ctaGroup, pricingSection, additionalStyle) {
+  if (!ctaGroup) return;
   ctaGroup.classList.add('card-cta-group');
   additionalStyle && ctaGroup.classList.add(additionalStyle);
   ctaGroup.querySelectorAll('a').forEach((a, i) => {
@@ -126,7 +126,6 @@ function createCTA( ctaGroup,pricingSection, additionalStyle) {
     ctaGroup.append(a);
   });
   pricingSection.append(ctaGroup);
-  
 }
 
 function createPricingSection(placeholders, pricingArea, ctaGroup, specialPromo, legacyVersion) {
@@ -150,7 +149,7 @@ function createPricingSection(placeholders, pricingArea, ctaGroup, specialPromo,
   }
   createCTA(ctaGroup, pricingSection);
   pricingSection.append(pricingArea);
-  
+
   return pricingSection;
 }
 
@@ -290,7 +289,7 @@ function decorateCard({
   featureList,
   compare,
   footer,
-  comparePlans
+  comparePlans,
 }, el, placeholders, legacyVersion) {
   const card = createTag('div', { class: 'card' });
   const cardBorder = createTag('div', { class: 'card-border' });
@@ -309,8 +308,8 @@ function decorateCard({
   subscribeToBlockMediator(mPricingSection, yPricingSection);
   decorateBasicTextSection(featureList, 'card-feature-list', card);
   decorateCompareSection(compare, el, card);
-  footer && decorateBasicTextSection(footer,'footer', el)
-  createCTA(comparePlans, el, 'compare-all-plans')
+  footer && decorateBasicTextSection(footer, 'footer', el);
+  createCTA(comparePlans, el, 'compare-all-plans');
   return cardWrapper;
 }
 


### PR DESCRIPTION
Describe your specific features or fixes

Adds the option to include a CTA at the bottom of all pricing cards blocks. 

Resolves: https://jira.corp.adobe.com/projects/MWPW/issues/MWPW-142523?filter=myopenissues

<img width="701" alt="Screenshot 2024-03-06 at 11 38 59 AM" src="https://github.com/adobecom/express/assets/159481679/a4a6049e-074f-4011-9a1a-d5b87e43e294">
<img width="401" alt="Screenshot 2024-03-06 at 11 39 14 AM" src="https://github.com/adobecom/express/assets/159481679/fd8f1102-641c-43ac-9f5c-ed2413e4c8d0">

<img width="740" alt="Screenshot 2024-03-06 at 11 43 47 AM" src="https://github.com/adobecom/express/assets/159481679/3a565f2f-1911-4e5c-90ca-179d5781a5c9">


Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After:  https://echen-pricing-cards-cta--express--adobecom.hlx.page/drafts/echen/pricing-cards
