### PR TITLE
[Security]Removed InnerHTML Usage For Animations

### DIFF
--- a/express/blocks/choose-your-path/choose-your-path.js
+++ b/express/blocks/choose-your-path/choose-your-path.js
@@ -90,8 +90,8 @@ async function enableMouseAnimation($block) {
   const $mouseRightLottie = createTag('div', { class: 'choose-your-path-mouse-lottie' });
   $mouseLeftContainer.textContent = placeholders['choose-your-path-cc'];
   $mouseRightContainer.textContent = placeholders['choose-your-path-express'];
-  $mouseLeftLottie.innerHTML = getLottie('mouse-arrow', '/express/blocks/choose-your-path/mouse-arrow.json');
-  $mouseRightLottie.innerHTML = getLottie('mouse-arrow', '/express/blocks/choose-your-path/mouse-arrow.json');
+  $mouseLeftLottie.appendChild(getLottie('mouse-arrow', '/express/blocks/choose-your-path/mouse-arrow.json'));
+  $mouseRightLottie.appendChild(getLottie('mouse-arrow', '/express/blocks/choose-your-path/mouse-arrow.json'));
   $mouseLeftAnimation.append($mouseLeftContainer);
   $mouseRightAnimation.append($mouseRightContainer);
   $mouseLeftAnimation.append($mouseLeftLottie);

--- a/express/blocks/floating-panel/floating-panel.js
+++ b/express/blocks/floating-panel/floating-panel.js
@@ -177,7 +177,7 @@ export default async function decorate(block) {
     if (index === 0) {
       row.classList.add('content-container');
       const toggleButton = createTag('a', { class: 'toggle-button' });
-      toggleButton.innerHTML = getLottie('plus-animation', '/express/icons/plus-animation.json');
+      toggleButton.appendChild(getLottie('plus-animation', '/express/icons/plus-animation.json'));
       const toggleIcon = getIconElement('plus-heavy');
       toggleButton.append(toggleIcon);
       row.prepend(toggleButton);

--- a/express/blocks/hero-3d/hero-3d.js
+++ b/express/blocks/hero-3d/hero-3d.js
@@ -76,7 +76,7 @@ function addScrollAnimation(block, scrollTo) {
   const container = createTag('div', { class: 'scroll-animation' });
   const link = createTag('a', { href });
   container.append(link);
-  link.innerHTML = loti;
+  link.appendChild(loti);
   block.append(container);
 
   lazyLoadLottiePlayer(block);

--- a/express/blocks/pricing-hub/pricing-hub.js
+++ b/express/blocks/pricing-hub/pricing-hub.js
@@ -362,7 +362,7 @@ function decorateMidSection($block) {
   const $midSectionAnimation = createTag('span', { class: 'pricing-hub-lottie' });
 
   $midSection.classList.add('pricing-hub-midsection');
-  $midSectionAnimation.innerHTML = getLottie('purple-arrows', '/express/blocks/pricing-hub/purple-arrows.json');
+  $midSectionAnimation.appendChild(getLottie('purple-arrows', '/express/blocks/pricing-hub/purple-arrows.json'));
   $midSectionHeader.append($midSectionAnimation);
   lazyLoadLottiePlayer();
 }

--- a/express/blocks/ratings/ratings.js
+++ b/express/blocks/ratings/ratings.js
@@ -178,7 +178,7 @@ export default async function decorate($block) {
     // Countdown timer to auto-submit
     const countdown = (bool) => {
       if (bool) {
-        $timerAnimation.innerHTML = getLottie('countdown', '/express/blocks/ratings/countdown.json', false, true, false, false);
+        $timerAnimation.appendChild(getLottie('countdown', '/express/blocks/ratings/countdown.json', false, true, false, false));
         let counter = 10;
         window.ratingSubmitCountdown = setInterval(() => {
           if (counter > 0) {

--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -428,7 +428,7 @@ export function buildToolBoxStructure(wrapper, data) {
 
   const floatingButton = wrapper.querySelector('.floating-button');
 
-  toggleButton.innerHTML = getLottie('plus-animation', '/express/icons/plus-animation.json');
+  toggleButton.appendChild(getLottie('plus-animation', '/express/icons/plus-animation.json'));
   toolBoxWrapper.append(boxTop, boxBottom);
   toolBox.append(toolBoxWrapper);
   toggleButton.append(toggleIcon);

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -920,7 +920,7 @@ async function decorateCategoryList(block, section, placeholders, props) {
   const $lottieArrows = createTag('a', { class: 'lottie-wrapper' });
   $mobileDrawerWrapper.append($lottieArrows);
   $inWrapper.append($categoriesMobileWrapper);
-  $lottieArrows.innerHTML = getLottie('purple-arrows', '/express/icons/purple-arrows.json');
+  $lottieArrows.appendChild(getLottie('purple-arrows', '/express/icons/purple-arrows.json'));
   lazyLoadLottiePlayer();
 
   $categoriesDesktopWrapper.classList.add('desktop-only');

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -640,7 +640,7 @@ async function decorateCategoryList(block, props) {
   const lottieArrows = createTag('a', { class: 'lottie-wrapper' });
   mobileDrawerWrapper.append(lottieArrows);
   drawerWrapper.append(categoriesMobileWrapper);
-  lottieArrows.innerHTML = getLottie('purple-arrows', '/express/icons/purple-arrows.json');
+  lottieArrows.appendChild(getLottie('purple-arrows', '/express/icons/purple-arrows.json'));
   lazyLoadLottiePlayer();
 
   block.prepend(categoriesDesktopWrapper);

--- a/express/blocks/toc/toc.js
+++ b/express/blocks/toc/toc.js
@@ -127,7 +127,8 @@ export default async function decorate($block) {
 
   const iconHTML = getLottie('arrow-down', '/express/icons/arrow-down.json');
   const $toggle = getToggleButton();
-  $toggle.innerHTML = iconHTML + $toggle.innerHTML;
+
+  $toggle.innerHTML = iconHTML.outerHTML + $toggle.innerHTML;
 
   [...$block.children].forEach((div) => {
     const wrapper = div.children.item(1);

--- a/express/experiments/ccx0027c/blocks/quick-action2/quick-action.js
+++ b/express/experiments/ccx0027c/blocks/quick-action2/quick-action.js
@@ -46,7 +46,7 @@ function createMockQuickAction() {
 function addLottieIcons(array, lottieIcon) {
   const lottie = getLottie(lottieIcon, LOTTIE_ICONS[lottieIcon]);
   array.forEach((el) => {
-    el.innerHTML = `${lottie}${el.innerHTML}`;
+    el.innerHTML = `${lottie.outerHTML}${el.innerHTML}`;
   });
   lazyLoadLottiePlayer();
 }

--- a/express/experiments/ccx0098/ch1/drawer-item/drawer-item.js
+++ b/express/experiments/ccx0098/ch1/drawer-item/drawer-item.js
@@ -143,9 +143,9 @@ function createCTA(payload, link, isSingleDownloadCTA) {
   if (payload.hasList) {
     const gradientCTALottie = createTag('div', { class: 'cta-lottie' });
     if (getMobileOperatingSystem() === 'iOS') {
-      gradientCTALottie.innerHTML = getLottie('apple-lottie', '/express/experiments/ccx0098/ch1/drawer-item/app_store_icons_apple.json');
+      gradientCTALottie.appendChild(getLottie('apple-lottie', '/express/experiments/ccx0098/ch1/drawer-item/app_store_icons_apple.json'));
     } else {
-      gradientCTALottie.innerHTML = getLottie('android-lottie', '/express/experiments/ccx0098/ch1/drawer-item/google_g_app_store.json');
+      gradientCTALottie.appendChild(getLottie('android-lottie', '/express/experiments/ccx0098/ch1/drawer-item/google_g_app_store.json'));
     }
     cta.append(...gradientCTALottie.children);
     cta.append(ctaText);
@@ -433,7 +433,7 @@ function decorateCarouselCTAList(payload) {
 function addScratchLottie(payload) {
   if (payload.hasScratchLottie && !document.querySelector('.scratch-lottie-container')) {
     const scratchLottie = createTag('div', { class: 'scratch-lottie-container' });
-    scratchLottie.innerHTML = getLottie('scratch-lottie', '/express/experiments/ccx0098/ch1/drawer-item/s2_create_0.1_from_blank.json');
+    scratchLottie.appendChild(getLottie('scratch-lottie', '/express/experiments/ccx0098/ch1/drawer-item/s2_create_0.1_from_blank.json');
     scratchLottie.style.position = 'absolute';
     const scratchIMG = document.querySelector('.drawer-item [title="Scratch"]');
     if (scratchIMG) {

--- a/express/experiments/ccx0098/ch1/mobile-drawer/mobile-drawer.js
+++ b/express/experiments/ccx0098/ch1/mobile-drawer/mobile-drawer.js
@@ -511,7 +511,7 @@ export default async function decorate($block) {
   const $tabLottieContainer = createTag('div', { class: 'tab-lottie-container' });
   const $tabLottie = createTag('div', { class: 'tab-lottie' });
   const $tabText = $oldMobileDrawerSection.querySelector('.default-content-wrapper p');
-  $tabLottie.innerHTML = getLottie('compass-lottie-white', '/express/experiments/ccx0098/ch2/mobile-drawer/compass-lottie-white.json', false, false);
+  $tabLottie.appendChild(getLottie('compass-lottie-white', '/express/experiments/ccx0098/ch2/mobile-drawer/compass-lottie-white.json', false, false));
   $tabLottie.append($tabText);
   $tabLottieContainer.append($tabLottie);
   $block.innerHTML = '';

--- a/express/experiments/ccx0098/ch2/drawer-item/drawer-item.js
+++ b/express/experiments/ccx0098/ch2/drawer-item/drawer-item.js
@@ -143,9 +143,9 @@ function createCTA(payload, link, isSingleDownloadCTA) {
   if (payload.hasList) {
     const gradientCTALottie = createTag('div', { class: 'cta-lottie' });
     if (getMobileOperatingSystem() === 'iOS') {
-      gradientCTALottie.innerHTML = getLottie('apple-lottie', '/express/experiments/ccx0098/ch2/drawer-item/app_store_icons_apple.json');
+      gradientCTALottie.appendChild(getLottie('apple-lottie', '/express/experiments/ccx0098/ch2/drawer-item/app_store_icons_apple.json'));
     } else {
-      gradientCTALottie.innerHTML = getLottie('android-lottie', '/express/experiments/ccx0098/ch2/drawer-item/google_g_app_store.json');
+      gradientCTALottie.appendChild(getLottie('android-lottie', '/express/experiments/ccx0098/ch2/drawer-item/google_g_app_store.json'));
     }
     cta.append(...gradientCTALottie.children);
     cta.append(ctaText);
@@ -433,7 +433,7 @@ function decorateCarouselCTAList(payload) {
 function addScratchLottie(payload) {
   if (payload.hasScratchLottie && !document.querySelector('.scratch-lottie-container')) {
     const scratchLottie = createTag('div', { class: 'scratch-lottie-container' });
-    scratchLottie.innerHTML = getLottie('scratch-lottie', '/express/experiments/ccx0098/ch2/drawer-item/s2_create_0.1_from_blank.json');
+    scratchLottie.appendChild(getLottie('scratch-lottie', '/express/experiments/ccx0098/ch2/drawer-item/s2_create_0.1_from_blank.json'));
     scratchLottie.style.position = 'absolute';
     const scratchIMG = document.querySelector('.drawer-item [title="Scratch"]');
     if (scratchIMG) {

--- a/express/experiments/ccx0098/ch2/mobile-drawer/mobile-drawer.js
+++ b/express/experiments/ccx0098/ch2/mobile-drawer/mobile-drawer.js
@@ -511,7 +511,7 @@ export default async function decorate($block) {
   const $tabLottieContainer = createTag('div', { class: 'tab-lottie-container' });
   const $tabLottie = createTag('div', { class: 'tab-lottie' });
   const $tabText = $oldMobileDrawerSection.querySelector('.default-content-wrapper p');
-  $tabLottie.innerHTML = getLottie('compass-lottie-white', '/express/experiments/ccx0098/ch2/mobile-drawer/compass-lottie-white.json', false, false);
+  $tabLottie.appendChild(getLottie('compass-lottie-white', '/express/experiments/ccx0098/ch2/mobile-drawer/compass-lottie-white.json', false, false));
   $tabLottie.append($tabText);
   $tabLottieContainer.append($tabLottie);
   $block.innerHTML = '';

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -333,10 +333,19 @@ export function createTag(tag, attributes, html) {
 }
 
 // Get lottie animation HTML - remember to lazyLoadLottiePlayer() to see it.
+// Get lottie animation HTML - remember to lazyLoadLottiePlayer() to see it.
 export function getLottie(name, src, loop = true, autoplay = true, control = false, hover = false) {
-  return (`<lottie-player class="lottie lottie-${name}" src="${src}" background="transparent" speed="1" ${(loop) ? 'loop ' : ''}${(autoplay) ? 'autoplay ' : ''}${(control) ? 'controls ' : ''}${(hover) ? 'hover ' : ''}></lottie-player>`);
+  return createTag('lottie-player', {
+    class: `lottie lottie-${name}`,
+    src,
+    background: 'transparent',
+    speed: 1,
+    loop: loop ? 'loop' : '',
+    autoplay: autoplay ? 'autoplay' : '',
+    control: control ? 'controls' : '',
+    hover: hover ? 'hover' : '',
+  });
 }
-
 // Lazy-load lottie player if you scroll to the block.
 export function lazyLoadLottiePlayer($block = null) {
   const usp = new URLSearchParams(window.location.search);

--- a/express/scripts/utils/free-plan.js
+++ b/express/scripts/utils/free-plan.js
@@ -70,7 +70,7 @@ export async function addFreePlanWidget(elem) {
     const lottieWrapper = createTag('span', { class: 'lottie-wrapper' });
 
     learnMoreButton.textContent = placeholders['learn-more'];
-    lottieWrapper.innerHTML = getLottie('purple-arrows', '/express/icons/purple-arrows.json');
+    lottieWrapper.appendChild(getLottie('purple-arrows', '/express/icons/purple-arrows.json'));
     learnMoreButton.append(lottieWrapper);
     lazyLoadLottiePlayer();
     widget.append(learnMoreButton);


### PR DESCRIPTION
Describe your specific features or fixes

Reworked getLottie to return a regular HTML element instead of a string, then replaced usage of innerHTML with appendChild.

Resolves: https://jira.corp.adobe.com/browse/MWPW-144961

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://create-tag-lottie--express--adobecom.hlx.page/express/templates/
