### PR TITLE
[Frictionless-QA] Always Init PROD Env SDK

### DIFF
--- a/express/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -51,9 +51,6 @@ function startSDK(data = '') {
       if (country) ietf = getConfig().locales[country]?.ietf;
       if (ietf === 'zh-Hant-TW') ietf = 'tw-TW';
       else if (ietf === 'zh-Hans-CN') ietf = 'cn-CN';
-      let env = getConfig().env.name;
-      if (env === 'local') env = 'dev';
-      if (env === 'stage') env = 'stage';
 
       const ccEverywhereConfig = {
         hostInfo: {
@@ -62,7 +59,6 @@ function startSDK(data = '') {
         },
         configParams: {
           locale: ietf.replace('-', '_'),
-          env,
         },
         authOption: () => ({
           mode: 'delayed',


### PR DESCRIPTION
From now on, we should only integrate with the stabilized PROD SDK. When env is missing from config, it's prod by default. So some code was removed.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/experiments/frictionless-qa/convert-to-png?martech=off
- After: https://frictionless-qa-always-prod---express--adobecom.hlx.page/express/experiments/frictionless-qa/convert-to-png?martech=off
