### PR TITLE
[MWPW-147232] Pricing Cards Border Enhancement

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -110,7 +110,11 @@ Border style variants
 }
 
 .pricing-cards .gradient-promo:has(div:empty) {
-  margin-top: -24px;
+  margin-top: -48px;
+}
+
+.pricing-cards .gradient-promo div:empty {
+  padding: 18px;
 }
 
 .pricing-cards .card-border {

--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -105,7 +105,7 @@ Border style variants
 .pricing-cards .cards-container:has( .card-border.gradient-promo) {
   margin-top:48px;
 }
-.pricing-cards .cards-container:has( .gradient-promo:has(div:empty)) {
+.pricing-cards .cards-container{
   margin-top:24px;
 }
 

--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -93,13 +93,29 @@ Border style variants
   border-radius: 10px;
   overflow: hidden;
   background: var(--color-white);
-  margin-top: 0px !important;
+  margin-top:-48px;
   margin-left: -2px;
   margin-right: -2px;
   display: flex;
   flex-direction: column;
+  margin-bottom: 48px;
+  
 }
 
+.pricing-cards .cards-container:has( .card-border.gradient-promo) {
+  margin-top:48px;
+}
+.pricing-cards .cards-container:has( .gradient-promo:has(div:empty)) {
+  margin-top:24px;
+}
+
+.pricing-cards .gradient-promo:has(div:empty) {
+  margin-top: -24px;
+}
+
+.pricing-cards .card-border {
+  margin-bottom: 48px;
+}
 
 .pricing-cards .special-promo {
   border: 2px solid #FFE600;
@@ -139,12 +155,7 @@ Border style variants
 
 /*
 End border style variants
-*/
-
-.pricing-cards .card-border {
-  margin-top: calc(24px + 1.5rem);
-}
-
+*/ 
 
 .pricing-cards .card-border .hide {
   display: none;
@@ -393,7 +404,6 @@ End border style variants
 
   .pricing-cards .cards-container:has(>.card-border:first-child:nth-last-child(3)) {
     width: calc(2 * --card-width);
-    margin: auto;
     grid-template-columns: repeat(auto-fit, minmax(var(--card-width), calc((1200px - 32px) / 3)));
   }
 
@@ -424,7 +434,8 @@ End border style variants
   }
 
   .pricing-cards .cards-container:has(>.card:first-child:nth-last-child(3)) {
-    margin: auto;
     grid-template-columns: repeat(auto-fit, minmax(var(--card-width), calc((1200px - 32px) / 3)));
   }
+
+  
 }

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -160,8 +160,7 @@ function readBraces(inputString, card) {
   if (matches.length > 0) {
     const [token, promoType] = matches[matches.length - 1];
     const specialPromo = createTag('div');
-    [specialPromo.textContent] = inputString.split(token);
-    specialPromo.textContent = specialPromo.textContent.trim();
+    specialPromo.textContent = inputString.split(token)[0].trim();
     card.classList.add(promoType.replaceAll(' ', ''));
     card.append(specialPromo);
     return specialPromo;

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -161,6 +161,7 @@ function readBraces(inputString, card) {
     const [token, promoType] = matches[matches.length - 1];
     const specialPromo = createTag('div');
     [specialPromo.textContent] = inputString.split(token);
+    specialPromo.textContent = specialPromo.textContent.trim();
     card.classList.add(promoType.replaceAll(' ', ''));
     card.append(specialPromo);
     return specialPromo;
@@ -207,7 +208,6 @@ function decorateHeader(header, borderParams, card, cardBorder) {
   header.classList.add('card-header');
   const specialPromo = readBraces(borderParams?.innerText, cardBorder);
   const premiumIcon = header.querySelector('img');
-
   // Finds the headcount, removes it from the original string and creates an icon with the hc
   const extractHeadCountExp = /(>?)\(\d+(.*?)\)/;
   if (extractHeadCountExp.test(h2.innerText)) {


### PR DESCRIPTION
Describe your specific features or fixes

For cards with gradient promos only. 
Uses negative margin and element specific CSS to detect card a gradient promo but no text. Adjusts the cards margins so that all cards line up regardless of whether there is text or no text inside the gradient promo. Does not require authoring changes.

Resolves: [MWPW-147232](https://jira.corp.adobe.com/browse/MWPW-147232)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://pricing-cards-eyebrow--express--adobecom.hlx.page/express/pricing
- https://pricing-cards-eyebrow--express--adobecom.hlx.page/express/business
- https://pricing-cards-eyebrow--express--adobecom.hlx.page/drafts/echen/pricing-cards

<img width="1308" alt="Screenshot 2024-04-25 at 1 35 36 PM" src="https://github.com/adobecom/express/assets/159481679/2473821d-b81c-426c-ab72-da6cc02e8396">
<img width="526" alt="Screenshot 2024-04-25 at 1 36 41 PM" src="https://github.com/adobecom/express/assets/159481679/3ce701c9-13a0-4df4-b882-e8c2ba50cdcd">
<img width="615" alt="Screenshot 2024-04-25 at 1 36 52 PM" src="https://github.com/adobecom/express/assets/159481679/506d1a43-1a8b-4b6b-9856-107c853cec71">
<img width="1048" alt="Screenshot 2024-04-25 at 1 37 12 PM" src="https://github.com/adobecom/express/assets/159481679/9dab72bb-469b-4cb9-b010-f1550f21a45d">


