### PR TITLE
[Pricing-Cards] Remove pricing-area Fixed Height

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -262,7 +262,6 @@ End border style variants
   background: var(--color-gray-150);
   border: 1px solid #E0E2FF;
   padding: var(--card-padding);
-  height: 125px;
 }
 
 .pricing-cards .pricing-row {
@@ -383,9 +382,6 @@ End border style variants
   box-sizing: border-box;
 }
 
-
-
-
 @media screen and (min-width: 768px) {
   :root {
     --card-width: 362px;
@@ -415,14 +411,6 @@ End border style variants
     gap: 24px;
   }
 
-  .pricing-cards .card .card-cta-group.min-height-2 {
-    min-height: 106px;
-  }
-
-  .pricing-cards .card .card-cta-group.min-height-3 {
-    min-height: 167px;
-  }
-
   .pricing-cards .card .card-header h2 {
     font-size: 1.75rem;
     margin-top: 0px;
@@ -439,7 +427,5 @@ End border style variants
 
   .pricing-cards .cards-container:has(>.card:first-child:nth-last-child(3)) {
     grid-template-columns: repeat(auto-fit, minmax(var(--card-width), calc((1200px - 32px) / 3)));
-  }
-
-  
+  }  
 }

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -348,6 +348,7 @@ export default async function init(el) {
           cards.map(({ header }) => header),
           cards.map(({ explain }) => explain),
           cards.reduce((acc, card) => [...acc, card.mCtaGroup, card.yCtaGroup], []),
+          [...el.querySelectorAll('.pricing-area')],
           cards.map(({ featureList }) => featureList.querySelector('p')),
           cards.map(({ featureList }) => featureList),
           cards.map(({ compare }) => compare),


### PR DESCRIPTION
Gives Pricing Area dynamic but consistent height. 

Resolves: https://jira.corp.adobe.com/browse/MWPW-147607?filter=381833

Test URLs:
- Before: https://main--express--adobecom.hlx.page/drafts/jinglhua/pricing-cards-grey-box?lighthouse=on
- After: https://pricing-cards-height--express--adobecom.hlx.page/drafts/jinglhua/pricing-cards-grey-box?lighthouse=on
