### PR TITLE
[Security] Sanitize HTML Inputs

### DIFF
--- a/express/blocks/filter-pages/filter-pages.js
+++ b/express/blocks/filter-pages/filter-pages.js
@@ -4,6 +4,7 @@ import {
   createTag,
   readBlockConfig,
   addPublishDependencies,
+  sanitize
 // eslint-disable-next-line import/no-unresolved
 } from '../../scripts/utils.js';
 
@@ -21,7 +22,7 @@ function filterMigratedPages(filter) {
         if (!path.startsWith(' ')) path = path.substr(1);
         path = path.replace('.html', '');
         let markedUpPath = path;
-        if (filter) markedUpPath = path.split(filter).join(`<b>${filter}</b>`);
+        if (filter) markedUpPath = sanitize(path.split(filter).join(`<b>${filter}</b>`));
         const $card = createTag('div', { class: 'card' });
         $card.innerHTML = `<div class="card-image">
             <img loading="lazy" src="${page.image}">

--- a/express/blocks/page-list/page-list.js
+++ b/express/blocks/page-list/page-list.js
@@ -23,7 +23,9 @@ async function fetchIndex(indexURL) {
 function outputPages(filteredPages, $block) {
   filteredPages.forEach((page) => {
     const p = createTag('p');
-    p.innerHTML = `<a href="${page.path}">${page.shortTitle}</a>`;
+    const a = createTag('a', {href : page.path });
+    a.innerText = page.shortTitle;
+    p.appendChild(a);
     $block.appendChild(p);
   });
 }

--- a/express/blocks/pricing-columns/pricing-columns.js
+++ b/express/blocks/pricing-columns/pricing-columns.js
@@ -8,6 +8,7 @@ import {
   getHelixEnv,
 // eslint-disable-next-line import/no-unresolved
 } from '../../scripts/utils.js';
+import HtmlSanitizer from '../../scripts/html-sanitizer.js';
 import { getOffer } from '../../scripts/utils/pricing.js';
 
 function replaceUrlParam(url, paramName, paramValue) {
@@ -231,13 +232,12 @@ async function fetchPlan(planUrl) {
 
 async function selectPlan($pricingHeader, planUrl, sendAnalyticEvent) {
   const plan = await fetchPlan(planUrl);
-
-  $pricingHeader.querySelector('.pricing-columns-price').innerHTML = plan.formatted;
+  $pricingHeader.querySelector('.pricing-columns-price').innerHTML = HtmlSanitizer.SanitizeHtml(plan.formatted);
   $pricingHeader.querySelector('.pricing-columns-price').classList.add(plan.currency.toLowerCase());
   $pricingHeader.querySelector('.pricing-columns-cta').href = buildUrl(plan.url, plan.country, plan.language);
   $pricingHeader.querySelector('.pricing-columns-cta').dataset.planUrl = planUrl;
   $pricingHeader.querySelector('.pricing-columns-cta').id = plan.stringId;
-  $pricingHeader.querySelector('.pricing-columns-vat-info').innerHTML = plan.vatInfo || '';
+  $pricingHeader.querySelector('.pricing-columns-vat-info').innerHTML = HtmlSanitizer.SanitizeHtml(plan.vatInfo) || '';
 
   if (sendAnalyticEvent) {
     const adobeEventName = 'adobe.com:express:pricing:commitmentType:selected';
@@ -263,8 +263,8 @@ function decoratePlan($column) {
     }
   });
 
-  $pricingTitle.innerHTML = $elements[0].innerHTML;
-  $pricingTitleIcon.innerHTML = $elements[1].innerHTML;
+  $pricingTitle.innerHTML = HtmlSanitizer.SanitizeHtml($elements[0].innerHTML);
+  $pricingTitleIcon.innerHTML = HtmlSanitizer.SanitizeHtml($elements[1].innerHTML);
   $pricingTitle.prepend($pricingTitleIcon);
   $pricingHeader.append($pricingTitle);
 

--- a/express/blocks/promotion/promotion.js
+++ b/express/blocks/promotion/promotion.js
@@ -30,8 +30,8 @@ export default async function decorate($block) {
   const html = await fetchPromotion(name);
   if (html) {
     const div = createTag('div');
-    div.innerHTML = html;
-
+    div.innerText = html;
+    
     normalizeHeadings(div, ['h2', 'h3']);
 
     const h2 = div.querySelector('h2');

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -17,6 +17,7 @@ import {
   linkImage,
   sampleRUM,
   toClassName,
+  sanitize,
 } from '../../scripts/utils.js';
 import { addTempWrapper } from '../../scripts/decorate.js';
 
@@ -495,7 +496,7 @@ function getRedirectUrl(tasks, topics, format, allTemplatesMetadata) {
   }
 
   const searchUrlTemplate = `/express/templates/search?tasks=${tasks}&phformat=${format}&topics=${topics || "''"}`;
-  return `${window.location.origin}${prefix}${searchUrlTemplate}`;
+  return sanitize(`${window.location.origin}${prefix}${searchUrlTemplate}`);
 }
 
 async function redirectSearch($searchBar, props) {

--- a/express/scripts/template-ckg.js
+++ b/express/scripts/template-ckg.js
@@ -7,6 +7,8 @@ import {
   getDataWithContext,
 } from './browse-api-controller.js';
 
+import HtmlSanitizer from './html-sanitizer.js';
+
 import fetchAllTemplatesMetadata from './all-templates-metadata.js';
 
 const defaultRegex = /\/express\/templates\/default/;
@@ -49,7 +51,7 @@ async function fetchLinkList() {
 function replaceLinkPill(linkPill, data) {
   const clone = linkPill.cloneNode(true);
   if (data) {
-    clone.innerHTML = clone.innerHTML.replace('/express/templates/default', data.url);
+    clone.innerHTML = HtmlSanitizer.SanitizeHtml(clone.innerHTML.replace('/express/templates/default', data.url));
     clone.innerHTML = clone.innerHTML.replaceAll('Default', data['short-title']);
   }
   if (defaultRegex.test(clone.innerHTML)) {
@@ -119,7 +121,7 @@ async function updateLinkList(container, linkPill, list) {
         };
 
         const clone = replaceLinkPill(linkPill, pageData);
-        clone.innerHTML = clone.innerHTML.replaceAll('Default', d.displayValue);
+        clone.innerHTML = HtmlSanitizer.SanitizeHtml(clone.innerHTML.replaceAll('Default', d.displayValue))
         clone.innerHTML = clone.innerHTML.replace('/express/templates/default', d.pathname);
         if (clone) pageLinks.push(clone);
       } else {

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1549,6 +1549,9 @@ export function checkTesting() {
   return (getMetadata('testing').toLowerCase() === 'on');
 }
 
+export function sanitize(str) {
+  return str?.replaceAll(/[$@%'"]/g, '');
+}
 /**
  * Sanitizes a string and turns it into camel case.
  * @param {*} name The unsanitized string


### PR DESCRIPTION
Describe your specific features or fixes

Sanitizes direct innerHTML calls in the following blocks.

template-ckg
page-list
pricing-columns
promotions
template-list


Resolves: 
https://jira.corp.adobe.com/browse/MWPW-144944
https://jira.corp.adobe.com/browse/MWPW-144949
https://jira.corp.adobe.com/browse/MWPW-144956
https://jira.corp.adobe.com/browse/MWPW-144962
https://jira.corp.adobe.com/browse/MWPW-144964

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://security-round-1--express--adobecom.hlx.page/express/
