### PR TITLE
[Mobile-GA] Added section metadata for no padding

### DIFF
--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -728,6 +728,10 @@ main .section {
   padding-top: 60px;
 }
 
+main .section[data-padding='none'] {
+  padding: 0;
+}
+
 main .section.secondary {
   background-color: var(--color-gray-100);
 }


### PR DESCRIPTION
Added an authoring option in the form of section metadata to remove padding of any sections.

Resolves: https://jira.corp.adobe.com/browse/MWPW-146697

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/
- After: https://section-no-padding--express--adobecom.hlx.page/express/?lighthouse=on

![SC 2024-04-16 at 6 30 05 PM](https://github.com/adobecom/express/assets/32369333/fe2e2bb1-1f47-4446-a9c4-4f8775b1fd13)
