### PR TITLE
Template Placeholder Card Fix

### DIFF
--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -668,6 +668,23 @@ main.with-holiday-templates-banner {
     align-items: center;
 }
 
+.template-x .wide.template.placeholder.h34{
+    margin-top: 10px;
+    margin-bottom: 0;
+    width: 165px;
+    margin-left: 5px;
+    
+}
+
+.template-x .wide.template.placeholder.h34 > div:first-of-type{
+    display: none;
+}
+
+.template-x .wide.template.placeholder.h34 > div:nth-of-type(2){
+    bottom: -1%;
+    background: none;
+}
+
 .template-x.sm-view .template.placeholder > div:first-of-type {
     height: 60%;
 }
@@ -694,10 +711,6 @@ main.with-holiday-templates-banner {
 
 .template-x .template.placeholder .template-link::after {
     display: none;
-}
-
-.template-x .template.placeholder.wide > div:first-of-type {
-    height: 65%;
 }
 
 .template-x .template.placeholder.wide > div:first-of-type > img,
@@ -2400,9 +2413,26 @@ nav ol.templates-breadcrumbs li:not(:first-child):before {
     }
 
     .template-x.sixcols:not(.horizontal) .template.placeholder,
+
     .template-x.fullwidth .template.placeholder {
         width: 145px;
         margin: 21px auto;
+    }
+
+    .template-x.sixcols:not(.horizontal) .template.placeholder.h34{
+        margin-top: 10px;
+        margin-bottom: 0;
+        width: 165px;
+        margin-left: 5px;      
+    }
+    
+    .template-x.sixcols:not(.horizontal) .template.placeholder.h34 > div:first-of-type{
+        display: none;
+    }
+    
+    .template-x.sixcols:not(.horizontal) .template.placeholder.h34 > div:nth-of-type(2){
+        bottom: -1%;
+        background: none;
     }
 
     .columns .template-x-inner-wrapper {

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -699,6 +699,10 @@ main.with-holiday-templates-banner {
     display: none;
 }
 
+.template-x .template.placeholder.short {
+    margin-bottom: 0px;
+}
+
 .template-x .template.placeholder.wide > div:first-of-type > img,
 .template-x .template.placeholder.wide > div:first-of-type > svg {
     width: 24px;

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -615,12 +615,6 @@ main.with-holiday-templates-banner {
     margin: 0 11px;
 }
 
-.template-x.sixcols:not(.horizontal) .template.placeholder,
-.template-x.fullwidth .template.placeholder {
-    width: 145px;
-    margin: 15px auto;
-}
-
 .template-x.fullwidth.lg-view .template.placeholder,
 .template-x.fullwidth.md-view .template.placeholder,
 .template-x.fullwidth.sm-view .template.placeholder {
@@ -668,19 +662,11 @@ main.with-holiday-templates-banner {
     align-items: center;
 }
 
-.template-x .wide.template.placeholder.h34{
-    margin-top: 5px;
-    margin-bottom: 0;
-    width: 165px;
-    margin-left: 5px;
-    height:40px !important;   
-}
-
-.template-x .wide.template.placeholder.h34 > div:first-of-type{
+.template-x .wide.template.placeholder.short > div:first-of-type{
     display: none;
 }
 
-.template-x .wide.template.placeholder.h34 > div:nth-of-type(2){
+.template-x .wide.template.placeholder.short > div:nth-of-type(2){
     bottom: 10%;
     background: none;
 }
@@ -2410,30 +2396,6 @@ nav ol.templates-breadcrumbs li:not(:first-child):before {
 
     .template-x.horizontal.fullwidth .template:not(.placeholder) {
         margin: 24px 11px 18px 11px;
-    }
-
-    .template-x.sixcols:not(.horizontal) .template.placeholder,
-
-    .template-x.fullwidth .template.placeholder {
-        width: 145px;
-        margin: 21px auto;
-    }
-
-    .template-x.sixcols:not(.horizontal) .template.placeholder.h34{
-        margin-top: 5px;
-        margin-bottom: 0;
-        width: 165px;
-        margin-left: 5px; 
-        height:40px !important;     
-    }
-    
-    .template-x.sixcols:not(.horizontal) .template.placeholder.h34 > div:first-of-type{
-        display: none;
-    }
-    
-    .template-x.sixcols:not(.horizontal) .template.placeholder.h34 > div:nth-of-type(2){
-        bottom: 10%;
-        background: none;
     }
 
     .columns .template-x-inner-wrapper {

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -669,11 +669,11 @@ main.with-holiday-templates-banner {
 }
 
 .template-x .wide.template.placeholder.h34{
-    margin-top: 10px;
+    margin-top: 5px;
     margin-bottom: 0;
     width: 165px;
     margin-left: 5px;
-    
+    height:40px !important;   
 }
 
 .template-x .wide.template.placeholder.h34 > div:first-of-type{
@@ -681,7 +681,7 @@ main.with-holiday-templates-banner {
 }
 
 .template-x .wide.template.placeholder.h34 > div:nth-of-type(2){
-    bottom: -1%;
+    bottom: 10%;
     background: none;
 }
 
@@ -2420,10 +2420,11 @@ nav ol.templates-breadcrumbs li:not(:first-child):before {
     }
 
     .template-x.sixcols:not(.horizontal) .template.placeholder.h34{
-        margin-top: 10px;
+        margin-top: 5px;
         margin-bottom: 0;
         width: 165px;
-        margin-left: 5px;      
+        margin-left: 5px; 
+        height:40px !important;     
     }
     
     .template-x.sixcols:not(.horizontal) .template.placeholder.h34 > div:first-of-type{
@@ -2431,7 +2432,7 @@ nav ol.templates-breadcrumbs li:not(:first-child):before {
     }
     
     .template-x.sixcols:not(.horizontal) .template.placeholder.h34 > div:nth-of-type(2){
-        bottom: -1%;
+        bottom: 10%;
         background: none;
     }
 

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -41,10 +41,6 @@ main.with-holiday-templates-banner > div[class='section section-wrapper template
     text-align: left;
 }
 
-.template-x.template-x-complete .template-x-inner-wrapper {
-    min-height: unset;
-}
-
 .template-x-horizontal-fullwidth-collaboration-container .default-content-wrapper h2,
 .template-x-horizontal-fullwidth-collaboration-container .default-content-wrapper h3,
 .template-x-horizontal-fullwidth-collaboration-container .default-content-wrapper p {
@@ -606,6 +602,13 @@ main.with-holiday-templates-banner {
     margin: 21px auto 53px;
     padding: 0;
 }
+
+
+.template-x.template-x-complete .template.placeholder {
+    height: unset !important;
+    margin: 0 0 30px 0;
+} 
+
 
 .template-x.horizontal .template.placeholder,
 .template-x.horizontal.fullwidth .template.placeholder {
@@ -2202,6 +2205,7 @@ nav ol.templates-breadcrumbs li:not(:first-child):before {
         margin-left: 16px;
         margin-right: 16px;
     }
+
 }
 
 @media (max-width: 900px) {
@@ -2224,6 +2228,11 @@ nav ol.templates-breadcrumbs li:not(:first-child):before {
     .template-x.horizontal.holiday .toggle-bar {
         margin-top: 10px;
     }
+
+
+    .template-x.template-x-complete .template.placeholder {
+        height: auto;
+    } 
 }
 
 @media (max-width: 1200px) {

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -262,7 +262,6 @@ function populateTemplates(block, props, templates) {
       // look for options in last cell
       const overlayCell = tmplt.querySelector(':scope > div:last-of-type');
       const option = overlayCell.textContent.trim();
-      console.log(option, isPlaceholder)
       if (option) {
         if (isPlaceholder) {
           // add aspect ratio to template
@@ -271,7 +270,6 @@ function populateTemplates(block, props, templates) {
           props.placeholderFormat = ratios;
           if (block.classList.contains('horizontal')) {
             const height = block.classList.contains('mini') ? 100 : 200;
-          
             if (ratios[1]) {
               const width = (ratios[0] / ratios[1]) * height;
               tmplt.style = `width: ${width}px`;
@@ -283,8 +281,8 @@ function populateTemplates(block, props, templates) {
             const width = block.classList.contains('sixcols') || block.classList.contains('fullwidth') ? 165 : 200;
             if (ratios[1]) {
               const height = (ratios[1] / ratios[0]) * width;
-              tmplt.style = `height: ${height}px`;
-              if (height < 62) tmplt.classList.add(`short`);
+              tmplt.style.height = `${height}px`;
+              if (height < 62) tmplt.classList.add('short');
               if (width / height > 1.3) tmplt.classList.add('wide');
             }
           }
@@ -1005,12 +1003,11 @@ function toggleMasonryView(block, props, button, toggleButtons) {
 
   if (ratios[1]) {
     const height = (ratios[1] / ratios[0]) * width;
-    placeholder.style = `height: ${height}px`;
+    placeholder.style.height = `${height}px`;
     if (width / height > 1.3) {
       placeholder.classList.add('wide');
     }
   }
-
 }
 
 function initViewToggle(block, props, toolBar) {

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -262,6 +262,7 @@ function populateTemplates(block, props, templates) {
       // look for options in last cell
       const overlayCell = tmplt.querySelector(':scope > div:last-of-type');
       const option = overlayCell.textContent.trim();
+      console.log(option, isPlaceholder)
       if (option) {
         if (isPlaceholder) {
           // add aspect ratio to template
@@ -270,6 +271,7 @@ function populateTemplates(block, props, templates) {
           props.placeholderFormat = ratios;
           if (block.classList.contains('horizontal')) {
             const height = block.classList.contains('mini') ? 100 : 200;
+          
             if (ratios[1]) {
               const width = (ratios[0] / ratios[1]) * height;
               tmplt.style = `width: ${width}px`;
@@ -282,6 +284,7 @@ function populateTemplates(block, props, templates) {
             if (ratios[1]) {
               const height = (ratios[1] / ratios[0]) * width;
               tmplt.style = `height: ${height - 21}px`;
+              tmplt.classList.add(`h${height - 21}`);
               if (width / height > 1.3) {
                 tmplt.classList.add('wide');
               }
@@ -1009,6 +1012,7 @@ function toggleMasonryView(block, props, button, toggleButtons) {
       placeholder.classList.add('wide');
     }
   }
+
 }
 
 function initViewToggle(block, props, toolBar) {

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -283,11 +283,9 @@ function populateTemplates(block, props, templates) {
             const width = block.classList.contains('sixcols') || block.classList.contains('fullwidth') ? 165 : 200;
             if (ratios[1]) {
               const height = (ratios[1] / ratios[0]) * width;
-              tmplt.style = `height: ${height - 21}px`;
-              tmplt.classList.add(`h${height - 21}`);
-              if (width / height > 1.3) {
-                tmplt.classList.add('wide');
-              }
+              tmplt.style = `height: ${height}px`;
+              if (height < 62) tmplt.classList.add(`short`);
+              if (width / height > 1.3) tmplt.classList.add('wide');
             }
           }
         } else {
@@ -1007,7 +1005,7 @@ function toggleMasonryView(block, props, button, toggleButtons) {
 
   if (ratios[1]) {
     const height = (ratios[1] / ratios[0]) * width;
-    placeholder.style = `height: ${height - 21}px`;
+    placeholder.style = `height: ${height}px`;
     if (width / height > 1.3) {
       placeholder.classList.add('wide');
     }


### PR DESCRIPTION
Describe your specific features or fixes

Fixes issues with the placeholder icon for the template-x-complete version of template-x. At some point in time the placeholder icon for short templates (less than 40px) became misaligned across multiple pages. These changes aim to redress that. 

Resolves:[ [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)](https://jira.corp.adobe.com/browse/MWPW-146707)
<img width="820" alt="Screenshot 2024-04-16 at 10 31 04 AM" src="https://github.com/adobecom/express/assets/159481679/23754308-3ff8-4b11-a837-dff5bfb62e91">

<img width="1475" alt="Screenshot 2024-04-16 at 10 30 10 AM" src="https://github.com/adobecom/express/assets/159481679/3cb163e1-4bea-4e98-9e9f-3418d2e98986">

<img width="916" alt="Screenshot 2024-04-16 at 2 05 53 PM" src="https://github.com/adobecom/express/assets/159481679/737aaa11-b3ec-44b8-ab8c-3947efe50322">
<img width="810" alt="Screenshot 2024-04-16 at 2 06 53 PM" src="https://github.com/adobecom/express/assets/159481679/b5f07826-0611-46cb-b381-eb708c7f7009">


Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://jp-templates-fix--express--adobecom.hlx.page/jp/express/create/banner
https://jp-templates-fix--express--adobecom.hlx.page/fr/express/create/banner/linkedin