### PR TITLE
FaaS Hotfix

### DIFF
--- a/express/blocks/faas/faas.js
+++ b/express/blocks/faas/faas.js
@@ -33,6 +33,7 @@ export default async function init(a) {
       el: a,
       options: { rootMargin: `${ROOT_MARGIN}px` },
       callback: loadFaas,
+      once: true,
     });
   }
 }

--- a/express/blocks/faas/faas.js
+++ b/express/blocks/faas/faas.js
@@ -28,8 +28,8 @@ const loadFaas = async (a) => {
 const loadedLinks = new Set();
 
 export default async function init(a) {
-  if (loadedLinks.has(a)) return;
-  loadedLinks.add(a);
+  if (loadedLinks.has(a.href)) return;
+  loadedLinks.add(a.href);
   if (a.textContent.includes('no-lazy')) {
     loadFaas(a);
   } else {

--- a/express/blocks/faas/faas.js
+++ b/express/blocks/faas/faas.js
@@ -9,7 +9,7 @@ function parseEncodedConfig(encodedConfig) {
   try {
     return JSON.parse(b64ToUtf8(decodeURIComponent(encodedConfig)));
   } catch (e) {
-    // console.log(e);
+    window.lana?.log(e);
   }
   return null;
 }

--- a/express/blocks/faas/faas.js
+++ b/express/blocks/faas/faas.js
@@ -9,7 +9,7 @@ function parseEncodedConfig(encodedConfig) {
   try {
     return JSON.parse(b64ToUtf8(decodeURIComponent(encodedConfig)));
   } catch (e) {
-    console.log(e);
+    // console.log(e);
   }
   return null;
 }
@@ -25,7 +25,11 @@ const loadFaas = async (a) => {
   }
 };
 
+const loadedLinks = new Set();
+
 export default async function init(a) {
+  if (loadedLinks.has(a)) return;
+  loadedLinks.add(a);
   if (a.textContent.includes('no-lazy')) {
     loadFaas(a);
   } else {

--- a/express/blocks/faas/faas.js
+++ b/express/blocks/faas/faas.js
@@ -25,11 +25,7 @@ const loadFaas = async (a) => {
   }
 };
 
-const loadedLinks = new Set();
-
 export default async function init(a) {
-  if (loadedLinks.has(a.href)) return;
-  loadedLinks.add(a.href);
   if (a.textContent.includes('no-lazy')) {
     loadFaas(a);
   } else {

--- a/express/blocks/modal/modal.js
+++ b/express/blocks/modal/modal.js
@@ -64,7 +64,6 @@ async function getPathModal(path, dialog) {
 
 export async function getModal(details, custom) {
   if (!(details?.path || custom)) return null;
-
   const { id } = details || custom;
 
   const dialog = createTag('div', { class: 'dialog-modal', id });
@@ -135,11 +134,16 @@ export async function getModal(details, custom) {
   return dialog;
 }
 
+const loadedPaths = new Set();
 // Deep link-based
 export default function init(el) {
   const { modalHash } = el.dataset;
   if (window.location.hash === modalHash) {
     const details = findDetails(window.location.hash, el);
+    if (details.path) {
+      if (loadedPaths.has(details.path)) return null;
+      loadedPaths.add(details.path);
+    }
     if (details) return getModal(details);
   }
   return null;

--- a/test/unit/scripts/loadLana.test.js
+++ b/test/unit/scripts/loadLana.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { waitFor } from '../../helpers/waitfor.js';


### PR DESCRIPTION
A temporary workaround to only load FaaS once even when Autoblocks will try to load several.

Resolves: https://jira.corp.adobe.com/browse/MWPW-147167

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/business#sales-contact-form-1
- After: https://faas-once--express--adobecom.hlx.page/express/business#sales-contact-form-1
