### PR TITLE
[Mobile GA] Remove Mobile Templates Section Top Padding

### DIFF
--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -1,6 +1,7 @@
 /* templates pages spacial styling */
 div[class='section section-wrapper template-x-container'],
-div[class='section section-wrapper browse-by-category-card-fullwidth-container template-x-container'] {
+div[class='section section-wrapper browse-by-category-card-fullwidth-container template-x-container'],
+div[data-audience="mobile"].section.section-wrapper.template-x-container {
     padding-top: 0;
 }
 


### PR DESCRIPTION
Adding an extra condition for removing top padding. Eventually we need to consolidate how to manage section's margin and padding.

Resolves: https://jira.corp.adobe.com/browse/MWPW-146548

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/create/cover/album?lighthouse=on
- After: https://template-mobile-section-pt--express--adobecom.hlx.page/express/create/cover/album?lighthouse=on
