### PR TITLE
[Performance] Template Eager Load LCP

### DIFF
--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -255,6 +255,7 @@ function decorateBackground(block) {
     if (media) {
       media.classList.add('backgroundimg');
       media.loading = 'eager';
+      media.setAttribute('fetchpriority', 'high');
       const wrapper = block.parentElement;
       if (wrapper.classList.contains('search-marquee-wrapper')) {
         wrapper.prepend(media);

--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -254,6 +254,7 @@ function decorateBackground(block) {
     const media = mediaRow.querySelector('picture img');
     if (media) {
       media.classList.add('backgroundimg');
+      media.loading = 'eager';
       const wrapper = block.parentElement;
       if (wrapper.classList.contains('search-marquee-wrapper')) {
         wrapper.prepend(media);

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -340,6 +340,21 @@ function renderMediaWrapper(template, placeholders) {
     mediaWrapper, enterHandler, leaveHandler, focusHandler,
   };
 }
+// temporary module sideeffect for mobile beta eligibility
+let isEligible = document.body.dataset.device === 'desktop' || !['yes', 'true', 'Y', 'on'].includes(getMetadata('mobile-benchmark'));
+if (!isEligible) {
+  const eligibility = BlockMediator.get('mobileBetaEligibility');
+  if (eligibility) {
+    isEligible = eligibility.deviceSupport;
+  } else {
+    isEligible = await new Promise((resolve) => {
+      const unsub = BlockMediator.subscribe('mobileBetaEligibility', (e) => {
+        resolve(e.newValue.deviceSupport);
+        unsub();
+      });
+    });
+  }
+}
 
 async function renderHoverWrapper(template, placeholders) {
   const btnContainer = createTag('div', { class: 'button-container' });
@@ -351,22 +366,6 @@ async function renderHoverWrapper(template, placeholders) {
   btnContainer.append(mediaWrapper);
   btnContainer.addEventListener('mouseenter', enterHandler);
   btnContainer.addEventListener('mouseleave', leaveHandler);
-
-  let isEligible = document.body.dataset.device === 'desktop' || !['yes', 'true', 'Y', 'on'].includes(getMetadata('mobile-benchmark'));
-
-  if (!isEligible) {
-    const eligibility = BlockMediator.get('mobileBetaEligibility');
-    if (eligibility) {
-      isEligible = eligibility.deviceSupport;
-    } else {
-      isEligible = await new Promise((resolve) => {
-        const unsub = BlockMediator.subscribe('mobileBetaEligibility', (e) => {
-          resolve(e.newValue.deviceSupport);
-          unsub();
-        });
-      });
-    }
-  }
 
   if (isEligible) {
     const cta = renderCTA(placeholders, template.customLinks.branchUrl);

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -1,5 +1,10 @@
 /* eslint-disable no-underscore-dangle */
-import { createTag, getIconElement, getMetadata } from '../../scripts/utils.js';
+import {
+  createTag,
+  getIconElement,
+  getMetadata,
+  yieldToMain,
+} from '../../scripts/utils.js';
 import BlockMediator from '../../scripts/block-mediator.min.js';
 
 function containsVideo(pages) {
@@ -432,6 +437,7 @@ function renderStillWrapper(template, placeholders) {
 export default async function renderTemplate(template, placeholders) {
   const tmpltEl = createTag('div');
   tmpltEl.append(renderStillWrapper(template, placeholders));
+  await yieldToMain();
   tmpltEl.append(await renderHoverWrapper(template, placeholders));
 
   return tmpltEl;

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -5,7 +5,6 @@ import {
   getMetadata,
   yieldToMain,
 } from '../../scripts/utils.js';
-import BlockMediator from '../../scripts/block-mediator.min.js';
 
 function containsVideo(pages) {
   return pages.some((page) => !!page?.rendition?.video?.thumbnail?.componentId);
@@ -340,23 +339,8 @@ function renderMediaWrapper(template, placeholders) {
     mediaWrapper, enterHandler, leaveHandler, focusHandler,
   };
 }
-// temporary module sideeffect for mobile beta eligibility
-let isEligible = document.body.dataset.device === 'desktop' || !['yes', 'true', 'Y', 'on'].includes(getMetadata('mobile-benchmark'));
-if (!isEligible) {
-  const eligibility = BlockMediator.get('mobileBetaEligibility');
-  if (eligibility) {
-    isEligible = eligibility.deviceSupport;
-  } else {
-    isEligible = await new Promise((resolve) => {
-      const unsub = BlockMediator.subscribe('mobileBetaEligibility', (e) => {
-        resolve(e.newValue.deviceSupport);
-        unsub();
-      });
-    });
-  }
-}
 
-async function renderHoverWrapper(template, placeholders) {
+async function renderHoverWrapper(template, placeholders, isEligible) {
   const btnContainer = createTag('div', { class: 'button-container' });
 
   const {
@@ -433,11 +417,11 @@ function renderStillWrapper(template, placeholders) {
   return stillWrapper;
 }
 
-export default async function renderTemplate(template, placeholders) {
+export default async function renderTemplate(template, placeholders, isEligible) {
   const tmpltEl = createTag('div');
   tmpltEl.append(renderStillWrapper(template, placeholders));
   await yieldToMain();
-  tmpltEl.append(await renderHoverWrapper(template, placeholders));
+  tmpltEl.append(await renderHoverWrapper(template, placeholders, isEligible));
 
   return tmpltEl;
 }

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -3,7 +3,6 @@ import {
   createTag,
   getIconElement,
   getMetadata,
-  yieldToMain,
 } from '../../scripts/utils.js';
 
 function containsVideo(pages) {
@@ -420,7 +419,6 @@ function renderStillWrapper(template, placeholders) {
 export default async function renderTemplate(template, placeholders, isEligible) {
   const tmpltEl = createTag('div');
   tmpltEl.append(renderStillWrapper(template, placeholders));
-  await yieldToMain();
   tmpltEl.append(await renderHoverWrapper(template, placeholders, isEligible));
 
   return tmpltEl;

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/named, import/extensions */
-
 import {
   createOptimizedPicture,
   createTag,

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -19,6 +19,7 @@ import { fetchTemplates, isValidTemplate, fetchTemplatesCategoryCount } from './
 import fetchAllTemplatesMetadata from '../../scripts/all-templates-metadata.js';
 import renderTemplate from './template-rendering.js';
 import isDarkOverlayReadable from '../../scripts/color-tools.js';
+import BlockMediator from '../../scripts/block-mediator.min.js';
 
 function wordStartsWithVowels(word) {
   return word.match('^[aieouâêîôûäëïöüàéèùœAIEOUÂÊÎÔÛÄËÏÖÜÀÉÈÙŒ].*');
@@ -37,9 +38,11 @@ function handlelize(str) {
     .toLowerCase(); // To lowercase
 }
 
-async function getTemplates(response, phs, fallbackMsg) {
+async function getTemplates(response, phs, fallbackMsg, isEligible) {
   const filtered = response.items.filter((item) => isValidTemplate(item));
-  const templates = await Promise.all(filtered.map((template) => renderTemplate(template, phs)));
+  const templates = await Promise.all(
+    filtered.map((template) => renderTemplate(template, phs, isEligible)),
+  );
   return {
     fallbackMsg,
     templates,
@@ -70,7 +73,7 @@ async function fetchAndRenderTemplates(props) {
   props.total = response.metadata.totalHits;
 
   // eslint-disable-next-line no-return-await
-  return await getTemplates(response, placeholders, fallbackMsg);
+  return await getTemplates(response, placeholders, fallbackMsg, props.isEligible);
 }
 
 async function processContentRow(block, props) {
@@ -1621,6 +1624,22 @@ export default async function decorate(block) {
   addTempWrapper(block, 'template-x');
 
   const props = constructProps(block);
+  // temporary for mobile beta eligibility
+  let isEligible = document.body.dataset.device === 'desktop' || !['yes', 'true', 'Y', 'on'].includes(getMetadata('mobile-benchmark'));
+  if (!isEligible) {
+    const eligibility = BlockMediator.get('mobileBetaEligibility');
+    if (eligibility) {
+      isEligible = eligibility.deviceSupport;
+    } else {
+      isEligible = await new Promise((resolve) => {
+        const unsub = BlockMediator.subscribe('mobileBetaEligibility', (e) => {
+          resolve(e.newValue.deviceSupport);
+          unsub();
+        });
+      });
+    }
+  }
+  props.isEligible = isEligible;
   block.innerHTML = '';
   await buildTemplateList(block, props, determineTemplateXType(props));
 }


### PR DESCRIPTION
Low hanging fruit before GA by eager loading an svg. Earlier the LCP was another png, but with staged content it's become this SVG that is lazy-loaded by default. Next step is to replace it with an updated and smaller webp image.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/templates/flyer?lighthouse=on
- After: https://template-eager-background--express--adobecom.hlx.page/express/templates/flyer?lighthouse=on

<img width="1508" alt="SC 2024-04-12 at 2 05 02 PM" src="https://github.com/adobecom/express/assets/32369333/e2e65247-9402-4dc9-904e-0c92f380f69b">
