### PR TITLE
Link list hotfix

### DIFF
--- a/express/blocks/link-list/link-list.js
+++ b/express/blocks/link-list/link-list.js
@@ -31,10 +31,16 @@ async function loadSpreadsheetData(block, relevantRowsData) {
   }
 }
 
-const formatBlockLinks = (links, variant, baseURL) => {
-  if (variant !== SMART_VARIANT) return;
+const formatSmartBlockLinks = (links, baseURL) => {
   if (!links || !baseURL) return;
-  const formattedURL = `${baseURL}?acomx-dno=true&category=templates`;
+
+  let url = baseURL;
+  const multipleURLs = baseURL?.replace(/\s/g, '').split(',');
+  if (multipleURLs.length > 0) {
+    [url] = multipleURLs;
+  }
+
+  const formattedURL = `${url}?acomx-dno=true&category=templates`;
   links.forEach((p) => {
     const a = p.querySelector('a');
     a.href = `${formattedURL}&q=${a.title}`;
@@ -104,6 +110,7 @@ export default async function decorate(block) {
     const { default: updateAsyncBlocks } = await import('../../scripts/template-ckg.js');
     await updateAsyncBlocks();
   }
-
-  formatBlockLinks(links, variant, placeholders['search-branch-links']?.replace(/\s/g, '').split(',')[0]);
+  if (variant === SMART_VARIANT) {
+    formatSmartBlockLinks(links, placeholders['search-branch-links']);
+  }
 }

--- a/express/blocks/link-list/link-list.js
+++ b/express/blocks/link-list/link-list.js
@@ -34,7 +34,6 @@ async function loadSpreadsheetData(block, relevantRowsData) {
 const formatBlockLinks = (links, variant, baseURL) => {
   if (variant !== SMART_VARIANT) return;
   if (!links || !baseURL) return;
-
   const formattedURL = `${baseURL}?acomx-dno=true&category=templates`;
   links.forEach((p) => {
     const a = p.querySelector('a');
@@ -106,5 +105,5 @@ export default async function decorate(block) {
     await updateAsyncBlocks();
   }
 
-  formatBlockLinks(links, variant, placeholders['search-branch-links']);
+  formatBlockLinks(links, variant, placeholders['search-branch-links']?.replace(/\s/g, '').split(',')[0]);
 }

--- a/express/blocks/link-list/link-list.js
+++ b/express/blocks/link-list/link-list.js
@@ -38,6 +38,8 @@ const formatSmartBlockLinks = (links, baseURL) => {
   const multipleURLs = baseURL?.replace(/\s/g, '').split(',');
   if (multipleURLs.length > 0) {
     [url] = multipleURLs;
+  } else {
+    return;
   }
 
   const formattedURL = `${url}?acomx-dno=true&category=templates`;


### PR DESCRIPTION
Describe your specific features or fixes

Resolves issue where multiple branch links caused the smart links to add urls twice, causing the feature to break

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://link-list-enhancements--express--adobecom.hlx.page/drafts/echen/templates/default
