### PR TITLE
New Video URL Hotfix

### DIFF
--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -524,10 +524,17 @@ export function transformLinkToAnimation($a, $videoLooping = true) {
   }
   // replace anchor with video element
   const videoUrl = new URL($a.href);
-  const helixId = videoUrl.hostname.includes('hlx.blob.core') ? videoUrl.pathname.split('/')[2] : videoUrl.pathname.split('media_')[1].split('.')[0];
-  const videoHref = `./media_${helixId}.mp4`;
+
+  const isLegacy = videoUrl.hostname.includes('hlx.blob.core') || videoUrl.pathname.includes('media_');
   const $video = createTag('video', attribs);
-  $video.innerHTML = `<source src="${videoHref}" type="video/mp4">`;
+  if (isLegacy) {
+    const helixId = videoUrl.hostname.includes('hlx.blob.core') ? videoUrl.pathname.split('/')[2] : videoUrl.pathname.split('media_')[1].split('.')[0];
+    const videoHref = `./media_${helixId}.mp4`;
+    $video.innerHTML = `<source src="${videoHref}" type="video/mp4">`;
+  } else {
+    $video.innerHTML = `<source src="${videoUrl}" type="video/mp4">`;
+  }
+
   const $innerDiv = $a.closest('div');
   $innerDiv.prepend($video);
   $innerDiv.classList.add('hero-animation-overlay');


### PR DESCRIPTION
Describe your specific features or fixes

Updates Utils.js to accept new format of video URLs that were not uploaded via the helix bot

Resolves: [MWPW-145160](https://jira.corp.adobe.com/browse/MWPW-145160)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/create/video/invitation/wedding
- After: https://video-marquee-fix--express--adobecom.hlx.page/express/create/video/invitation/wedding
