### PR TITLE
Last Minute CSS Fixes 

### DIFF
--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -258,10 +258,10 @@
   main .section .free-plan-container {
     margin : auto;
   }
-  .fullscreen-marquee .fullscreen-marquee-heading h1 {
+  .fullscreen-marquee.centered .fullscreen-marquee-heading h1 {
     text-align: center;
   }
-  .fullscreen-marquee .fullscreen-marquee-heading h1 + p{
+  .fullscreen-marquee.centered .fullscreen-marquee-heading h1 + p{
     text-align: center;
   }
 }

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -254,6 +254,12 @@
   margin: 0;
 }
 
+@media (max-width: 900px) {
+  main .section .free-plan-container {
+    margin : auto;
+  }
+}
+
 @media (min-width: 900px) {
   .section > .fullscreen-marquee {
     padding-bottom: 40px;

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -258,6 +258,12 @@
   main .section .free-plan-container {
     margin : auto;
   }
+  .fullscreen-marquee .fullscreen-marquee-heading h1 {
+    text-align: center;
+  }
+  .fullscreen-marquee .fullscreen-marquee-heading h1 + p{
+    text-align: center;
+  }
 }
 
 @media (min-width: 900px) {

--- a/express/blocks/hero-color/hero-color.css
+++ b/express/blocks/hero-color/hero-color.css
@@ -51,8 +51,9 @@ main .hero-color .text-container p {
 }
 
 main .hero-color .text-container .button-container {
-  margin: 0;
+  margin: auto;
   text-align: left;
+  width: fit-content;
 }
 
 main .hero-color .text-container .button-container .button {

--- a/express/blocks/hero-color/hero-color.css
+++ b/express/blocks/hero-color/hero-color.css
@@ -85,6 +85,10 @@ main .hero-color .hidden-svg {
   main .hero-color .text-container {
     padding: 32px;
   }
+  main .hero-color .text-container .button-container  {
+    margin: 0;
+    text-align: left;
+  }
 }
 
 @media screen and (min-width: 900px) {


### PR DESCRIPTION
Describe your specific features or fixes

Will update as I go along.

1) Center the button for hero color block on mobile.
2) Centered free plan button for fullscreen marquee
3) Center the text for fullscreen marquee on mobile resolutions, but only if a `centered` variant is specified by authors
<img width="546" alt="Screenshot 2024-04-15 at 11 22 40 AM" src="https://github.com/adobecom/express/assets/159481679/149dbbdb-43a4-4803-83df-ca6c16d456a7">
<img width="458" alt="Screenshot 2024-04-15 at 11 22 54 AM" src="https://github.com/adobecom/express/assets/159481679/02a7156d-cd3d-42ca-ab1c-549532dbbfd8">

<img width="483" alt="Screenshot 2024-04-16 at 11 11 00 AM" src="https://github.com/adobecom/express/assets/159481679/0cff0a2b-b2b3-4410-86bb-205d9dafb71e">

<img width="459" alt="Screenshot 2024-04-22 at 1 04 02 PM" src="https://github.com/adobecom/express/assets/159481679/f5140df5-ea76-413b-91f8-47fa8546652e">


Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://last-min-css-fixes--express--adobecom.hlx.page/express/colors/red
