### PR TITLE
[SEO] Deep Links No Follow

### DIFF
--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -223,9 +223,10 @@ export async function trackBranchParameters($links) {
     params.get('cgen'),
   ];
 
-  $links.forEach(($a) => {
-    if ($a.href && $a.href.match('adobesparkpost.app.link')) {
-      const btnUrl = new URL($a.href);
+  $links.forEach((a) => {
+    if (a.href && a.href.match('adobesparkpost.app.link')) {
+      a.rel = 'nofollow';
+      const btnUrl = new URL(a.href);
       const isSearchBranchLink = placeholders['search-branch-links']?.replace(/\s/g, '').split(',').includes(`${btnUrl.origin}${btnUrl.pathname}`);
       const urlParams = btnUrl.searchParams;
       const setParams = (k, v) => {
@@ -234,10 +235,10 @@ export async function trackBranchParameters($links) {
       if (urlParams.has('acomx-dno')) {
         urlParams.delete('acomx-dno');
         btnUrl.search = urlParams.toString();
-        $a.href = decodeURIComponent(btnUrl.toString());
+        a.href = decodeURIComponent(btnUrl.toString());
         return;
       }
-      const placement = getPlacement($a);
+      const placement = getPlacement(a);
 
       if (isSearchBranchLink) {
         setParams('category', category || 'templates');
@@ -285,7 +286,7 @@ export async function trackBranchParameters($links) {
       experimentStatus === 'active' && setParams('expid', `${experiment.id}-${experiment.selectedVariant}`);
 
       btnUrl.search = urlParams.toString();
-      $a.href = decodeURIComponent(btnUrl.toString());
+      a.href = decodeURIComponent(btnUrl.toString());
     }
   });
 }


### PR DESCRIPTION
Deep links or branch links will now have nofollow tags. Removed a few dollar signs BTW.
You can verify by inspecting on the homepage any anchors linking to adobesparkpost

Resolves: https://jira.corp.adobe.com/browse/MWPW-146309

Test URLs:
- Before: https://stage--express--adobecom.hlx.live/express/?gnav=off
- After: https://branch-link-no-follow--express--adobecom.hlx.live/express/?gnav=off
