### PR TITLE
Fix Color How To Carousel Icon/CTA Bug

### DIFF
--- a/express/blocks/color-how-to-carousel/color-how-to-carousel.js
+++ b/express/blocks/color-how-to-carousel/color-how-to-carousel.js
@@ -1,10 +1,8 @@
-/* eslint-disable import/named, import/extensions */
-
 import { createTag } from '../../scripts/utils.js';
 import { addTempWrapper } from '../../scripts/decorate.js';
 import isDarkOverlayReadable from '../../scripts/color-tools.js';
 
-function activate(block, payload, target) {
+function activate(block, target) {
   // de-activate all
   block.querySelectorAll('.tip, .tip-number')
     .forEach((item) => {
@@ -57,7 +55,7 @@ function initRotation(payload) {
             // if no next adjacent, back to first
             activeAdjacentSibling = numbers.firstElementChild;
           }
-          activate(numbers.parentElement, payload, activeAdjacentSibling);
+          activate(numbers.parentElement, activeAdjacentSibling);
         });
     }, 5000);
   }
@@ -79,7 +77,7 @@ function buildColorHowToCarousel(block, payload) {
   carousel.append(tips);
   if (payload.icon) carouselDivs.append(payload.icon);
   carouselDivs.append(payload.heading, carousel);
-  if (payload.cta) carouselDivs.append(payload.icon);
+  if (payload.cta) carouselDivs.append(payload.cta);
 
   if (includeSchema) {
     buildSchema(rows, payload);
@@ -122,7 +120,7 @@ function buildColorHowToCarousel(block, payload) {
       if (e.target.nodeName.toLowerCase() === 'span') {
         target = e.target.parentElement;
       }
-      activate(block, payload, target);
+      activate(block, target);
     });
 
     number.addEventListener('keyup', (e) => {
@@ -247,7 +245,7 @@ export default async function decorate(block) {
 
   buildColorHowToCarousel(block, payload);
   colorizeSVG(block, payload);
-  activate(block, payload, block.querySelector('.tip-number.tip-1'));
+  activate(block, block.querySelector('.tip-number.tip-1'));
 
   const onIntersect = ([entry], observer) => {
     if (!entry.isIntersecting) return;


### PR DESCRIPTION
Fixes the visual bug on the Color How To Carousel on colors pages. 
![Screenshot 2024-03-14 at 1 05 51 PM](https://github.com/adobecom/express/assets/57737624/45830754-d779-4d74-8030-d3507b90a229)
![Screenshot 2024-03-14 at 1 05 29 PM](https://github.com/adobecom/express/assets/57737624/f5ba8bf9-96e0-4909-888a-1064ca4996b7)

Resolves: [MWPW-144539](https://jira.corp.adobe.com/browse/MWPW-144539)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/colors/pink?martech=off
- After: https://color-carousel-bug-fix--express--adobecom.hlx.page/express/colors/pink?martech=off
