### PR TITLE
Prevent Relevant Rows from rendering on desktop

### DIFF
--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1937,7 +1937,7 @@ async function buildAutoBlocks(main) {
     }
   }
 
-  if (['yes', 'true', 'on'].includes(getMetadata('show-relevant-rows').toLowerCase())) {
+  if (['yes', 'true', 'on'].includes(getMetadata('show-relevant-rows').toLowerCase()) && document.body.dataset.device === 'mobile') {
     const authoredRRFound = [
       '.template-list.horizontal.fullwidth.mini',
       '.link-list.noarrows',


### PR DESCRIPTION
The relevant rows have been able to make its way to desktop since we removed the audience specific CSS and rely on removeIrrelevantSections() to weed out non-matching audience content. This PR should fix it. We'll also be removing this autoBlock after mobile GA since relevantRows are only supporting 1.N content.

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER) pending

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/create/advertisement/cyber-monday?martech=off
- After: https://autoblock-audience-fix--express--adobecom.hlx.page/express/create/advertisement/cyber-monday?martech=off
