### PR TITLE
Same getMetadata Fallback as Milo

### DIFF
--- a/express/blocks/firefly-card/firefly-card.js
+++ b/express/blocks/firefly-card/firefly-card.js
@@ -92,7 +92,7 @@ const buildCard = (block, payload) => {
 };
 
 export default async function decorate(block) {
-  if (['yes', 'on', 'true'].includes(getMetadata('rush-beta-gating')) && ['yes', 'true', 'on'].includes(getMetadata('mobile-benchmark').toLowerCase()) && document.body.dataset.device === 'mobile') {
+  if (['yes', 'on', 'true'].includes(getMetadata('rush-beta-gating')) && ['yes', 'true', 'on'].includes(getMetadata('mobile-benchmark')?.toLowerCase()) && document.body.dataset.device === 'mobile') {
     const eligibility = BlockMediator.get('mobileBetaEligibility');
     if (eligibility) {
       if (eligibility.deviceSupport) {

--- a/express/blocks/ratings/ratings.js
+++ b/express/blocks/ratings/ratings.js
@@ -66,7 +66,7 @@ export default async function decorate($block) {
       '@type': 'Product',
       '@context': 'https://schema.org',
       name: document.title,
-      description: getMetadata('description'),
+      description: getMetadata('description') || '',
       aggregateRating: { '@type': 'AggregateRating', ratingValue: ratingAverage, ratingCount: ratingTotal },
     });
     document.head.appendChild(script);

--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -112,12 +112,12 @@ function initSearchFunction(block) {
     const taskMap = placeholders['task-name-mapping'] ? JSON.parse(placeholders['task-name-mapping']) : {};
     const taskXMap = placeholders['x-task-name-mapping'] ? JSON.parse(placeholders['x-task-name-mapping']) : {};
 
-    const format = getMetadata('placeholder-format');
+    const format = getMetadata('placeholder-format') || '';
     const currentTasks = {
       xCore: '',
       content: '',
     };
-    let searchInput = searchBar.value || getMetadata('topics');
+    let searchInput = searchBar.value || getMetadata('topics') || '';
 
     const tasksFoundInInput = findTask(taskMap);
     const tasksXFoundInInput = findTask(taskXMap);

--- a/express/blocks/sticky-promo-bar/sticky-promo-bar.js
+++ b/express/blocks/sticky-promo-bar/sticky-promo-bar.js
@@ -47,7 +47,7 @@ export default async function decorate(block) {
   });
 
   if (block.classList.contains('loadinbody')) {
-    if (['yes', 'on', 'true'].includes(getMetadata('rush-beta-gating')) && ['yes', 'true', 'on'].includes(getMetadata('mobile-benchmark').toLowerCase()) && document.body.dataset.device === 'mobile') {
+    if (['yes', 'on', 'true'].includes(getMetadata('rush-beta-gating')) && ['yes', 'true', 'on'].includes(getMetadata('mobile-benchmark')?.toLowerCase()) && document.body.dataset.device === 'mobile') {
       const eligibility = BlockMediator.get('mobileBetaEligibility');
       if (eligibility) {
         if (eligibility.deviceSupport) {

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -1909,9 +1909,9 @@ function constructProps() {
   const smScreen = window.matchMedia('(max-width: 900px)');
   const mdScreen = window.matchMedia('(min-width: 901px) and (max-width: 1200px)');
   const bgScreen = window.matchMedia('(max-width: 1440px)');
-  const ratioSeparator = getMetadata('placeholder-format').includes(':') ? ':' : 'x';
+  const ratioSeparator = getMetadata('placeholder-format')?.includes(':') ? ':' : 'x';
   const ratioFromMetadata = getMetadata('placeholder-format')
-    .split(ratioSeparator)
+    ?.split(ratioSeparator)
     .map((str) => parseInt(str, 10));
 
   return {

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -116,7 +116,7 @@ async function formatHeadingPlaceholder(props) {
     toolBarHeading = toolBarHeading
       .replace('{{quantity}}', props.fallbackMsg ? '0' : templateCount)
       .replace('{{Type}}', titleCase(getMetadata('short-title') || getMetadata('q') || getMetadata('topics')))
-      .replace('{{type}}', getMetadata('short-title') || getMetadata('q') || getMetadata('topics'));
+      ?.replace('{{type}}', getMetadata('short-title') || getMetadata('q') || getMetadata('topics'));
     if (region === 'fr') {
       toolBarHeading.split(' ').forEach((word, index, words) => {
         if (index + 1 < words.length) {
@@ -1372,9 +1372,9 @@ function importSearchBar(block, blockMediator) {
           const placeholders = await fetchPlaceholders();
           const taskMap = placeholders['task-name-mapping'] ? JSON.parse(placeholders['task-name-mapping']) : {};
 
-          const format = getMetadata('placeholder-format');
+          const format = getMetadata('placeholder-format') || '';
           let currentTasks = '';
-          let searchInput = searchBar.value.toLowerCase() || getMetadata('topics');
+          let searchInput = searchBar.value.toLowerCase() || getMetadata('topics') || '';
 
           const tasksFoundInInput = Object.entries(taskMap)
             .filter((task) => task[1].some((word) => {

--- a/express/scripts/browse-api-controller.js
+++ b/express/scripts/browse-api-controller.js
@@ -109,7 +109,7 @@ export async function getDataWithId() {
         filters: [
           {
             categories: [
-              getMetadata('ckgid'),
+              getMetadata('ckgid') || '',
             ],
           },
         ],

--- a/express/scripts/content-replace.js
+++ b/express/scripts/content-replace.js
@@ -162,14 +162,14 @@ async function updateNonBladeContent(main) {
   if (templateList) {
     await replaceDefaultPlaceholders(templateList, {
       link: getMetadata('create-link') || '/',
-      tasks: getMetadata('tasks'),
+      tasks: getMetadata('tasks') || '',
     });
   }
 
   if (templateX) {
     await replaceDefaultPlaceholders(templateX, {
       link: getMetadata('create-link-x') || getMetadata('create-link') || '/',
-      tasks: getMetadata('tasks-x'),
+      tasks: getMetadata('tasks-x') || '',
     });
   }
 

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -185,7 +185,7 @@ async function loadFEDS() {
   window.addEventListener('feds.events.experience.loaded', async () => {
     document.querySelector('body').classList.add('feds-loaded');
 
-    if (['no', 'f', 'false', 'n', 'off'].includes(getMetadata('gnav-retract').toLowerCase())) {
+    if (['no', 'f', 'false', 'n', 'off'].includes(getMetadata('gnav-retract')?.toLowerCase())) {
       window.feds.components.NavBar.disableRetractability();
     }
 
@@ -271,7 +271,7 @@ async function loadFEDS() {
 if (!window.hlx || window.hlx.gnav) {
   await loadIMS();
   loadFEDS();
-  if (!['off', 'no'].includes(getMetadata('google-yolo').toLowerCase())) {
+  if (!['off', 'no'].includes(getMetadata('google-yolo')?.toLowerCase())) {
     setTimeout(() => {
       import('./google-yolo.js').then((mod) => {
         mod.default();

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -143,11 +143,11 @@ export async function trackBranchParameters($links) {
   const { experiment } = window.hlx;
   const { referrer } = window.document;
   const experimentStatus = experiment ? experiment.status.toLocaleLowerCase() : null;
-  const templateSearchTag = getMetadata('branch-search-term') || getMetadata('short-title');
-  const canvasHeight = getMetadata('branch-canvas-height');
-  const canvasWidth = getMetadata('branch-canvas-width');
-  const canvasUnit = getMetadata('branch-canvas-unit');
-  const sceneline = getMetadata('branch-sceneline');
+  const templateSearchTag = getMetadata('branch-search-term') || getMetadata('short-title') || '';
+  const canvasHeight = getMetadata('branch-canvas-height') || '';
+  const canvasWidth = getMetadata('branch-canvas-width') || '';
+  const canvasUnit = getMetadata('branch-canvas-unit') || '';
+  const sceneline = getMetadata('branch-sceneline') || '';
   const pageUrl = window.location.pathname;
   const sdid = rootUrlParameters.get('sdid');
   const mv = rootUrlParameters.get('mv');
@@ -542,7 +542,7 @@ function decorateAnalyticsEvents() {
     }
   });
 
-  if (['yes', 'true', 'on'].includes(getMetadata('mobile-benchmark').toLowerCase()) && document.body.dataset.device === 'mobile') {
+  if (['yes', 'true', 'on'].includes(getMetadata('mobile-benchmark')?.toLowerCase()) && document.body.dataset.device === 'mobile') {
     import('./block-mediator.min.js').then((resp) => {
       const { default: BlockMediator } = resp;
       const eligibility = BlockMediator.get('mobileBetaEligibility');

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -146,8 +146,8 @@ const listenAlloy = () => {
     sessionStorage.setItem('imsclient', 'MarvelWeb3');
   }
 
-  const isMobileGating = ['yes', 'true', 'on'].includes(getMetadata('mobile-benchmark').toLowerCase()) && document.body.dataset.device === 'mobile';
-  const rushGating = ['yes', 'on', 'true'].includes(getMetadata('rush-beta-gating').toLowerCase());
+  const isMobileGating = ['yes', 'true', 'on'].includes(getMetadata('mobile-benchmark')?.toLowerCase()) && document.body.dataset.device === 'mobile';
+  const rushGating = ['yes', 'on', 'true'].includes(getMetadata('rush-beta-gating')?.toLowerCase());
   const runGating = () => {
     import('./mobile-beta-gating.js').then(async (gatingScript) => {
       gatingScript.default();

--- a/express/scripts/template-ckg.js
+++ b/express/scripts/template-ckg.js
@@ -97,7 +97,7 @@ async function updateLinkList(container, linkPill, list) {
   const rightTrigger = container.querySelector('.carousel-right-trigger');
   container.innerHTML = '';
 
-  const taskMeta = getMetadata('tasks');
+  const taskMeta = getMetadata('tasks') || '';
   const currentTasks = taskMeta ? taskMeta.replace(/[$@%"]/g, '') : ' ';
   const currentTasksX = getMetadata('tasks-x') || '';
 
@@ -124,7 +124,7 @@ async function updateLinkList(container, linkPill, list) {
         if (clone) pageLinks.push(clone);
       } else {
         // fixme: we need single page search UX
-        const searchParams = `tasks=${currentTasks}&tasksx=${currentTasksX}&phformat=${getMetadata('placeholder-format')}&topics=${topicsQuery}&q=${d.displayValue}&ckgid=${d.ckgID}`;
+        const searchParams = `tasks=${currentTasks}&tasksx=${currentTasksX}&phformat=${getMetadata('placeholder-format') || ''}&topics=${topicsQuery}&q=${d.displayValue}&ckgid=${d.ckgID}`;
         const pageData = {
           url: `${prefix}/express/templates/search?${searchParams}`,
           'short-title': d.displayValue,
@@ -150,7 +150,7 @@ async function updateLinkList(container, linkPill, list) {
           linkListData.push({
             childSibling: row['child-siblings'],
             shortTitle: getMetadata('short-title'),
-            tasks: getMetadata('tasks'),
+            tasks: getMetadata('tasks') || '',
           });
         }
       });

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -38,10 +38,10 @@ const LANGSTORE = 'langstore';
 
 const PAGE_URL = new URL(window.location.href);
 
-export function getMetadata(name) {
+export function getMetadata(name, doc = document) {
   const attr = name && name.includes(':') ? 'property' : 'name';
-  const $meta = document.head.querySelector(`meta[${attr}="${name}"]`);
-  return ($meta && $meta.content) || '';
+  const meta = doc.head.querySelector(`meta[${attr}="${name}"]`);
+  return meta && meta.content;
 }
 
 function getEnv(conf) {
@@ -1552,7 +1552,7 @@ export function decorateButtons(el = document) {
 }
 
 export function checkTesting() {
-  return (getMetadata('testing').toLowerCase() === 'on');
+  return (getMetadata('testing')?.toLowerCase() === 'on');
 }
 
 /**
@@ -1708,7 +1708,7 @@ function loadIMS() {
 
 async function loadAndRunExp(config, forcedExperiment, forcedVariant) {
   const promises = [import('./experiment.js')];
-  const aepaudiencedevice = getMetadata('aepaudiencedevice').toLowerCase();
+  const aepaudiencedevice = getMetadata('aepaudiencedevice')?.toLowerCase();
   if (aepaudiencedevice === 'all' || aepaudiencedevice === document.body.dataset?.device) {
     loadIMS();
     // rush instrument-martech-launch-alloy
@@ -1938,14 +1938,14 @@ async function buildAutoBlocks(main) {
   const lastDiv = main.querySelector(':scope > div:last-of-type');
 
   // Load the branch.io banner autoblock...
-  if (['yes', 'true', 'on'].includes(getMetadata('show-banner').toLowerCase())) {
+  if (['yes', 'true', 'on'].includes(getMetadata('show-banner')?.toLowerCase())) {
     const branchio = buildBlock('branch-io', '');
     if (lastDiv) {
       lastDiv.append(branchio);
     }
   }
 
-  if (['yes', 'true', 'on'].includes(getMetadata('show-relevant-rows').toLowerCase()) && document.body.dataset.device === 'mobile') {
+  if (['yes', 'true', 'on'].includes(getMetadata('show-relevant-rows')?.toLowerCase()) && document.body.dataset.device === 'mobile') {
     const authoredRRFound = [
       '.template-list.horizontal.fullwidth.mini',
       '.link-list.noarrows',
@@ -1966,7 +1966,7 @@ async function buildAutoBlocks(main) {
     }
   }
 
-  if (['yes', 'true', 'on'].includes(getMetadata('show-plans-comparison').toLowerCase())) {
+  if (['yes', 'true', 'on'].includes(getMetadata('show-plans-comparison')?.toLowerCase())) {
     const $plansComparison = buildBlock('plans-comparison', '');
     if (lastDiv) {
       lastDiv.append($plansComparison);
@@ -2050,7 +2050,7 @@ async function buildAutoBlocks(main) {
         });
       }
     }
-  } else if (['yes', 'true', 'on'].includes(getMetadata('show-floating-cta').toLowerCase())) {
+  } else if (['yes', 'true', 'on'].includes(getMetadata('show-floating-cta')?.toLowerCase())) {
     const { default: BlockMediator } = await import('./block-mediator.min.js');
 
     if (!BlockMediator.get('floatingCtasLoaded')) {

--- a/express/scripts/utils/free-plan.js
+++ b/express/scripts/utils/free-plan.js
@@ -44,7 +44,7 @@ export async function buildFreePlanWidget(config) {
 }
 
 export async function addFreePlanWidget(elem) {
-  const freePlanMeta = getMetadata('show-free-plan').toLowerCase();
+  const freePlanMeta = getMetadata('show-free-plan')?.toLowerCase();
 
   if (!freePlanMeta || ['no', 'false', 'n', 'off'].includes(freePlanMeta)) return;
   const placeholders = await fetchPlaceholders();


### PR DESCRIPTION
As of now, we fallback to empty string when a metadata is missing. This PR will enable us to differentiate "empty" from "undefined". But all references of the method will now need to watch out for undefined value. This will get us more in sync with Milo.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/
- After: https://update-metadata-fallback--express--adobecom.hlx.page/express/?martech=off
