### PR TITLE
Echen marquee p token

### DIFF
--- a/express/blocks/marquee/marquee.js
+++ b/express/blocks/marquee/marquee.js
@@ -30,10 +30,11 @@ const breakpointConfig = [
   },
 ];
 
+// Transforms a {{pricing}} tag into human readable format.
 async function handlePrice(block) {
   const priceEl = block.querySelector('[title="{{pricing}}"]');
   if (!priceEl) return null;
-  let textContent = 'Contact Sales for prices';
+  let textContent = 'Contact sales for prices';
   const parent = priceEl.parentElement;
   const newContainer = createTag('span');
   priceEl.remove();
@@ -41,7 +42,7 @@ async function handlePrice(block) {
   parent.remove();
   try {
     const response = await fetchPlanOnePlans(priceEl?.href);
-    textContent = `${response.symbol}${response.price}${response.suffix}`;
+    textContent = `${response.symbol}${response.price}${response.suffix}.`;
   } catch (error) {
     console.error('Failed to fetch prices for page plan');
     console.error(error);
@@ -391,12 +392,11 @@ async function handleOptions(div, typeHint, block) {
 
 export default async function decorate(block) {
   addTempWrapper(block, 'marquee');
-
+  handlePrice(block);
   const possibleBreakpoints = breakpointConfig.map((bp) => bp.typeHint);
   const possibleOptions = ['shadow', 'background'];
   const animations = {};
   const rows = [...block.children];
-  handlePrice(block);
   for (let index = 0; index < rows.length; index += 1) {
     const div = rows[index];
     let rowType = 'animation';


### PR DESCRIPTION
Describe your specific features or fixes

Adds the option to specify a pricing token in the marquee blocks. In the text content area, include a {{pricing}} element that contains a link to the pricing plan you want. Currently in testing

Resolves: https://jira.corp.adobe.com/projects/MWPW/issues/MWPW-143269?filter=myopenissues

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://echen-marquee-p-token--express--adobecom.hlx.page/drafts/echen/marketers
- 
<img width="1770" alt="Screenshot 2024-03-06 at 11 41 28 AM" src="https://github.com/adobecom/express/assets/159481679/0a3409cb-23ee-442d-9c15-38a5f893bc6d">

