### PR TITLE
[Pricing] New Headline Block

### DIFF
--- a/express/blocks/headline/headline.js
+++ b/express/blocks/headline/headline.js
@@ -1,0 +1,17 @@
+// avoid using this kind of text-block unless necessary
+export default function init(el) {
+  const heading = el.querySelector('h1, h2, h3, h4, h5, h6');
+  const cfg = el.querySelector(':scope p:last-of-type');
+  try {
+    if (cfg === heading) return el;
+    cfg.textContent.split(',').forEach((item) => {
+      const [key, value] = item.split(':').map((t) => t.trim().toLowerCase());
+      heading.style[key] = value;
+    });
+    cfg.remove();
+  } catch (e) {
+    window.lana?.log(e);
+  }
+  el.innerHTML = heading?.outerHTML || '';
+  return el;
+}

--- a/test/unit/blocks/headline/headline.test.js
+++ b/test/unit/blocks/headline/headline.test.js
@@ -1,0 +1,45 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+import { spy } from 'sinon';
+
+const { default: decorate } = await import('../../../../express/blocks/headline/headline.js');
+document.body.innerHTML = await readFile({ path: './mocks/body.html' });
+describe('Headline', () => {
+  let oldLana;
+  let lanaSpy;
+  before(() => {
+    oldLana = window.lana;
+    window.lana = { log: () => {} };
+    lanaSpy = spy(window.lana, 'log');
+  });
+  after(() => {
+    window.lana = oldLana;
+  });
+  it('adds style to headline elements', () => {
+    for (let i = 1; i <= 3; i += 1) {
+      const headline = decorate(document.getElementById(`headline-ut-${i}`)).querySelector(`h${i}`);
+      expect(headline.style.fontSize).to.equal(`${i}rem`);
+      expect(headline.style.paddingTop).to.equal(`${i}rem`);
+      expect(headline.style.paddingBottom).to.equal(`${i}rem`);
+      expect(headline.parentElement.firstElementChild === headline.parentElement.lastElementChild);
+    }
+  });
+  it('works without config', () => {
+    const headline = decorate(document.getElementById('headline-ut-no-cfg')).querySelector('h4');
+    expect(headline).to.exist;
+    expect(headline.parentElement.firstElementChild)
+      .to.equal(headline.parentElement.firstElementChild);
+  });
+  it('leaves only headline when config fails', () => {
+    const headline = decorate(document.getElementById('headline-ut-bad-cfg')).querySelector('h5');
+    expect(headline.parentElement.firstElementChild)
+      .to.equal(headline.parentElement.firstElementChild);
+    expect(lanaSpy.calledOnce).to.be.true;
+    expect(lanaSpy.calledTwice).to.be.false;
+  });
+  it('leaves nothing when whole thing fails', () => {
+    const block = decorate(document.getElementById('headline-ut-bad-block'));
+    expect(block.innerHTML === '').to.be.true;
+    expect(lanaSpy.calledTwice).to.be.true;
+  });
+});

--- a/test/unit/blocks/headline/mocks/body.html
+++ b/test/unit/blocks/headline/mocks/body.html
@@ -41,7 +41,7 @@
   <div id="headline-ut-bad-block" class="headline">
     <div>
       <div>
-        <p>Stand out with Adobe Express. Pick your plan.</h3>
+        <p>Stand out with Adobe Express. Pick your plan.</p>
         <p>Font-s.ize::3rem, padding-top:3rem, padding-bottom:3rem,</p>
       </div>
     </div>

--- a/test/unit/blocks/headline/mocks/body.html
+++ b/test/unit/blocks/headline/mocks/body.html
@@ -1,0 +1,49 @@
+<div>
+  <div id="headline-ut-1" class="headline">
+    <div>
+      <div>
+        <h1>Stand out with Adobe Express. Pick your plan.</h1>
+        <p>Font-size: 1rem, padding-top: 1rem, padding-bottom: 1rem</p>
+      </div>
+    </div>
+  </div>
+  <div id="headline-ut-2" class="headline">
+    <div>
+      <div>
+        <h2>Stand out with Adobe Express. Pick your plan.</h2>
+        <p>font-size:2rem,padding-top:2rem,padding-bottom:2rem,</p>
+      </div>
+    </div>
+  </div>
+  <div id="headline-ut-3" class="headline">
+    <div>
+      <div>
+        <h3>Stand out with Adobe Express. Pick your plan.</h3>
+        <p>Font-size:3rem, padding-top:3rem, padding-bottom:3rem,</p>
+      </div>
+    </div>
+  </div>
+  <div id="headline-ut-no-cfg" class="headline">
+    <div>
+      <div>
+        <h4>Stand out with Adobe Express. Pick your plan.</h4>
+      </div>
+    </div>
+  </div>
+  <div id="headline-ut-bad-cfg" class="headline">
+    <div>
+      <div>
+        <h5>Stand out with Adobe Express. Pick your plan.</h5>
+        <p>Font-s.ize::3rem, paddinqweg-top:3rem, padding-bottom:3rem,</p>
+      </div>
+    </div>
+  </div>
+  <div id="headline-ut-bad-block" class="headline">
+    <div>
+      <div>
+        <p>Stand out with Adobe Express. Pick your plan.</h3>
+        <p>Font-s.ize::3rem, padding-top:3rem, padding-bottom:3rem,</p>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
A block specifically for customizing a headline element. Usage of this block is generally not encouraged, but given legacy issue and the fact that Milo Migration is happening, it is the only practical way to give authors enough control for special styling of raw default headline content. It is said to be only used on pricing pages, where we have no images/videos/hero/marquee elements.

Resolves: https://jira.corp.adobe.com/browse/MWPW-147298

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/jinglhua/padding-headline?lighthouse=on
- After: https://headline-padding--express--adobecom.hlx.page/drafts/jinglhua/padding-headline?lighthouse=on
- Kitchen sink: https://headline-padding--express--adobecom.hlx.page/docs/library/kitchen-sink/headline?lighthouse=on
