### PR TITLE
[MWPW-147515] Bump Holiday Banner Height

### DIFF
--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -1951,7 +1951,7 @@ main .template-x-wrapper.horizontal > .template-x.horizontal.tabbed > .template-
 
 .template-x.holiday .carousel-container .carousel-platform {
     scroll-padding: initial;
-    max-height: 200px;
+    max-height: 250px;
     padding: 20px 0 24px;
 }
 


### PR DESCRIPTION
Describe your specific features or fixes

Bumps the height of the holiday banner so that template cards fit.

Resolves: https://jira.corp.adobe.com/projects/MWPW/issues/MWPW-147515?filter=myopenissues

<img width="1728" alt="Screenshot 2024-04-30 at 10 34 29 AM" src="https://github.com/adobecom/express/assets/159481679/1465b750-61fd-4c27-b843-c3af00fd2e10">

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://holiday-blade-fix--express--adobecom.hlx.page/uk/express/
