### PR TITLE
[Frictionless] Support Static Image

### DIFF
--- a/express/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -48,7 +48,8 @@
     margin-top: 26px;
 }
 
-.frictionless-quick-action.block video {
+.frictionless-quick-action.block video,
+.frictionless-quick-action.block img:not(.icon) {
     max-width: 444px;
 }
 


### PR DESCRIPTION
Support image on the left of fqa block.

Resolves: https://jira.corp.adobe.com/browse/MWPW-147222

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/jingle/remove-background-copy?lighthouse=on
- After: https://fqa-static-asset--express--adobecom.hlx.page/drafts/jingle/remove-background-copy?lighthouse=on
