### PR TITLE
[PEP] No PEP when No Primary CTA

### DIFF
--- a/express/features/direct-path-to-product/direct-path-to-product.js
+++ b/express/features/direct-path-to-product/direct-path-to-product.js
@@ -6,8 +6,7 @@ import {
   getIconElement,
   loadStyle,
 } from '../../scripts/utils.js';
-import BlockMediator from '../../scripts/block-mediator.js';
-import { getProfile } from '../../scripts/express-delayed.js';
+import { getProfile, getDestination } from '../../scripts/express-delayed.js';
 
 const OPT_OUT_KEY = 'no-direct-path-to-product';
 
@@ -99,16 +98,9 @@ export default async function loadLoginUserAutoRedirect() {
   const initRedirect = (container) => {
     container.classList.add('done');
 
-    const primaryCtaUrl = BlockMediator.get('primaryCtaUrl')
-      || document.querySelector('a.button.xlarge.same-as-floating-button-CTA, a.primaryCTA')?.href;
-
     track(`${adobeEventName}:redirect`);
 
-    if (primaryCtaUrl) {
-      window.location.assign(primaryCtaUrl);
-    } else {
-      window.assign('https://new.express.adobe.com');
-    }
+    window.location.assign(getDestination());
   };
 
   const optOutCounter = localStorage.getItem(OPT_OUT_KEY);

--- a/express/scripts/express-delayed.js
+++ b/express/scripts/express-delayed.js
@@ -3,6 +3,12 @@ import {
   createTag,
   getMetadata,
 } from './utils.js';
+import BlockMediator from './block-mediator.js';
+
+export function getDestination() {
+  return BlockMediator.get('primaryCtaUrl')
+    || document.querySelector('a.button.xlarge.same-as-floating-button-CTA, a.primaryCTA')?.href;
+}
 
 function loadExpressProduct() {
   if (!window.hlx.preload_product) return;
@@ -61,6 +67,7 @@ async function canPEP() {
   if (document.body.dataset.device !== 'desktop') return false;
   const pepSegment = getMetadata('pep-segment');
   if (!pepSegment) return false;
+  if (!getDestination()) return false;
   const placeholders = await fetchPlaceholders();
   if (!placeholders.cancel || !placeholders['pep-header'] || !placeholders['pep-cancel']) return false;
   const segments = getSegmentsFromAlloyResponse(await window.alloyLoader);


### PR DESCRIPTION
We have pages where intentionally there will be no CTA. Instead of taking them to the default product homepage, we should just do no PEP.

Resolves: https://jira.corp.adobe.com/browse/MWPW-143929

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/spotlight/beta
- After: https://no-pep-when-no-cta--express--adobecom.hlx.page/express/spotlight/beta
