### PR TITLE
Moved SEO Fallback link

### DIFF
--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2588,7 +2588,7 @@ export async function loadArea(area = document) {
   // milo's links featurecc
   const config = getConfig();
   if (config.links === 'on') {
-    const path = `${config.contentRoot || ''}${getMetadata('links-path') || '/seo/links.json'}`;
+    const path = `${config.contentRoot || ''}${getMetadata('links-path') || '/express/seo/links.json'}`;
     import('../features/links.js').then((mod) => mod.default(path, area));
   }
 


### PR DESCRIPTION
Describe your specific features or fixes

Moved the fallback link for seo JSON from /seo/json to /express/seo/json

Resolves: [MWPW-143447](https://jira.corp.adobe.com/browse/MWPW-143447)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://echen-seo-express-move--express--adobecom.hlx.page/express/
