### PR TITLE
Template Accessibility Hover Fix

### DIFF
--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -314,7 +314,6 @@ function renderMediaWrapper(template, placeholders) {
     if (!renderedMedia) {
       renderedMedia = await renderRotatingMedias(mediaWrapper, template.pages, templateInfo);
       mediaWrapper.append(renderShareWrapper(branchUrl, placeholders));
-      mediaWrapper.querySelector('.icon')?.focus();
     }
     renderedMedia.hover();
     tabbingAllowed = false;
@@ -332,7 +331,6 @@ function renderMediaWrapper(template, placeholders) {
     if (!renderedMedia) {
       renderedMedia = await renderRotatingMedias(mediaWrapper, template.pages, templateInfo);
       mediaWrapper.append(renderShareWrapper(branchUrl, placeholders));
-      mediaWrapper.querySelector('.icon')?.focus();
       renderedMedia.hover();
     }
   };
@@ -371,7 +369,7 @@ async function renderHoverWrapper(template, placeholders) {
 
   if (isEligible) {
     const cta = renderCTA(placeholders, template.customLinks.branchUrl);
-    btnContainer.append(cta);
+    btnContainer.prepend(cta);
     cta.addEventListener('focusin', focusHandler);
   }
 

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -289,6 +289,8 @@ async function renderRotatingMedias(wrapper,
   return { cleanup, hover: playMedia };
 }
 
+let tabbingAllowed = true;
+
 function renderMediaWrapper(template, placeholders) {
   const mediaWrapper = createTag('div', { class: 'media-wrapper' });
 
@@ -315,15 +317,19 @@ function renderMediaWrapper(template, placeholders) {
       mediaWrapper.querySelector('.icon')?.focus();
     }
     renderedMedia.hover();
+    tabbingAllowed = false;
   };
   const leaveHandler = () => {
     document.activeElement.blur();
     if (renderedMedia) renderedMedia.cleanup();
+    tabbingAllowed = true;
   };
 
   const focusHandler = async (e) => {
     e.preventDefault();
     e.stopPropagation();
+    if (!tabbingAllowed) return;
+    //  document.dispatchEvent("mouseleave")
     if (!renderedMedia) {
       renderedMedia = await renderRotatingMedias(mediaWrapper, template.pages, templateInfo);
       mediaWrapper.append(renderShareWrapper(branchUrl, placeholders));
@@ -431,6 +437,11 @@ function renderStillWrapper(template, placeholders) {
 }
 
 export default async function renderTemplate(template, placeholders) {
+  document.onkeydown = (event) => {
+    if (event.code === 'Tab' && !tabbingAllowed) {
+      event.preventDefault();
+    }
+  }
   const tmpltEl = createTag('div');
   tmpltEl.append(renderStillWrapper(template, placeholders));
   tmpltEl.append(await renderHoverWrapper(template, placeholders));

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -320,7 +320,6 @@ function renderMediaWrapper(template, placeholders) {
     currentHoveredElement = e.target;
     currentHoveredElement?.classList.add('singleton-hover');
     document.activeElement.blur();
-    e?.target.querySelector('a').focus({ focusVisible: true });
   };
 
   const leaveHandler = () => {

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -329,7 +329,6 @@ function renderMediaWrapper(template, placeholders) {
     e.preventDefault();
     e.stopPropagation();
     if (!tabbingAllowed) return;
-    //  document.dispatchEvent("mouseleave")
     if (!renderedMedia) {
       renderedMedia = await renderRotatingMedias(mediaWrapper, template.pages, templateInfo);
       mediaWrapper.append(renderShareWrapper(branchUrl, placeholders));

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -320,7 +320,7 @@ function renderMediaWrapper(template, placeholders) {
     currentHoveredElement = e.target;
     currentHoveredElement?.classList.add('singleton-hover');
     document.activeElement.blur();
-    e.target.querySelector('a').focus({ focusVisible: true });
+    e?.target.querySelector('a').focus({ focusVisible: true });
   };
 
   const leaveHandler = () => {

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -317,6 +317,7 @@ function renderMediaWrapper(template, placeholders) {
     renderedMedia.hover();
   };
   const leaveHandler = () => {
+    document.activeElement.blur();
     if (renderedMedia) renderedMedia.cleanup();
   };
 

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -289,8 +289,6 @@ async function renderRotatingMedias(wrapper,
   return { cleanup, hover: playMedia };
 }
 
-let tabbingAllowed = true;
-
 function renderMediaWrapper(template, placeholders) {
   const mediaWrapper = createTag('div', { class: 'media-wrapper' });
 
@@ -316,18 +314,18 @@ function renderMediaWrapper(template, placeholders) {
       mediaWrapper.append(renderShareWrapper(branchUrl, placeholders));
     }
     renderedMedia.hover();
-    tabbingAllowed = false;
+    document.activeElement.blur();
+    e.target.querySelector('a').focus({ focusVisible: true });
   };
+
   const leaveHandler = () => {
     document.activeElement.blur();
     if (renderedMedia) renderedMedia.cleanup();
-    tabbingAllowed = true;
   };
 
   const focusHandler = async (e) => {
     e.preventDefault();
     e.stopPropagation();
-    if (!tabbingAllowed) return;
     if (!renderedMedia) {
       renderedMedia = await renderRotatingMedias(mediaWrapper, template.pages, templateInfo);
       mediaWrapper.append(renderShareWrapper(branchUrl, placeholders));
@@ -434,11 +432,6 @@ function renderStillWrapper(template, placeholders) {
 }
 
 export default async function renderTemplate(template, placeholders) {
-  document.onkeydown = (event) => {
-    if (event.code === 'Tab' && !tabbingAllowed) {
-      event.preventDefault();
-    }
-  };
   const tmpltEl = createTag('div');
   tmpltEl.append(renderStillWrapper(template, placeholders));
   tmpltEl.append(await renderHoverWrapper(template, placeholders));

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -289,6 +289,8 @@ async function renderRotatingMedias(wrapper,
   return { cleanup, hover: playMedia };
 }
 
+let currentHoveredElement;
+
 function renderMediaWrapper(template, placeholders) {
   const mediaWrapper = createTag('div', { class: 'media-wrapper' });
 
@@ -314,12 +316,14 @@ function renderMediaWrapper(template, placeholders) {
       mediaWrapper.append(renderShareWrapper(branchUrl, placeholders));
     }
     renderedMedia.hover();
+    currentHoveredElement?.classList.remove('singleton-hover');
+    currentHoveredElement = e.target;
+    currentHoveredElement?.classList.add('singleton-hover');
     document.activeElement.blur();
     e.target.querySelector('a').focus({ focusVisible: true });
   };
 
   const leaveHandler = () => {
-    document.activeElement.blur();
     if (renderedMedia) renderedMedia.cleanup();
   };
 
@@ -331,6 +335,9 @@ function renderMediaWrapper(template, placeholders) {
       mediaWrapper.append(renderShareWrapper(branchUrl, placeholders));
       renderedMedia.hover();
     }
+    currentHoveredElement?.classList.remove('singleton-hover');
+    currentHoveredElement = e.target;
+    currentHoveredElement?.classList.add('singleton-hover');
   };
 
   return {

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -438,7 +438,7 @@ export default async function renderTemplate(template, placeholders) {
     if (event.code === 'Tab' && !tabbingAllowed) {
       event.preventDefault();
     }
-  }
+  };
   const tmpltEl = createTag('div');
   tmpltEl.append(renderStillWrapper(template, placeholders));
   tmpltEl.append(await renderHoverWrapper(template, placeholders));

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -545,6 +545,18 @@ main.with-holiday-templates-banner {
     z-index: 2;
 }
 
+.template-x .template:hover:not(.placeholder) .button-container:not(.singleton-hover),
+.template-x.horizontal .template:hover:not(.placeholder) .button-container:not(.singleton-hover),
+.template-x.horizontal .template:hover:not(.placeholder) .template-link,
+.template-x.sixcols .template:hover:not(.placeholder) .button-container:not(.singleton-hover),
+.template-x.sixcols .template:hover:not(.placeholder) .template-link,
+.template-x.fullwidth .template:hover:not(.placeholder) .button-container:not(.singleton-hover),
+.template-x.fullwidth .template:hover:not(.placeholder) .template-link {
+    opacity: 0;
+    pointer-events: initial;
+    z-index: 2;
+}
+
 .template-x.horizontal .template:not(.placeholder) .template-link,
 .template-x.sixcols .template:not(.placeholder) .template-link,
 .template-x.fullwidth .template:not(.placeholder) .template-link {

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -500,6 +500,8 @@ main.with-holiday-templates-banner {
     will-change: opacity;
     pointer-events: none;
     z-index: 1;
+    display: flex;
+    flex-direction: column-reverse;
 }
 
 .template-x.horizontal .template:not(.placeholder) .button-container {


### PR DESCRIPTION
Describe your specific features or fixes

Fixes a condition where two template cards could be expanded at the same time due to new tabbing behavior. This Pr contains 2 fixes addressing that.

1) Templates have their focus automatically cleared when they are entered via tabbing and the mouse cursor moves to another template, ensuring only 1 template is expanded.

2) The tab key is disabled when the mouse cursor enters any template and enabled when the mouse cursor exits any template. This prevents a condition where a user mouses over a template then tabs to another template, causing 2 to be rendered at the same time. However, this disables tabbing behavior within the template itself. 

Resolves: https://jira.corp.adobe.com/browse/MWPW-146253

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://templates-accessibility-hover--express--adobecom.hlx.page/express/templates/
