### PR TITLE
Fix Fullscreen Marquee h1 text align on desktop

### DIFF
--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -268,6 +268,7 @@
   .fullscreen-marquee .fullscreen-marquee-heading h1 {
     font-size: 80px;
     line-height: 90px;
+    text-align: center;
   }
 
   .fullscreen-marquee .fullscreen-marquee-heading p {


### PR DESCRIPTION
adding a missed styling for desktop h1 in fullscreen marquee block

Resolves: [MWPW-143742](https://jira.corp.adobe.com/browse/MWPW-143742) follow up

Test URLs:
- Before: https://main--express--adobecom.hlx.page/fr/express/create/video/birthday?martech=off
- After: https://fullscreen-fix-2--express--adobecom.hlx.page/fr/express/create/video/birthday?martech=off
