### PR TITLE
[Frictionless] Remove One Metadata Dependency

### DIFF
--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -711,7 +711,7 @@ function martechLoadedCB() {
   // Fire the landing:viewedPage event
   sendEventToAdobeAnaltics('landing:viewedPage');
 
-  if (getMetadata('quickaction-upload-page') === 'on') {
+  if (d.querySelector('div.frictionless-quick-action')) {
     sendEventToAdobeAnaltics('view-quickaction-upload-page');
   }
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -75,7 +75,6 @@ const eagerLoad = (img) => {
 (function handleSplit() {
   const { userAgent } = navigator;
   document.body.dataset.device = userAgent.includes('Mobile') ? 'mobile' : 'desktop';
-  if (getMetadata('quickaction-upload-page') !== 'on') return;
   const fqaMeta = createTag('meta', { content: 'on' });
   if (document.body.dataset.device === 'mobile'
     || (/Safari/.test(userAgent) && !/Chrome|CriOS|FxiOS|Edg|OPR|Opera|OPiOS|Vivaldi|YaBrowser|Avast|VivoBrowser|GSA/.test(userAgent))) {


### PR DESCRIPTION
One new metadata was introduced to differentiate frictionless pages from others, because we need to fire an extra "landing" event on frictionless pages. This PR will remove the need of using an extra metadata, and just rely on a dom scanning.

Resolves: https://jira.corp.adobe.com/browse/MWPW-146143

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/feature/image/remove-background
- After: https://fqa-rm-meta-dep--express--adobecom.hlx.page/express/feature/image/remove-background
