### PR TITLE
De template fix

### DIFF
--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -411,7 +411,7 @@ main.with-holiday-templates-banner {
 
 .template-x.horizontal.mini .template {
     min-height: unset;
-    min-width: 80px;
+    min-width: 64px;
     max-height: 100px;
     max-width: 200px;
     margin: 0 4px;

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -411,7 +411,7 @@ main.with-holiday-templates-banner {
 
 .template-x.horizontal.mini .template {
     min-height: unset;
-    min-width: 64px;
+    min-width: 80px;
     max-height: 100px;
     max-width: 200px;
     margin: 0 4px;


### PR DESCRIPTION
Describe your specific features or fixes

Bumps min width for text bubbles in mobile templates to 80px so it can fit other languages like German

Resolves: https://jira.corp.adobe.com/browse/MWPW-146623

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://de-template-fix--express--adobecom.hlx.page/express/create/flyer
<img width="500" alt="Screenshot 2024-04-15 at 9 42 30 AM" src="https://github.com/adobecom/express/assets/159481679/0edd91c6-29bf-4f22-bf40-00239b0baa2e">
<img width="515" alt="Screenshot 2024-04-15 at 9 42 47 AM" src="https://github.com/adobecom/express/assets/159481679/6b78e821-e958-4342-924c-1cec2f7c4686">

