### PR TITLE
[Pricing-Cards] Bring Back Dots for Feature List

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -320,14 +320,9 @@ End border style variants
   padding: 8px;
 }
 
-.pricing-cards .card-feature-list ul {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
-
 .pricing-cards .card-feature-list li {
-  padding: 8px;
+  padding-top: 8px;
+  padding-bottom: 8px;
 }
 
 .pricing-cards .card-feature-list li:first-of-type {


### PR DESCRIPTION
Bring back bullet points to the feature list of pricing-cards.

Resolves: https://jira.corp.adobe.com/browse/MWPW-147163

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/?lighthouse=on
- After: https://pricing-cards-bullets--express--adobecom.hlx.page/express/pricing?lighthouse=on
