### PR TITLE
Add min-width to mini horizontal templates

### DIFF
--- a/express/blocks/shared/masonry.js
+++ b/express/blocks/shared/masonry.js
@@ -45,7 +45,7 @@ export class Masonry {
       }
 
       if (block.classList.contains('md-view')) {
-        colWidth = 256;
+        colWidth = 270;
       }
 
       if (block.classList.contains('lg-view')) {

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -410,6 +410,7 @@ main.with-holiday-templates-banner {
 
 .template-x.horizontal.mini .template {
     min-height: unset;
+    min-width: 64px;
     max-height: 100px;
     max-width: 200px;
     margin: 0 4px;
@@ -445,6 +446,7 @@ main.with-holiday-templates-banner {
 .template-x.horizontal.mini .template .still-wrapper video {
     object-fit: cover;
     height: 100px;
+    width: 100%;
 }
 
 .template-x.horizontal.mini .template .icon-free-badge {

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -457,7 +457,7 @@ main.with-holiday-templates-banner {
     top: 4px;
 }
 
-.template-x.sixcols .template,
+.template-x.sixcols:not(.horizontal) .template,
 .template-x.fullwidth .template {
     position: relative;
     display: inline-flex;
@@ -477,8 +477,8 @@ main.with-holiday-templates-banner {
 
 .template-x.horizontal .template:not(.placeholder) img,
 .template-x.horizontal .template:not(.placeholder) video,
-.template-x.sixcols .template:not(.placeholder) img,
-.template-x.sixcols .template:not(.placeholder) video,
+.template-x.sixcols:not(.horizontal) .template:not(.placeholder) img,
+.template-x.sixcols:not(.horizontal) .template:not(.placeholder) video,
 .template-x.fullwidth .template:not(.placeholder) img,
 .template-x.fullwidth .template:not(.placeholder) video {
     transition: transform .3s ease-in-out;
@@ -486,7 +486,7 @@ main.with-holiday-templates-banner {
 }
 
 .template-x .template:not(.placeholder) .button-container,
-.template-x.sixcols .template:not(.placeholder) .button-container,
+.template-x.sixcols:not(.horizontal) .template:not(.placeholder) .button-container,
 .template-x.fullwidth .template:not(.placeholder) .button-container {
     position: absolute;
     width: 120%;
@@ -526,7 +526,7 @@ main.with-holiday-templates-banner {
 }
 
 .template-x.horizontal .template:not(.placeholder) .template-link,
-.template-x.sixcols .template:not(.placeholder) .template-link,
+.template-x.sixcols:not(.horizontal) .template:not(.placeholder) .template-link,
 .template-x.fullwidth .template:not(.placeholder) .template-link {
     opacity: 0;
     transition: opacity .4s ease-in-out .2s;
@@ -536,8 +536,8 @@ main.with-holiday-templates-banner {
 .template-x .template:hover:not(.placeholder) .button-container,
 .template-x.horizontal .template:hover:not(.placeholder) .button-container,
 .template-x.horizontal .template:hover:not(.placeholder) .template-link,
-.template-x.sixcols .template:hover:not(.placeholder) .button-container,
-.template-x.sixcols .template:hover:not(.placeholder) .template-link,
+.template-x.sixcols:not(.horizontal) .template:hover:not(.placeholder) .button-container,
+.template-x.sixcols:not(.horizontal) .template:hover:not(.placeholder) .template-link,
 .template-x.fullwidth .template:hover:not(.placeholder) .button-container,
 .template-x.fullwidth .template:hover:not(.placeholder) .template-link {
     opacity: 1;
@@ -546,7 +546,7 @@ main.with-holiday-templates-banner {
 }
 
 .template-x.horizontal .template:not(.placeholder) .template-link,
-.template-x.sixcols .template:not(.placeholder) .template-link,
+.template-x.sixcols:not(.horizontal) .template:not(.placeholder) .template-link,
 .template-x.fullwidth .template:not(.placeholder) .template-link {
     text-decoration: none;
     border-radius: 18px;
@@ -573,7 +573,7 @@ main.with-holiday-templates-banner {
 }
 
 .template-x.horizontal .template:not(.placeholder) .template-link::after,
-.template-x.sixcols .template:not(.placeholder) .template-link::after,
+.template-x.sixcols:not(.horizontal) .template:not(.placeholder) .template-link::after,
 .template-x.fullwidth .template:not(.placeholder) .template-link::after {
     display: none;
 }
@@ -597,7 +597,7 @@ main.with-holiday-templates-banner {
     margin: 0 11px;
 }
 
-.template-x.sixcols .template.placeholder,
+.template-x.sixcols:not(.horizontal) .template.placeholder,
 .template-x.fullwidth .template.placeholder {
     width: 145px;
     margin: 15px auto;
@@ -2328,7 +2328,7 @@ nav ol.templates-breadcrumbs li:not(:first-child):before {
         max-width: 900px;
     }
 
-    .template-x-wrapper.sixcols {
+    .template-x-wrapper.sixcols:not(.horizontal) {
         max-width: 748px;
     }
 
@@ -2355,7 +2355,7 @@ nav ol.templates-breadcrumbs li:not(:first-child):before {
         text-align: left;
     }
 
-    .template-x.sixcols > .template-x-inner-wrapper > .masonry-col,
+    .template-x.sixcols:not(.horizontal) > .template-x-inner-wrapper > .masonry-col,
     .template-x.fullwidth > .template-x-inner-wrapper > .masonry-col {
         max-width: 180px;
     }
@@ -2375,7 +2375,7 @@ nav ol.templates-breadcrumbs li:not(:first-child):before {
         margin: 24px 11px 18px 11px;
     }
 
-    .template-x.sixcols .template.placeholder,
+    .template-x.sixcols:not(.horizontal) .template.placeholder,
     .template-x.fullwidth .template.placeholder {
         width: 145px;
         margin: 21px auto;
@@ -2620,7 +2620,7 @@ nav ol.templates-breadcrumbs li:not(:first-child):before {
         max-width: 1200px;
     }
 
-    .template-x-wrapper.sixcols {
+    .template-x-wrapper.sixcols:not(.horizontal) {
         max-width: 1122px;
     }
 


### PR DESCRIPTION
fixing a layout issue caused by templates that are too narrow.
![image (1)](https://github.com/adobecom/express/assets/57737624/03b91055-3ab5-4a14-b7a1-5602811e3167)

Resolves: [MWPW-140778](https://jira.corp.adobe.com/browse/MWPW-140778) lastest comment

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/create/video/infographic?martech=off
- After: https://mini-template-x-fix--express--adobecom.hlx.page/express/create/video/infographic?martech=off
