### PR TITLE
Fullscreen Marquee H1 For Mobile

### DIFF
--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -242,13 +242,6 @@
   transition: .5s opacity ease-in;
 }
 
-.fullscreen-marquee-image-container + .template-list-sixcols-container > .default-content-wrapper {
-  display: none;
-}
-.fullscreen-marquee-image-container + .section {
-  padding-top: 0px;
-}
-
 .block.fullscreen-marquee .button-container.free-plan-container {
   flex-direction: row;
   width: auto;
@@ -262,6 +255,7 @@
 .block.fullscreen-marquee .button-container.free-plan-container .free-plan-widget {
   margin: 0;
 }
+
 
 @media (min-width: 900px) {
   .section > .fullscreen-marquee {
@@ -292,4 +286,29 @@
   .fullscreen-marquee .fullscreen-marquee-app-frame {
     display: unset;
   }
+}
+
+
+
+@media (max-width : 480px) {
+
+  .fullscreen-marquee-image-container + .template-list-sixcols-container > .default-content-wrapper {
+    display: none;
+  }
+  .fullscreen-marquee-image-container + .section {
+    padding-top: 0px;
+  }
+
+  .fullscreen-marquee .fullscreen-marquee-heading p {
+    text-align: center;
+  }
+
+  .fullscreen-marquee .fullscreen-marquee-heading h1 {
+    text-align: center;
+  }
+
+  .fullscreen-marquee {
+    padding-bottom: 0px;
+  }
+  
 }

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -242,6 +242,13 @@
   transition: .5s opacity ease-in;
 }
 
+.fullscreen-marquee-image-container + .template-list-sixcols-container > .default-content-wrapper {
+  display: none;
+}
+.fullscreen-marquee-image-container + .section {
+  padding-top: 0px;
+}
+
 .block.fullscreen-marquee .button-container.free-plan-container {
   flex-direction: row;
   width: auto;

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -290,11 +290,20 @@
 
 
 
-@media (max-width : 480px) {
+@media (max-width : 900px) {
 
   .fullscreen-marquee-image-container + .template-list-sixcols-container > .default-content-wrapper {
     display: none;
   }
+
+
+  .fullscreen-marquee-container + div > .default-content-wrapper {
+    display: none;
+  }
+  .fullscreen-marquee-container  + div:has(>.template-list-wrapper) {
+    padding: 0px;
+  }
+
   .fullscreen-marquee-image-container + .section {
     padding-top: 0px;
   }
@@ -305,10 +314,27 @@
 
   .fullscreen-marquee .fullscreen-marquee-heading h1 {
     text-align: center;
+    margin: auto;
   }
 
   .fullscreen-marquee {
     padding-bottom: 0px;
   }
+
+  .fullscreen-marquee-image-container + div .template-title {
+    display: none;
+  }
+
+  .fullscreen-marquee-container + div .template-title {
+    display: none;
+  }
+
+  .fullscreen-marquee-container{
+    min-height: auto;
+    padding: 0px;
+  }
   
-}
+  .block.fullscreen-marquee .button-container.free-plan-container{
+    margin: auto;
+  }
+} 


### PR DESCRIPTION
Describe your specific features or fixes

Implements CSS for the mobile version of the fullscreen marquee. Requires authoring changes.

With these new CSS rules, the h1 of the fullscreen marquee block is made available on mobile pages. In turn, the h2 and description of the following template-x block is suppressed only on mobile pages. The fullscreen image is not displayed on mobile pages. This will improve SEO since we are missing the H1 on mobile pages. 

<img width="484" alt="Screenshot 2024-03-11 at 2 40 08 PM" src="https://github.com/adobecom/express/assets/159481679/a5a1f1b0-a93a-4f9f-ae36-774c9ee503e0">


Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://echen-fs-marquee-mobile--express--adobecom.hlx.page/drafts/echen/vertical