### PR TITLE
[Sidekick][QA-Guide][Mobile-GA] Enable qa-guide on Prod

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -46,7 +46,7 @@
       "containerId": "tools",
       "id": "qa-guide",
       "title": "QA Guide",
-      "environments": ["dev", "preview", "live"],
+      "environments": ["dev", "preview", "live", "prod"],
       "event": "qa-guide"
     },
     {


### PR DESCRIPTION
Enable using qa-guide on prod

Resolves: https://jira.corp.adobe.com/browse/MWPW-146637

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/?lighthouse=on
- After: https://qa-guide--express--adobecom.hlx.page/express/?lighthouse=on
