### PR TITLE
[Mobile GA][FloatingCTA]Remove Self-Opening Controlled by Delay Column

### DIFF
--- a/express/blocks/multifunction-button/multifunction-button.css
+++ b/express/blocks/multifunction-button/multifunction-button.css
@@ -56,10 +56,6 @@ main .floating-button-wrapper.multifunction.with-transition .toolbox:after {
     transition: 0.5s;
 }
 
-main .floating-button-wrapper.multifunction.with-transition.initial-load .toolbox {
-    transition: max-height 2s ease, padding 0.5s ease-in;
-}
-
 main .floating-button-wrapper.multifunction .toolbox.hidden {
     display: none;
 }
@@ -185,10 +181,6 @@ main .floating-button-wrapper.multifunction.toolbox-opened .toolbox-background {
     pointer-events: auto;
     background-color: var(--color-black);
     opacity: 0.75;
-}
-
-main .floating-button-wrapper.multifunction.with-transition.initial-load .toolbox-background {
-    transition: all 2s;
 }
 
 main .floating-button-wrapper.multifunction.floating-button--hidden .toolbox,

--- a/express/blocks/multifunction-button/multifunction-button.js
+++ b/express/blocks/multifunction-button/multifunction-button.js
@@ -13,18 +13,10 @@ import {
   closeToolBox,
 } from '../shared/floating-cta.js';
 
-function toggleMultifunctionToolBox(wrapper, lottie, data, userInitiated = true) {
+function toggleMultifunctionToolBox(wrapper, lottie, data) {
   wrapper.classList.add('with-transition');
-  if (userInitiated) {
-    wrapper.classList.remove('initial-load');
-  }
-  if (wrapper.classList.contains('initial-load') && wrapper.classList.contains('closed')) {
-    wrapper.classList.remove('closed');
-    return;
-  }
-
   if (wrapper.classList.contains('toolbox-opened')) {
-    openToolBox(wrapper, lottie, data, userInitiated);
+    openToolBox(wrapper, lottie, data);
   } else {
     closeToolBox(wrapper, lottie);
   }

--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -24,7 +24,7 @@ export const showScrollArrow = (floatButtonWrapper, lottieScrollButton) => {
   if (lottieScrollButton) lottieScrollButton.removeAttribute('tabIndex');
 };
 
-export function openToolBox(wrapper, lottie, data, userInitiated) {
+export function openToolBox(wrapper, lottie, data) {
   const toolbox = wrapper.querySelector('.toolbox');
   const button = wrapper.querySelector('.floating-button');
 
@@ -33,23 +33,13 @@ export function openToolBox(wrapper, lottie, data, userInitiated) {
     showScrollArrow(wrapper, lottie);
   }
   wrapper.classList.remove('toolbox-opened');
-  if (userInitiated) {
-    setTimeout(() => {
-      if (!wrapper.classList.contains('toolbox-opened')) {
-        toolbox.classList.add('hidden');
-        wrapper.classList.remove('clamped');
-        button.classList.remove('toolbox-opened');
-      }
-    }, 500);
-  } else {
-    setTimeout(() => {
-      if (wrapper.classList.contains('initial-load')) {
-        toolbox.classList.add('hidden');
-        wrapper.classList.remove('clamped');
-        button.classList.remove('toolbox-opened');
-      }
-    }, 2000);
-  }
+  setTimeout(() => {
+    if (!wrapper.classList.contains('toolbox-opened')) {
+      toolbox.classList.add('hidden');
+      wrapper.classList.remove('clamped');
+      button.classList.remove('toolbox-opened');
+    }
+  }, 500);
 }
 
 export function closeToolBox(wrapper, lottie) {
@@ -333,7 +323,6 @@ export async function collectFloatingButtonData() {
     scrollState: 'withLottie',
     showAppStoreBadge: true,
     useLottieArrow: true,
-    delay: 0,
     tools: [],
     appStore: {},
     mainCta: {},
@@ -342,10 +331,6 @@ export async function collectFloatingButtonData() {
   dataArray.forEach((col, index, array) => {
     const key = col[0];
     const value = col[1];
-
-    if (key === 'delay') {
-      data.delay = value;
-    }
 
     if (key === 'desktop cta link') {
       data.mainCta.desktopHref = value;
@@ -457,17 +442,6 @@ export function buildToolBoxStructure(wrapper, data) {
     toolBox.append(appStoreBadge);
     appStoreBadge.href = data.appStore.href ? data.appStore.href : data.tools[0].anchor.href;
   }
-
-  if (data.delay > 0) {
-    wrapper.classList.add('initial-load');
-    wrapper.classList.add('clamped');
-    if (wrapper.classList.contains('closed')) {
-      toolBox.classList.add('hidden');
-    } else {
-      wrapper.classList.add('toolbox-opened');
-      floatingButton.classList.add('toolbox-opened');
-    }
-  }
 }
 
 export function initToolBox(wrapper, data, toggleFunction) {
@@ -477,14 +451,6 @@ export function initToolBox(wrapper, data, toggleFunction) {
   const lottie = wrapper.querySelector('.floating-button-lottie');
   const notch = wrapper.querySelector('.notch');
   const background = wrapper.querySelector('.toolbox-background');
-
-  if (data.delay > 0) {
-    setTimeout(() => {
-      if (wrapper.classList.contains('initial-load')) {
-        toggleFunction(wrapper, lottie, data, false);
-      }
-    }, data.delay * 1000);
-  }
 
   cta.addEventListener('click', (e) => {
     if (!wrapper.classList.contains('toolbox-opened')) {


### PR DESCRIPTION
Self opening floatingCTA is no longer wanted. This will remove the behavior for multifunction-button. Bubble-UI and Mobile-Drawer remains untouched. On the branch link you should see that floatingCTA no longer expands itself.

Resolves: second requirement of https://jira.corp.adobe.com/browse/MWPW-145180?filter=381833

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/create/flyer?lighthouse=on
- After: https://fcta-no-delay--express--adobecom.hlx.page/express/create/flyer?lighthouse=on
