### PR TITLE
Fixes category typo in new smart link list

### DIFF
--- a/express/blocks/link-list/link-list.js
+++ b/express/blocks/link-list/link-list.js
@@ -35,7 +35,7 @@ const formatBlockLinks = (links, variant, baseURL) => {
   if (!links || variant !== SMART_VARIANT || !baseURL) {
     return;
   }
-  const formattedURL = `${baseURL}?acomx-dno=true&category=template`;
+  const formattedURL = `${baseURL}?acomx-dno=true&category=templates`;
   links.forEach((p) => {
     const a = p.querySelector('a');
     a.href = `${formattedURL}&q=${a.title}`;


### PR DESCRIPTION
Describe your specific features or fixes

Changes the hardcoded template to "templates" so that the category is correctly parsed by Adobe Express
<img width="799" alt="Screenshot 2024-03-28 at 9 54 44 AM" src="https://github.com/adobecom/express/assets/159481679/c5ed076b-d0b4-4f46-affb-e8da5d379607">


Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://link-list-category-fix--express--adobecom.hlx.page/drafts/echen/vertical
