### PR TITLE
Revert animation minwidth

### DIFF
--- a/express/blocks/hero-animation/hero-animation.js
+++ b/express/blocks/hero-animation/hero-animation.js
@@ -24,7 +24,7 @@ const animationBreakPointSettings = [
   },
   {
     typeHint: 'desktop',
-    minWidth: 430,
+    minWidth: 400,
   },
   {
     typeHint: 'hd',


### PR DESCRIPTION
This old change could break hero-animation for devices below 430px width. We definitely need a serious refactor of hero-animation soon

Test URLs:
- Before: https://stage--express--adobecom.hlx.live/express/templates/?lighthouse=on
- After: https://hero-animation-hotfix--express--adobecom.hlx.live/express/templates/?lighthouse=on
