### PR TITLE
[Template-List][Analytics][Hemingway] Fix Hemingway tracking for Template-List

### DIFF
--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -205,6 +205,9 @@ export function sampleRUM(checkpoint, data = {}, forceSampleRate) {
 }
 
 export function getAssetDetails(el) {
+  if (el.tagName === 'PICTURE') {
+    return getAssetDetails(el.querySelector('img'));
+  }
   // Get asset details
   const assetUrl = new URL(
     el.href // the reference for an a/svg tag


### PR DESCRIPTION
As of now, template-list's tracking could crash, due to Hemingway only able to handle img but not picture. Although template-list will be retired soon, this PR should still fix its behavior and get us more tracking data before GA.

You can see that getAssetDetails crashing on stage but should be fixed in the branch link.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/spotlight/marketers
- After: https://tempate-list-hemingway-fix--express--adobecom.hlx.page/express/spotlight/marketers
