### PR TITLE
[One Plans] Center Contact Sales Message for Small Screens

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -276,6 +276,7 @@ End border style variants
   display: flex;
   justify-content: center;
   align-items: center;
+  text-align: center;
 }
 
 /** pricing styles end **/


### PR DESCRIPTION
Since we reduced the min max-width of cards, the could wrap into the second line. Centering the text can make things look better. You can test by reducing the width of your device

Resolves: https://jira.corp.adobe.com/browse/MWPW-141070

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/pricing?martech=off
- After: https://pricing-cards-bold-center--express--adobecom.hlx.page/express/pricing?martech=off
![SC 2024-03-06 at 12 52 25 PM](https://github.com/adobecom/express/assets/32369333/a2354598-0f2e-4a7b-83a5-103bf4177c64)
![SC 2024-03-06 at 12 52 49 PM](https://github.com/adobecom/express/assets/32369333/9ee34954-001d-4b54-a412-85f25ae468e2)
