### PR TITLE
[Pricing-Cards] Handle when specialPromo Doesn't Exist

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -98,7 +98,7 @@ function handlePrice(placeholders, pricingArea, placeholderArr, specialPromo, le
         specialPromoPercentageEyeBrowTextReplaced = true;
       }
     }
-    if (!isPremiumCard && specialPromo.parentElement.classList.contains('special-promo')) {
+    if (!isPremiumCard && specialPromo?.parentElement?.classList?.contains('special-promo')) {
       specialPromo.parentElement.classList.remove('special-promo');
       if (specialPromo.parentElement.firstChild.innerHTML !== '') {
         specialPromo.parentElement.firstChild.remove();


### PR DESCRIPTION
On some scenarios we don't have specialPromo, and this could prevent the page from throwing errors.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/pricing?martech=off
- After: https://pricing-cards-hotfix--express--adobecom.hlx.page/express/pricing?martech=off
