### PR TITLE
[MWPW-147065] Adds Alt Text To How To Steps Carousel 

### DIFF
--- a/express/blocks/how-to-steps-carousel/how-to-steps-carousel.js
+++ b/express/blocks/how-to-steps-carousel/how-to-steps-carousel.js
@@ -270,6 +270,7 @@ export default async function decorate(block) {
     const placeholderImgUrl = createTag('div');
     const placeholders = await fetchPlaceholders();
     const url = placeholders['how-to-steps-carousel-image-app'];
+    const alt = block.querySelector('picture > img').getAttribute('alt');
     const eagerLoad = document.querySelector('.block') === block;
     const backgroundPic = createOptimizedPicture(url, 'template in express', eagerLoad);
     const backgroundPicImg = backgroundPic.querySelector('img', { alt: 'template in express' });
@@ -304,6 +305,7 @@ export default async function decorate(block) {
             const blobUrl = URL.createObjectURL(blob);
             img.src = blobUrl;
             backgroundPic.append(img);
+            img.alt = alt;
             backgroundPicImg.remove();
             setPictureHeight(block, true);
           });


### PR DESCRIPTION
Describe your specific features or fixes

Adds the alt text to the image in the how to steps carousel. Previously it was being lost due to the image being completely reconstructed. 

Resolves: https://jira.corp.adobe.com/browse/MWPW-147065

<img width="1790" alt="Screenshot 2024-04-23 at 11 41 08 AM" src="https://github.com/adobecom/express/assets/159481679/be365196-d302-4193-9cbb-1e95bcb9f915">


Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://alt-text-how-to--express--adobecom.hlx.page/express/create/curriculum-vitae
