### PR TITLE
Fix a Typo Missed Text

### DIFF
--- a/express/blocks/template-list-ace/template-list-ace.js
+++ b/express/blocks/template-list-ace/template-list-ace.js
@@ -486,7 +486,7 @@ function initState() {
 }
 
 export default async function decorate(block) {
-  addTempWrapper(block, 'template-list');
+  addTempWrapper(block, 'template-list-ace');
 
   if (!(/localhost:3000/.test(window.location.host) || /stage\.adobe\.com/.test(window.location.hostname))) {
     block.style.display = 'none';


### PR DESCRIPTION
Fix a typo during wrapper removal

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/ace
- After: https://fix-wrapper-typo--express--adobecom.hlx.page/express/ace
