### PR TITLE
[MWPW-147509] Add Class For Suppressing Floating CTA On Mobile

### DIFF
--- a/express/blocks/hero-color/hero-color.js
+++ b/express/blocks/hero-color/hero-color.js
@@ -108,6 +108,7 @@ function decorateCTA(block) {
   if (!primaryCta) return;
 
   primaryCta.classList.add('primaryCta');
+  primaryCta.classList.add('suppress-on-mobile');
   BlockMediator.set('primaryCtaUrl', primaryCta.href);
 }
 

--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -160,7 +160,7 @@ export function createFloatingButton(block, audience, data) {
   // Hide CTAs with same url & text as the Floating CTA && is NOT a Floating CTA (in mobile/tablet)
   const sameUrlCTAs = Array.from(main.querySelectorAll('a.button:any-link'))
     .filter((a) => (a.textContent.trim() === aTag.textContent.trim()
-      || new URL(a.href).pathname === new URL(aTag.href).pathname)
+      || new URL(a.href).pathname === new URL(aTag.href).pathname) || aTag.classList.contains('suppress-on-mobile')
       && !a.parentElement.parentElement.classList.contains('floating-button') && !a.classList.contains('floating-cta-ignore'));
   sameUrlCTAs.forEach((cta) => {
     cta.classList.add('same-as-floating-button-CTA');


### PR DESCRIPTION
Describe your specific features or fixes

Adds the 'suppress-on-mobile' CSS class. Elements with this class will be suppressed on mobile devices if they are a primary CTA.

Resolves: [MWPW-147509](https://jira.corp.adobe.com/browse/MWPW-147509)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://color-cta-fix--express--adobecom.hlx.page/express/colors/orange

<img width="557" alt="Screenshot 2024-05-02 at 1 22 40 PM" src="https://github.com/adobecom/express/assets/159481679/5e917602-f421-4f06-9b5d-06dac878f986">
