### PR TITLE
[MWPW-145311] Enable Plan Explanations On Mobile

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -391,10 +391,6 @@ End border style variants
     grid-template-columns: repeat(auto-fit, minmax(var(--card-width), calc((1200px - 32px) / 3)));
   }
 
-  .pricing-cards .card-explain {
-    display: block;
-  }
-
   .pricing-cards .pricing-section {
     gap: 24px;
   }

--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -177,10 +177,6 @@ End border style variants
   padding-right: 6px;
 }
 
-.pricing-cards .card-explain {
-  display: none;
-}
-
 .pricing-cards .card-offer {
   position: absolute;
   right: 8px;


### PR DESCRIPTION
Describe your specific features or fixes

Allows plan explanation to be displayed on mobile again.
<img width="619" alt="Screenshot 2024-03-25 at 8 51 26 AM" src="https://github.com/adobecom/express/assets/159481679/29e00e14-91c8-4aa5-8ebb-d62d666d48e9">


Resolves: [MWPW-145311](https://jira.corp.adobe.com/browse/MWPW-145311)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://pricing-cards-mobile-desc--express--adobecom.hlx.page/express/
