### PR TITLE
MWPW-145662 | Adding logic to suppress special promo for non premium cards

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -98,6 +98,12 @@ function handlePrice(placeholders, pricingArea, placeholderArr, specialPromo, le
         specialPromoPercentageEyeBrowTextReplaced = true;
       }
     }
+    if (!isPremiumCard && specialPromo.parentElement.classList.contains('special-promo')) {
+      specialPromo.parentElement.classList.remove('special-promo');
+      if (specialPromo.parentElement.firstChild.innerHTML !== '') {
+        specialPromo.parentElement.firstChild.remove();
+      }
+    }
   });
 
   priceParent?.remove();


### PR DESCRIPTION
Adding logic to suppress special promo for non premium cards

Resolves: [MWPW-145662](https://jira.corp.adobe.com/browse/MWPW-145662)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/in/express/business?country=de
- After: https://MWPW-145662--express--adobecom.hlx.page/in/express/business?country=de

- Before: https://main--express--adobecom.hlx.page/express/in/express/business?country=in
- After: https://MWPW-145662--express--adobecom.hlx.page/in/express/business?country=in
- 
- Before: https://main--express--adobecom.hlx.page/express/in/express/business?country=mx
- After: https://MWPW-145662--express--adobecom.hlx.page/in/express/business?country=mx

- Before: https://main--express--adobecom.hlx.page/express/in/express/business?country=us
- After: https://MWPW-145662--express--adobecom.hlx.page/in/express/business?country=us