### PR TITLE
Soft fail beta gating device list fetching

### DIFF
--- a/express/scripts/mobile-beta-gating.js
+++ b/express/scripts/mobile-beta-gating.js
@@ -49,10 +49,10 @@ export async function preBenchmarkCheck() {
   if (!isChrome()) return [false, 'Android not Chrome'];
   const { allowList, denyList } = await fetchAndroidAllowDenyLists();
   const { userAgent, hardwareConcurrency, deviceMemory } = navigator;
-  if (allowList.data.some(({ device }) => new RegExp(`Android .+; ${device}`).test(userAgent))) {
+  if (allowList?.data.some(({ device }) => new RegExp(`Android .+; ${device}`).test(userAgent))) {
     return [true, 'Android whitelisted'];
   }
-  if (denyList.data.some(({ device }) => new RegExp(`Android .+; ${device}`).test(userAgent))) {
+  if (denyList?.data.some(({ device }) => new RegExp(`Android .+; ${device}`).test(userAgent))) {
     return [false, 'Android denylisted'];
   }
   if (!hardwareConcurrency || hardwareConcurrency < 4) {


### PR DESCRIPTION
The device list fetching is already lana logged properly. We just need to add the ? notation to soft fail the accessing of the data object from the resp.

Resolves: [MWPW-143883](https://jira.corp.adobe.com/browse/MWPW-143883)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/?martech=off
- After: https://soft-fail-beta-gating--express--adobecom.hlx.page/express/?martech=off
