### PR TITLE
[Frictionless][SEO] - Support authoring DOM structure Change

### DIFF
--- a/express/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -96,7 +96,7 @@
     padding: 40px 24px 0 24px;
 }
 
-.frictionless-quick-action.block .dropzone p:first-of-type {
+.frictionless-quick-action.block .dropzone-bg + p {
     margin: 0;
     padding: 39px 24px 0 24px;
     font-size: var(--heading-font-size-m);
@@ -104,7 +104,7 @@
     line-height: var(--heading-line-height);
 }
 
-.frictionless-quick-action.block .dropzone p:first-of-type em {
+.frictionless-quick-action.block .dropzone-bg + p em {
     font-style: normal;
     color: var(--color-info-accent);
 }

--- a/express/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -52,6 +52,7 @@
     max-width: 444px;
 }
 
+/* TODO: remove after authoring removes h4 */
 .frictionless-quick-action.block h4 em {
     font-style: normal;
     color: var(--color-info-accent);
@@ -89,9 +90,23 @@
     position: relative;
 }
 
+/* TODO: remove after authoring removes h4 */
 .frictionless-quick-action.block .dropzone h4 {
     margin-top: 0;
     padding: 40px 24px 0 24px;
+}
+
+.frictionless-quick-action.block .dropzone p:first-of-type {
+    margin: 0;
+    padding: 39px 24px 0 24px;
+    font-size: var(--heading-font-size-m);
+    font-weight: var(--heading-font-weight);
+    line-height: var(--heading-line-height);
+}
+
+.frictionless-quick-action.block .dropzone p:first-of-type em {
+    font-style: normal;
+    color: var(--color-info-accent);
 }
 
 .frictionless-quick-action.block .dropzone p:last-of-type {
@@ -112,7 +127,7 @@
     background-color: unset;
     flex-direction: row;
     padding: unset;
-    margin: 8px auto 0 auto;
+    margin: 16px auto 0 auto;
     gap: 8px;
 }
 


### PR DESCRIPTION
Using a normal p instead of h4 will maintain a more natural h1->h2 flow for better SEO. This should be a backward compatible update. Once authors change all the h4 to normal p, we can remove the unused css.

Resolves: https://jira.corp.adobe.com/browse/MWPW-146333

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/feature/image/remove-background?lighthouse=on
- After: https://fqa-seo--express--adobecom.hlx.page/express/feature/image/remove-background?lighthouse=on
- After replacing h4 with normal paragraph in word doc, it will be like: https://fqa-seo--express--adobecom.hlx.page/drafts/jingle/remove-background-copy?lighthouse=on
