### PR TITLE
[SEO] CKG Pills nofollow

### DIFF
--- a/express/scripts/template-ckg.js
+++ b/express/scripts/template-ckg.js
@@ -46,11 +46,21 @@ async function fetchLinkList() {
   }
 }
 
+const searchRegex = /\/search\?/;
+function isSearch(pathname) {
+  return searchRegex.test(pathname);
+}
+
 function replaceLinkPill(linkPill, data) {
   const clone = linkPill.cloneNode(true);
   if (data) {
     clone.innerHTML = clone.innerHTML.replace('/express/templates/default', data.url);
     clone.innerHTML = clone.innerHTML.replaceAll('Default', data['short-title']);
+  }
+  if (isSearch(data.url)) {
+    clone.querySelectorAll('a').forEach((a) => {
+      a.rel = 'nofollow';
+    });
   }
   if (defaultRegex.test(clone.innerHTML)) {
     return null;
@@ -112,7 +122,7 @@ async function updateLinkList(container, linkPill, list) {
         .replace(currentTasksX, '')
         .trim();
 
-      if (!new URL(`https://www.adobe.com${d.pathname}`).search) {
+      if (!isSearch(d.pathname)) {
         const pageData = {
           url: d.pathname,
           'short-title': d.displayValue,


### PR DESCRIPTION
CKG Pills linking to search pages should now be nofollow tags. You can test in branch link by checking some of the CKG links (the beginning ones) linking to SEO pages still don't have nofollow, but later ones like Yoga Flyer have rel=nofollow.

Resolves: https://jira.corp.adobe.com/browse/MWPW-146308

Test URLs:
- Before: https://stage--express--adobecom.hlx.live/express/templates/flyer?lighthouse=on
- After: https://ckg-search-no-follow--express--adobecom.hlx.live/express/templates/flyer?lighthouse=on
