### PR TITLE
[Pricing-Cards] Sync Heights Across Cards for Each Section

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -3,6 +3,9 @@
   --card-padding: 16px 12px;
 }
 
+.pricing-cards.no-visible {
+  visibility: hidden;
+}
 
 /*
 Legacy CSS for cards and special promo
@@ -81,6 +84,7 @@ Border style variants
   color: var(--color-white);
   font-weight: 400;
   padding-bottom: 12px;
+  line-height: 1.5rem;
 }
 
 .pricing-cards .gradient-promo {
@@ -388,7 +392,7 @@ End border style variants
   }
 
   .pricing-cards .cards-container:has(>.card-border:first-child:nth-last-child(3)) {
-    width: var(2 * --card-width);
+    width: calc(2 * --card-width);
     margin: auto;
     grid-template-columns: repeat(auto-fit, minmax(var(--card-width), calc((1200px - 32px) / 3)));
   }

--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -138,15 +138,7 @@ End border style variants
 */
 
 .pricing-cards .card-border {
-  margin-top: 44px;
-}
-
-.pricing-cards .card-border:lang(ja){
-  margin-top: 50px;
-}
-
-.pricing-cards .card-border:lang(zh-Hant){
-  margin-top: 47px;
+  margin-top: calc(24px + 1.5rem);
 }
 
 

--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -307,6 +307,7 @@ End border style variants
   padding: 16px 0px;
   border-bottom: 1px solid var(--Palette-gray-100, #E9E9E9);
   margin: 0 0 24px 0;
+  box-sizing: border-box;
 }
 
 .pricing-cards .card-feature-list p strong {

--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -141,6 +141,15 @@ End border style variants
   margin-top: 44px;
 }
 
+.pricing-cards .card-border:lang(ja){
+  margin-top: 50px;
+}
+
+.pricing-cards .card-border:lang(zh-Hant){
+  margin-top: 47px;
+}
+
+
 .pricing-cards .card-border .hide {
   display: none;
 }

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -333,6 +333,7 @@ export default async function init(el) {
   if (phoneNumberTags.length > 0) {
     await formatSalesPhoneNumber(phoneNumberTags, SALES_NUMBERS);
   }
+  el.classList.add('no-visible');
   el.prepend(cardsContainer);
 
   const observer = new IntersectionObserver((entries) => {
@@ -347,6 +348,7 @@ export default async function init(el) {
           cards.map(({ featureList }) => featureList),
           cards.map(({ compare }) => compare),
         );
+        el.classList.remove('no-visible');
       }
     });
   });

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -299,10 +299,12 @@ function decorateCard({
 
 // less thrashing by separating get and set
 async function syncMinHeights(...groups) {
-  const maxHeights = groups.map((els) => els.reduce((max, e) => Math.max(max, e.offsetHeight), 0));
+  const maxHeights = groups.map((els) => els
+    .filter((e) => !!e)
+    .reduce((max, e) => Math.max(max, e.offsetHeight), 0));
   await yieldToMain();
-  maxHeights.forEach((maxHeight, i) => groups[i].forEach((el) => {
-    el.style.minHeight = `${maxHeight}px`;
+  maxHeights.forEach((maxHeight, i) => groups[i].forEach((e) => {
+    if (e) e.style.minHeight = `${maxHeight}px`;
   }));
 }
 


### PR DESCRIPTION
Keeping copy length consistent turns out to be too big of a lift for authoring, especially for localized pages. Therefore, we have to rely on engineering to sync each section's minHeight across cards. This would certainly come with some performance cost, so when it's below the fold, the impact is reduced via using IntersectionObserver. But when it's above the fold, we are compromising either CLS or TBT, and I choose to sacrifice TBT.

Resolves: https://jira.corp.adobe.com/browse/MWPW-145576

To see the difference, scroll to bottom to see the pricing-cards
![SC 2024-03-25 at 2 02 10 PM](https://github.com/adobecom/express/assets/32369333/f5200594-cc48-4591-b219-055a9024d3bd)
![SC 2024-03-25 at 2 06 05 PM](https://github.com/adobecom/express/assets/32369333/4fa555bb-dce3-435f-a7b9-317d464b0ebf)


Test URLs:
- Before: https://stage--express--adobecom.hlx.page/jp/express/business?lighthouse=on
- After: https://pricing-cards-sync-heights--express--adobecom.hlx.page/jp/express/business?lighthouse=on
