### PR TITLE
Floating Panel z-index against jarvis chatbot fix

### DIFF
--- a/express/blocks/floating-panel/floating-panel.css
+++ b/express/blocks/floating-panel/floating-panel.css
@@ -35,6 +35,7 @@ div[class='section section-wrapper floating-panel-container'] {
 
 .block.floating-panel.expanded {
     color: var(--color-black);
+    z-index: 10000000;
 }
 
 .block.floating-panel .bottom-container {


### PR DESCRIPTION
Floating Panel and the Jarvis bot are fighting for layerings. Let floating panel win when it's expanded.

Resolves: [MWPW-142792](https://jira.corp.adobe.com/browse/MWPW-142792)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://fpanel-jarvis-overlap-fix--express--adobecom.hlx.page/express/
