### PR TITLE
[MWPW-147486] Third pricing token + Tooltip

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -167,18 +167,22 @@ End border style variants
 }
 
 .pricing-cards .tooltip-text {
-  visibility: hidden;
-  margin-left: 8px;
+  display: none;
+  margin-left: 20px;
   padding: 8px;
   background-color:#5258E4;
   color: white;
   border-radius: 8px;
+  position: absolute;
+  bottom: 0; left: 25%;transition: bottom 0.5s ease-in-out;
+}
 
-
+.pricing-cards .tooltip {
+  position: relative;
 }
 
 .pricing-cards .tooltip:hover .tooltip-text{
-  visibility: visible;
+  display: block;
 }
 
 .pricing-cards .card-border .hide {

--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -181,7 +181,7 @@ End border style variants
   position: relative;
 }
 
-.pricing-cards .tooltip:hover .tooltip-text{
+.pricing-cards .tooltip .icon:hover ~.tooltip-text{
   display: block;
 }
 

--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -161,6 +161,26 @@ Border style variants
 End border style variants
 */ 
 
+.pricing-cards .tooltip-icon {
+  position: relative;
+  top : 2px;
+}
+
+.pricing-cards .tooltip-text {
+  visibility: hidden;
+  margin-left: 8px;
+  padding: 8px;
+  background-color:#5258E4;
+  color: white;
+  border-radius: 8px;
+
+
+}
+
+.pricing-cards .tooltip:hover .tooltip-text{
+  visibility: visible;
+}
+
 .pricing-cards .card-border .hide {
   display: none;
 }
@@ -262,7 +282,7 @@ End border style variants
   background: var(--color-gray-150);
   border: 1px solid #E0E2FF;
   padding: var(--card-padding);
-  height: 125px;
+  height: 150px;
 }
 
 .pricing-cards .pricing-row {

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -1,6 +1,10 @@
 import { addTempWrapper } from '../../scripts/decorate.js';
 import BlockMediator from '../../scripts/block-mediator.min.js';
-import { createTag, fetchPlaceholders, yieldToMain } from '../../scripts/utils.js';
+import {
+  createTag,
+  fetchPlaceholders,
+  yieldToMain,
+} from '../../scripts/utils.js';
 
 import {
   formatDynamicCartLink,
@@ -9,11 +13,23 @@ import {
   fetchPlanOnePlans,
 } from '../../scripts/utils/pricing.js';
 
-const blockKeys = ['header', 'borderParams', 'explain', 'mPricingRow', 'mCtaGroup', 'yPricingRow', 'yCtaGroup', 'featureList', 'compare'];
+const blockKeys = [
+  'header',
+  'borderParams',
+  'explain',
+  'mPricingRow',
+  'mCtaGroup',
+  'yPricingRow',
+  'yCtaGroup',
+  'featureList',
+  'compare',
+];
 const plans = ['monthly', 'yearly']; // authored order should match with billing-radio
 const BILLING_PLAN = 'billing-plan';
-const SAVE_PERCENTAGE = 'savePercentage';
+const SAVE_PERCENTAGE = '{{savePercentage}}';
 const SALES_NUMBERS = '{{business-sales-numbers}}';
+const PRICE_TOKEN = '{{pricing}}';
+const YEAR_2_PRICING_TOKEN = '[[year-2-pricing-token]]';
 
 function suppressOfferEyebrow(specialPromo, legacyVersion) {
   if (specialPromo.parentElement) {
@@ -29,10 +45,42 @@ function suppressOfferEyebrow(specialPromo, legacyVersion) {
   }
 }
 
-function handlePrice(placeholders, pricingArea, placeholderArr, specialPromo, legacyVersion) {
+function getPriceElementSuffix(placeholders, placeholderArr, response) {
+  return placeholderArr
+    .map((phText) => {
+      const key = phText.replace('{{', '').replace('}}', '');
+      return key.includes('vat') && !response.showVat
+        ? ''
+        : placeholders[key] || '';
+    })
+    .join(' ');
+}
+
+function handleYear2PricingToken(pricingArea, y2p, elementSuffix) {
+
+  try {
+    const elements = pricingArea.querySelectorAll('p');
+    console.log(elements)
+    const year2PricingToken = Array.from(elements).find((p) => p.textContent === YEAR_2_PRICING_TOKEN);
+   
+    if (!year2PricingToken) return;
+    if (y2p) {
+      console.log(y2p, year2PricingToken)
+      year2PricingToken.textContent = `${y2p} ${elementSuffix} after the first year`;
+    } 
+  } catch (e) {
+    window.lana.log(e);
+  }
+}
+
+function handlePrice(placeholders, pricingArea, specialPromo, legacyVersion) {
+  const pricingBtnContainer = pricingArea.querySelector('.button-container');
+  if (pricingBtnContainer === null) return;
+  const pricingSuffixTextElem = pricingBtnContainer.nextElementSibling;
+  const placeholderArr = pricingSuffixTextElem.textContent?.split(' ');
   const priceRow = createTag('div', { class: 'pricing-row' });
-  const priceEl = pricingArea.querySelector('[title="{{pricing}}"]');
-  if (!priceEl) return null;
+  const priceEl = pricingArea.querySelector(`[title="${PRICE_TOKEN}"]`);
+  if (!priceEl) return;
   const priceParent = priceEl?.parentNode;
 
   const price = createTag('span', { class: 'pricing-price' });
@@ -42,16 +90,20 @@ function handlePrice(placeholders, pricingArea, placeholderArr, specialPromo, le
   priceRow.append(basePrice, price, priceSuffix);
 
   fetchPlanOnePlans(priceEl?.href).then((response) => {
+    const priceSuffixTextContent = getPriceElementSuffix(
+      placeholders,
+      placeholderArr,
+      response,
+    );
     let specialPromoPercentageEyeBrowTextReplaced = false;
     let pricingCardPercentageEyeBrowTextReplaced = false;
     const parentP = priceEl.parentElement;
     price.innerHTML = response.formatted;
     basePrice.innerHTML = response.formattedBP || '';
-    if (basePrice.innerHTML !== '') {
-      price.classList.add('price-active');
-    } else {
-      price.classList.remove('price-active');
-    }
+    basePrice.innerHTML !== ''
+      ? price.classList.add('price-active')
+      : price.classList.remove('price-active');
+
     if (parentP.children.length > 1) {
       Array.from(parentP.childNodes).forEach((node) => {
         if (node === priceEl) return;
@@ -62,28 +114,38 @@ function handlePrice(placeholders, pricingArea, placeholderArr, specialPromo, le
         }
       });
     } else {
-      const priceSuffixContent = placeholderArr.map((phText) => {
-        const key = phText.replace('{{', '').replace('}}', '');
-        return (key.includes('vat') && !response.showVat) ? '' : placeholders[key] || '';
-      }).join(' ');
-      priceSuffix.textContent = priceSuffixContent;
+      priceSuffix.textContent = priceSuffixTextContent;
     }
+
     const isPremiumCard = response.ooAvailable || false;
     const savePercentElem = pricingArea.querySelector('.card-offer');
     if (savePercentElem && !pricingCardPercentageEyeBrowTextReplaced) {
       const offerTextContent = savePercentElem.textContent;
-      if (shallSuppressOfferEyebrowText(response.savePer, offerTextContent, isPremiumCard,
-        false, response.offerId)) {
+      if (
+        shallSuppressOfferEyebrowText(
+          response.savePer,
+          offerTextContent,
+          isPremiumCard,
+          false,
+          response.offerId,
+        )
+      ) {
         savePercentElem.remove();
       } else {
-        savePercentElem.innerHTML = savePercentElem.innerHTML.replace(`{{${SAVE_PERCENTAGE}}}`, response.savePer);
+        savePercentElem.innerHTML = savePercentElem.innerHTML.replace(
+          SAVE_PERCENTAGE,
+          response.savePer,
+        );
         pricingCardPercentageEyeBrowTextReplaced = true;
       }
     }
 
-    if (specialPromo && !specialPromoPercentageEyeBrowTextReplaced && specialPromo.textContent.includes(`{{${SAVE_PERCENTAGE}}}`)) {
+    if (
+      specialPromo
+      && !specialPromoPercentageEyeBrowTextReplaced
+      && specialPromo.textContent.includes(SAVE_PERCENTAGE)
+    ) {
       const offerTextContent = specialPromo.textContent;
-
       const shouldSuppress = shallSuppressOfferEyebrowText(
         response.savePer,
         offerTextContent,
@@ -91,44 +153,57 @@ function handlePrice(placeholders, pricingArea, placeholderArr, specialPromo, le
         true,
         response.offerId,
       );
+
       if (shouldSuppress) {
         suppressOfferEyebrow(specialPromo, legacyVersion);
       } else {
-        specialPromo.innerHTML = specialPromo.innerHTML.replace(`{{${SAVE_PERCENTAGE}}}`, response.savePer);
+        specialPromo.innerHTML = specialPromo.innerHTML.replace(
+          SAVE_PERCENTAGE,
+          response.savePer,
+        );
         specialPromoPercentageEyeBrowTextReplaced = true;
       }
     }
-    if (!isPremiumCard && specialPromo?.parentElement?.classList?.contains('special-promo')) {
+
+    if (
+      !isPremiumCard
+      && specialPromo?.parentElement?.classList?.contains('special-promo')
+    ) {
       specialPromo.parentElement.classList.remove('special-promo');
       if (specialPromo.parentElement.firstChild.innerHTML !== '') {
         specialPromo.parentElement.firstChild.remove();
       }
     }
+    console.log(response, pricingArea)
+    handleYear2PricingToken(
+      pricingArea,
+      response.y2p,
+      priceSuffixTextContent,
+    );
   });
 
   priceParent?.remove();
-  return priceRow;
+  if (!priceRow) return;
+  pricingArea.prepend(priceRow);
+
+  pricingBtnContainer?.remove();
+  pricingSuffixTextElem?.remove();
 }
 
-function createPricingSection(placeholders, pricingArea, ctaGroup, specialPromo, legacyVersion) {
+function createPricingSection(
+  placeholders,
+  pricingArea,
+  ctaGroup,
+  specialPromo,
+  legacyVersion,
+) {
   const pricingSection = createTag('div', { class: 'pricing-section' });
   pricingArea.classList.add('pricing-area');
   const offer = pricingArea.querySelector(':scope > p > em');
   if (offer) {
     offer.classList.add('card-offer');
   }
-  const pricingBtnContainer = pricingArea.querySelector('.button-container');
-  if (pricingBtnContainer != null) {
-    const pricingSuffixTextElem = pricingBtnContainer.nextElementSibling;
-    const placeholderArr = pricingSuffixTextElem.textContent?.split(' ');
-    const priceRow = handlePrice(placeholders, pricingArea,
-      placeholderArr, specialPromo, legacyVersion);
-    if (priceRow) {
-      pricingArea.prepend(priceRow);
-      pricingBtnContainer?.remove();
-      pricingSuffixTextElem?.remove();
-    }
-  }
+  handlePrice(placeholders, pricingArea, specialPromo, legacyVersion);
   ctaGroup.classList.add('card-cta-group');
   ctaGroup.querySelectorAll('a').forEach((a, i) => {
     a.classList.add('large');
@@ -183,7 +258,12 @@ function decorateLegacyHeader(header, card) {
     if (/^\d/.test(cfg)) {
       const headCntDiv = createTag('div', { class: 'head-cnt', alt: '' });
       headCntDiv.textContent = cfg;
-      headCntDiv.prepend(createTag('img', { src: '/express/icons/head-count.svg', alt: 'icon-head-count' }));
+      headCntDiv.prepend(
+        createTag('img', {
+          src: '/express/icons/head-count.svg',
+          alt: 'icon-head-count',
+        }),
+      );
       header.append(headCntDiv);
     } else {
       specialPromo = createTag('div');
@@ -211,10 +291,18 @@ function decorateHeader(header, borderParams, card, cardBorder) {
   const extractHeadCountExp = /(>?)\(\d+(.*?)\)/;
   if (extractHeadCountExp.test(h2.innerText)) {
     const headCntDiv = createTag('div', { class: 'head-cnt', alt: '' });
-    const headCount = h2.innerText.match(extractHeadCountExp)[0].replace(')', '').replace('(', '');
+    const headCount = h2.innerText
+      .match(extractHeadCountExp)[0]
+      .replace(')', '')
+      .replace('(', '');
     [h2.innerText] = h2.innerText.split(extractHeadCountExp);
     headCntDiv.textContent = headCount;
-    headCntDiv.prepend(createTag('img', { src: '/express/icons/head-count.svg', alt: 'icon-head-count' }));
+    headCntDiv.prepend(
+      createTag('img', {
+        src: '/express/icons/head-count.svg',
+        alt: 'icon-head-count',
+      }),
+    );
     header.append(headCntDiv);
   }
   if (premiumIcon) h2.append(premiumIcon);
@@ -270,17 +358,22 @@ function decorateCompareSection(compare, el, card) {
 }
 // In legacy versions, the card element encapsulates all content
 // In new versions, the cardBorder element encapsulates all content instead
-function decorateCard({
-  header,
-  borderParams,
-  explain,
-  mPricingRow,
-  mCtaGroup,
-  yPricingRow,
-  yCtaGroup,
-  featureList,
-  compare,
-}, el, placeholders, legacyVersion) {
+function decorateCard(
+  {
+    header,
+    borderParams,
+    explain,
+    mPricingRow,
+    mCtaGroup,
+    yPricingRow,
+    yCtaGroup,
+    featureList,
+    compare,
+  },
+  el,
+  placeholders,
+  legacyVersion,
+) {
   const card = createTag('div', { class: 'card' });
   const cardBorder = createTag('div', { class: 'card-border' });
 
@@ -289,10 +382,21 @@ function decorateCard({
     : decorateHeader(header, borderParams, card, cardBorder);
 
   decorateBasicTextSection(explain, 'card-explain', card);
-  const mPricingSection = createPricingSection(placeholders, mPricingRow, mCtaGroup,
-    specialPromo, legacyVersion);
+  console.log(mPricingRow)
+  const mPricingSection = createPricingSection(
+    placeholders,
+    mPricingRow,
+    mCtaGroup,
+    specialPromo,
+    legacyVersion,
+  );
   mPricingSection.classList.add('monthly');
-  const yPricingSection = createPricingSection(placeholders, yPricingRow, yCtaGroup, null);
+  const yPricingSection = createPricingSection(
+    placeholders,
+    yPricingRow,
+    yCtaGroup,
+    null,
+  );
   yPricingSection.classList.add('yearly', 'hide');
   card.append(mPricingSection, yPricingSection);
   subscribeToBlockMediator(mPricingSection, yPricingSection);
@@ -303,9 +407,7 @@ function decorateCard({
 
 // less thrashing by separating get and set
 async function syncMinHeights(...groups) {
-  const maxHeights = groups.map((els) => els
-    .filter((e) => !!e)
-    .reduce((max, e) => Math.max(max, e.offsetHeight), 0));
+  const maxHeights = groups.map((els) => els.filter((e) => !!e).reduce((max, e) => Math.max(max, e.offsetHeight), 0));
   await yieldToMain();
   maxHeights.forEach((maxHeight, i) => groups[i].forEach((e) => {
     if (e) e.style.minHeight = `${maxHeight}px`;
@@ -333,7 +435,9 @@ export default async function init(el) {
     .map((card) => decorateCard(card, el, placeholders, legacyVersion))
     .forEach((card) => cardsContainer.append(card));
 
-  const phoneNumberTags = [...cardsContainer.querySelectorAll('a')].filter((a) => a.title.includes(SALES_NUMBERS));
+  const phoneNumberTags = [...cardsContainer.querySelectorAll('a')].filter(
+    (a) => a.title.includes(SALES_NUMBERS),
+  );
   if (phoneNumberTags.length > 0) {
     await formatSalesPhoneNumber(phoneNumberTags, SALES_NUMBERS);
   }
@@ -347,7 +451,10 @@ export default async function init(el) {
         syncMinHeights(
           cards.map(({ header }) => header),
           cards.map(({ explain }) => explain),
-          cards.reduce((acc, card) => [...acc, card.mCtaGroup, card.yCtaGroup], []),
+          cards.reduce(
+            (acc, card) => [...acc, card.mCtaGroup, card.yCtaGroup],
+            [],
+          ),
           cards.map(({ featureList }) => featureList.querySelector('p')),
           cards.map(({ featureList }) => featureList),
           cards.map(({ compare }) => compare),

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -4,6 +4,7 @@ import {
   createTag,
   fetchPlaceholders,
   yieldToMain,
+  getIconElement,
 } from '../../scripts/utils.js';
 
 import {
@@ -60,7 +61,7 @@ function handleYear2PricingToken(pricingArea, y2p, priceSuffix) {
   try {
     const elements = pricingArea.querySelectorAll('p');
     const year2PricingToken = Array.from(elements).find(
-      (p) => p.textContent.includes(YEAR_2_PRICING_TOKEN)
+      (p) => p.textContent.includes(YEAR_2_PRICING_TOKEN),
     );
     if (!year2PricingToken) return;
     if (y2p) {
@@ -68,6 +69,8 @@ function handleYear2PricingToken(pricingArea, y2p, priceSuffix) {
         YEAR_2_PRICING_TOKEN,
         `${y2p} ${priceSuffix}`,
       );
+    } else {
+      year2PricingToken.textContent = '';
     }
   } catch (e) {
     window.lana.log(e);
@@ -156,6 +159,29 @@ function handleRawPrice(price, basePrice, response) {
     : price.classList.remove('price-active');
 }
 
+function handleTooltip(pricingArea) {
+  const elements = pricingArea.querySelectorAll('p');
+  const pattern = /\[\[([^]+)\]\]([^]+)\[\[\/([^]+)\]\]/g;
+  let tooltip;
+  let tooltipDiv;
+
+  Array.from(elements).forEach((p) => {
+    const res = pattern.exec(p.textContent);
+    if (res) {
+      tooltip = res;
+      tooltipDiv = p;
+    }
+  });
+  if (!tooltip) return;
+  tooltipDiv.textContent = tooltipDiv.textContent.replace(pattern, '');
+  const tooltipText = tooltip[2];
+  tooltipDiv.classList.add('tooltip');
+  const span = createTag('span', { class: 'tooltip-text' });
+  span.innerText = tooltipText;
+  const icon = getIconElement('info', 44, 'Info', 'tooltip-icon');
+  tooltipDiv.append(icon);
+  tooltipDiv.append(span);
+}
 function handlePrice(placeholders, pricingArea, specialPromo, legacyVersion) {
   const priceEl = pricingArea.querySelector(`[title="${PRICE_TOKEN}"]`);
   const pricingBtnContainer = pricingArea.querySelector('.button-container');
@@ -180,9 +206,9 @@ function handlePrice(placeholders, pricingArea, specialPromo, legacyVersion) {
     );
     const isPremiumCard = response.ooAvailable || false;
     const savePercentElem = pricingArea.querySelector('.card-offer');
-    console.log(response);
     handleRawPrice(price, basePrice, response);
     handlePriceSuffix(priceEl, priceSuffix, priceSuffixTextContent);
+    handleTooltip(pricingArea);
     handleSavePercentage(savePercentElem, isPremiumCard, response);
     handleSpecialPromo(specialPromo, isPremiumCard, response, legacyVersion);
     handleYear2PricingToken(pricingArea, response.y2p, priceSuffixTextContent);

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -121,7 +121,7 @@ function handleSavePercentage(savePercentElem, isPremiumCard, response) {
         response.savePer,
         offerTextContent,
         isPremiumCard,
-        false,
+        true,
         response.offerId,
       )
     ) {

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -176,7 +176,7 @@ function handleTooltip(pricingArea) {
   tooltipDiv.textContent = tooltipDiv.textContent.replace(pattern, '');
   const tooltipText = tooltip[2];
   tooltipDiv.classList.add('tooltip');
-  const span = createTag('span', { class: 'tooltip-text' });
+  const span = createTag('div', { class: 'tooltip-text' });
   span.innerText = tooltipText;
   const icon = getIconElement('info', 44, 'Info', 'tooltip-icon');
   tooltipDiv.append(icon);

--- a/express/scripts/utils/pricing.js
+++ b/express/scripts/utils/pricing.js
@@ -336,7 +336,7 @@ export const getOffer = (() => {
       savePer: offer.savePer,
       ooAvailable,
       showVat,
-      y2p: offer.y2p,
+      y2p: await formatPrice(offer.y2p, currency),
     };
   };
 })();
@@ -366,7 +366,6 @@ export const getOfferOnePlans = (() => {
     const customOfferId = offer.oo || offerId;
     const ooAvailable = offer.oo || false;
     const showVat = offer.showVat || false;
-    console.log(offer.y2p);
     return {
       country,
       currency,
@@ -384,7 +383,7 @@ export const getOfferOnePlans = (() => {
       savePer: offer.savePer,
       ooAvailable,
       showVat,
-      y2p: offer.y2p,
+      y2p: await formatPrice(offer.y2p, currency),
     };
   };
 })();

--- a/express/scripts/utils/pricing.js
+++ b/express/scripts/utils/pricing.js
@@ -336,6 +336,7 @@ export const getOffer = (() => {
       savePer: offer.savePer,
       ooAvailable,
       showVat,
+      y2p: offer.y2p,
     };
   };
 })();
@@ -365,7 +366,7 @@ export const getOfferOnePlans = (() => {
     const customOfferId = offer.oo || offerId;
     const ooAvailable = offer.oo || false;
     const showVat = offer.showVat || false;
-
+    console.log(offer.y2p)
     return {
       country,
       currency,
@@ -383,6 +384,7 @@ export const getOfferOnePlans = (() => {
       savePer: offer.savePer,
       ooAvailable,
       showVat,
+      y2p: offer.y2p,
     };
   };
 })();
@@ -456,6 +458,7 @@ export async function fetchPlanOnePlans(planUrl) {
           `<strong>${plan.prefix}${plan.rawBasePrice[0]}</strong>`,
         );
       }
+      plan.y2p = offer.y2p;
     }
 
     window.pricingPlans[planUrl] = plan;

--- a/express/scripts/utils/pricing.js
+++ b/express/scripts/utils/pricing.js
@@ -366,7 +366,7 @@ export const getOfferOnePlans = (() => {
     const customOfferId = offer.oo || offerId;
     const ooAvailable = offer.oo || false;
     const showVat = offer.showVat || false;
-    console.log(offer.y2p)
+    console.log(offer.y2p);
     return {
       country,
       currency,

--- a/express/scripts/utils/pricing.js
+++ b/express/scripts/utils/pricing.js
@@ -457,7 +457,7 @@ export async function fetchPlanOnePlans(planUrl) {
           `<strong>${plan.prefix}${plan.rawBasePrice[0]}</strong>`,
         );
       }
-      plan.y2p = await formatPrice(offer.y2p, offer.currency);
+      plan.y2p = offer.y2p;
     }
 
     window.pricingPlans[planUrl] = plan;

--- a/express/scripts/utils/pricing.js
+++ b/express/scripts/utils/pricing.js
@@ -457,7 +457,7 @@ export async function fetchPlanOnePlans(planUrl) {
           `<strong>${plan.prefix}${plan.rawBasePrice[0]}</strong>`,
         );
       }
-      plan.y2p = offer.y2p;
+      plan.y2p = await formatPrice(offer.y2p, offer.currency);
     }
 
     window.pricingPlans[planUrl] = plan;


### PR DESCRIPTION
Describe your specific features or fixes

Adds tooltips and a third pricing token to pricing cards.

The 2nd year pricing token will be added if you include a [[year-2-pricing-token]] in the pricing area and if an entry is made in the y2p column in the pricing spreadsheet. I already added the column and two example values to offer-one.xlsx. They are in row 333 and 427. The third pricing token will remove itself from the page if there is no value in the y2p column for the deal that corresponds to the page + locale.
The tooltip token can be added by including [[tooltip]] "tooltip text here" [[/tooltip]] within the pricing area. I only tested with one tooltip but you should be able to add multiple if

<img width="1274" alt="Screenshot 2024-05-01 at 1 37 53 PM" src="https://github.com/adobecom/express/assets/159481679/9969721d-6777-4eb9-9cdd-36c5c2df5f3d">

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-147486)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After:  https://third-pricing-token--express--adobecom.hlx.page/drafts/echen/pricing-cards?country=eg
