### PR TITLE
[MWPW-142523] Pricing Card Icon Fix

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -90,7 +90,7 @@ Border style variants
 .pricing-cards .gradient-promo {
   background: linear-gradient(90deg, #ff477b 0%, #5c5ce0 52%, #318fff 100%) !important;
   padding: 12px 2px 4px 2px;
-  border-radius: 16px;
+  border-radius: 10px;
   overflow: hidden;
   background: var(--color-white);
   margin-top: 0px !important;

--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -77,7 +77,6 @@ Border style variants
 
 .pricing-cards .gradient-promo .card {
   background-color: white;
-  margin-bottom: 2px;
 }
 
 .pricing-cards .gradient-promo>div:first-of-type {

--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -98,7 +98,8 @@ Border style variants
 
 
 .pricing-cards .special-promo {
-  border: 1px solid #FFE600;
+  border: 2px solid #FFE600;
+  padding-bottom: 1px;
 }
 
 .pricing-cards .card-border.special-promo{

--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -381,7 +381,7 @@ End border style variants
 
 @media screen and (min-width: 1250px) {
   :root {
-    --card-width: 391px;
+    --card-width: 400px;
     --card-padding: 24px 16px;
   }
 

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -202,7 +202,7 @@ function decorateHeader(header, borderParams, card, cardBorder) {
   header.classList.add('card-header');
   const specialPromo = readBraces(borderParams?.innerText, cardBorder);
   const premiumIcon = header.querySelector('img');
- 
+
   // Finds the headcount, removes it from the original string and creates an icon with the hc
   const extractHeadCountExp = /(>?)\(\d+(.*?)\)/;
   if (extractHeadCountExp.test(h2.innerText)) {

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -202,11 +202,7 @@ function decorateHeader(header, borderParams, card, cardBorder) {
   header.classList.add('card-header');
   const specialPromo = readBraces(borderParams?.innerText, cardBorder);
   const premiumIcon = header.querySelector('img');
-  if (premiumIcon) h2.append(premiumIcon);
-
-  header.querySelectorAll('p').forEach((p) => {
-    if (p.innerHTML.trim() === '') p.remove();
-  });
+ 
   // Finds the headcount, removes it from the original string and creates an icon with the hc
   const extractHeadCountExp = /(>?)\(\d+(.*?)\)/;
   if (extractHeadCountExp.test(h2.innerText)) {
@@ -217,6 +213,10 @@ function decorateHeader(header, borderParams, card, cardBorder) {
     headCntDiv.prepend(createTag('img', { src: '/express/icons/head-count.svg', alt: 'icon-head-count' }));
     header.append(headCntDiv);
   }
+  if (premiumIcon) h2.append(premiumIcon);
+  header.querySelectorAll('p').forEach((p) => {
+    if (p.innerHTML.trim() === '') p.remove();
+  });
   card.append(header);
   cardBorder.append(card);
   return { cardWrapper: cardBorder, specialPromo };


### PR DESCRIPTION
Describe your specific features or fixes

Allows both premium icons and headcount icons to be displayed in new pricing cards header. again

Resolves: [MWPW-142523](https://jira.corp.adobe.com/browse/MWPW-142523) 
<img width="1792" alt="Screenshot 2024-03-13 at 1 14 15 PM" src="https://github.com/adobecom/express/assets/159481679/12444e06-6652-4397-b004-ae9ff13d0484">



Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://icon-and-headcount-fix--express--adobecom.hlx.page/drafts/echen/pricing-cards
