### PR TITLE
[Sales-Number] GNAV & Marquee Consistency - No Read International Cookie

### DIFF
--- a/express/scripts/utils/pricing.js
+++ b/express/scripts/utils/pricing.js
@@ -188,9 +188,9 @@ export function normCountry(country) {
 }
 
 // urlparam > cookie > sessionStorage > feds > api > config
-export async function getCountry() {
+export async function getCountry(ignoreCookie = false) {
   const urlParams = new URLSearchParams(window.location.search);
-  let countryCode = urlParams.get('country') || getCookie('international');
+  let countryCode = urlParams.get('country') || (!ignoreCookie && getCookie('international'));
   if (countryCode) {
     return normCountry(countryCode);
   }
@@ -249,7 +249,7 @@ export const formatSalesPhoneNumber = (() => {
     }
 
     if (!numbersMap?.data) return;
-    const country = await getCountry() || 'us';
+    const country = await getCountry(true) || 'us';
     tags.forEach((a) => {
       const r = numbersMap.data.find((d) => d.country === country);
 


### PR DESCRIPTION
GNAV does not use international cookie when displaying phone numbers. To show consistent numbers on our pages, when we use formatSalesPhoneNumber(), we would need to ignore the international cookie. Using a boolean parameter is not ideal but as we will have geo-routing soon, should be ok temporarily.
To see the fix, go to https://www.adobe.com/express/business and use the bottom region-selector to go to the France page. You should see consistent numbers in both GNAV and marquee now but inconsistent in stage.

Resolves: https://jira.corp.adobe.com/browse/MWPW-144567?filter=381833 

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/business?martech=off
- After: https://sync-gnav-sales-number--express--adobecom.hlx.page/express/business?martech=off
