### PR TITLE
[Frictionless-QA] Added Safari Split via showwith

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -72,8 +72,20 @@ const eagerLoad = (img) => {
   img?.setAttribute('fetchpriority', 'high');
 };
 
+(function handleSplit() {
+  const { userAgent } = navigator;
+  document.body.dataset.device = userAgent.includes('Mobile') ? 'mobile' : 'desktop';
+  const fqaMeta = createTag('meta', { content: 'on' });
+  if (document.body.dataset.device === 'mobile'
+    || (/Safari/.test(userAgent) && !/Chrome|CriOS|FxiOS|Edg|OPR|Opera|OPiOS|Vivaldi|YaBrowser|Avast|VivoBrowser|GSA/.test(userAgent))) {
+    fqaMeta.setAttribute('name', 'fqa-off');
+  } else {
+    fqaMeta.setAttribute('name', 'fqa-on');
+  }
+  document.head.append(fqaMeta);
+}());
+
 (function loadLCPImage() {
-  document.body.dataset.device = navigator.userAgent.includes('Mobile') ? 'mobile' : 'desktop';
   const main = document.body.querySelector('main');
   removeIrrelevantSections(main);
   const firstDiv = main.querySelector('div:nth-child(1) > div');


### PR DESCRIPTION
Added Safari split. So mobile or Safari users see the old experience, and desktop non-safari users see the new experience.
To test, open the branch link in different browsers and you should see the changing behavior.

Resolves: https://jira.corp.adobe.com/browse/MWPW-145726

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/experiments/frictionless-qa/remove-background?lighthouse=on
- After: https://fqa-safari-split--express--adobecom.hlx.page/express/experiments/frictionless-qa/remove-background?lighthouse=on
