### PR TITLE
[FrictionlessQA] Miscellaneous Updates

### DIFF
--- a/express/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -136,7 +136,8 @@
 }
 
 .frictionless-quick-action.block > div.hidden {
-    display: none;
+    opacity: 0;
+    position: absolute;
 }
 
 .frictionless-quick-action.block > div.transparent {

--- a/express/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -3,7 +3,6 @@
 }
 
 .frictionless-quick-action.block {
-    min-height: 697px;
     padding: 40px 20px;
 }
 

--- a/express/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -114,11 +114,6 @@ function startSDK(data = '') {
       parentElementId: `${quickAction}-container`,
       backgroundColor: 'transparent',
       hideCloseButton: true,
-      minSize: {
-        width: 1112,
-        height: 620,
-        unit: 'px',
-      },
     };
 
     const docConfig = {

--- a/express/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -59,6 +59,7 @@ function startSDK(data = '') {
         },
         configParams: {
           locale: ietf.replace('-', '_'),
+          env: urlParams.get('env') === 'stage' ? 'stage' : 'prod',
         },
         authOption: () => ({
           mode: 'delayed',

--- a/express/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -242,6 +242,7 @@ export default async function decorate(block) {
     } else {
       uploadFile();
     }
+    document.body.dataset.suppressfloatingcta = 'true';
   });
 
   function preventDefaults(e) {
@@ -274,6 +275,7 @@ export default async function decorate(block) {
     const { files } = dt;
 
     [...files].forEach(startSDKWithUnconvertedFile);
+    document.body.dataset.suppressfloatingcta = 'true';
   }, false);
 
   const quickActionRow = rows.filter((r) => r.children && r.children[0].textContent.toLowerCase().trim() === 'quick-action');
@@ -296,6 +298,7 @@ export default async function decorate(block) {
       document.body.classList.remove('editor-modal-loaded');
       inputElement.value = '';
       fade(uploadContainer, 'in');
+      document.body.dataset.suppressfloatingcta = 'false';
     }
   }, { passive: true });
 }

--- a/express/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -59,7 +59,7 @@ function startSDK(data = '') {
         },
         configParams: {
           locale: ietf.replace('-', '_'),
-          env: urlParams.get('env') === 'stage' ? 'stage' : 'prod',
+          env: urlParams.get('hzenv') === 'stage' ? 'stage' : 'prod',
         },
         authOption: () => ({
           mode: 'delayed',

--- a/express/blocks/shared/floating-cta.css
+++ b/express/blocks/shared/floating-cta.css
@@ -168,6 +168,9 @@ body[data-device="mobile"] main .floating-button-wrapper[data-audience="mobile"]
 body[data-device="desktop"] main .floating-button-wrapper[data-audience="desktop"][data-section-status="loaded"] {
     display: flex;
 }
+body[data-suppressfloatingcta="true"] main .floating-button-wrapper[data-audience="desktop"][data-section-status="loaded"] {
+    display: none;
+}
 
 body[data-device="mobile"] main .floating-button-wrapper[data-audience="mobile"][data-section-status="loaded"] .same-as-floating-button-CTA {
     display: block;


### PR DESCRIPTION
1. The minHeight ContConfig seems to be no longer needed and can be removed
2. Block's own min-height can cause too big of a blank space below
3. Change how we hide the block when Editor is up
4. Hide floatingCTA after the new experience has started

Resolves: https://jira.corp.adobe.com/browse/MWPW-146037

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/feature/image/remove-background?martech=off
- After: https://fqa-no-minheight--express--adobecom.hlx.page/express/feature/image/remove-background?martech=off
