### PR TITLE
MWPW-143922 ensure mobile image loads on mobile devices for hero-anim…

### DIFF
--- a/express/blocks/hero-animation/hero-animation.js
+++ b/express/blocks/hero-animation/hero-animation.js
@@ -24,7 +24,7 @@ const animationBreakPointSettings = [
   },
   {
     typeHint: 'desktop',
-    minWidth: 400,
+    minWidth: 430,
   },
   {
     typeHint: 'hd',


### PR DESCRIPTION
the hero animation block used as LCP on the homepage is loading the desktop image currently on mobile devices. This is wrong. 

Resolves: [MWPW-143922](https://jira.corp.adobe.com/browse/MWPW-143922)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/?lighthouse=on
- After: https://mwpw-143922-homepage-mobile-perf-improvement--express--adobecom.hlx.page/express/?lighthouse=on

![image](https://github.com/adobecom/express/assets/115231412/114d6866-1cca-4c66-ba58-e2b034b53eea)

![image](https://github.com/adobecom/express/assets/115231412/fc02348e-7752-440b-bbbf-b48b88dee2dd)

