### PR TITLE
[Pricing] Pricing Cards Height

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -209,6 +209,7 @@ End border style variants
   font-weight: 700;
   color: #5258E4;
   height: 20px;
+  font-style: normal;
 }
 
 .pricing-cards .card-offer a {
@@ -262,10 +263,10 @@ End border style variants
   background: var(--color-gray-150);
   border: 1px solid #E0E2FF;
   padding: var(--card-padding);
-}
-
-.pricing-cards .pricing-row {
-  height: 55px;
+  box-sizing: border-box;
+  displaY: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .pricing-cards .pricing-area p {
@@ -273,14 +274,8 @@ End border style variants
   font-size: var(--body-font-size-s);
 }
 
-.pricing-cards .pricing-area p em {
-  font-style: normal;
-  color: #5258E4;
-}
-
 .pricing-cards .pricing-area .pricing-row-suf {
   font-size: var(--body-font-size-xs);
-  padding-bottom: 12px;
 }
 
 .pricing-cards .pricing-area:not(:has(p)) {
@@ -395,7 +390,7 @@ End border style variants
 @media screen and (min-width: 1250px) {
   :root {
     --card-width: 400px;
-    --card-padding: 24px 16px;
+    --card-padding: 16px;
   }
 
   .pricing-cards .cards-container:has(>.card-border:only-child) {

--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -1,6 +1,6 @@
 :root {
   --card-width: 353px;
-  --card-padding: 16px 12px;
+  --card-padding: 12px;
 }
 
 .pricing-cards.no-visible {
@@ -378,19 +378,14 @@ End border style variants
 }
 
 @media screen and (min-width: 768px) {
-  :root {
-    --card-width: 362px;
-  }
-
   .pricing-cards .card-border .card-header h2 {
     margin-top: 0;
   }
 }
 
-@media screen and (min-width: 1250px) {
+@media screen and (min-width: 1277px) {
   :root {
     --card-width: 400px;
-    --card-padding: 16px;
   }
 
   .pricing-cards .cards-container:has(>.card-border:only-child) {

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -73,7 +73,7 @@ async function handlePrice(placeholders, pricingArea, placeholderArr, specialPro
   } else {
     const priceSuffixContent = placeholderArr.map((phText) => {
       const key = phText.replace('{{', '').replace('}}', '');
-      return (key.includes('vat') && !response.showVat) ? '' : placeholders[key] || '';
+      return (key.includes('vat') && !response.showVat) ? '' : placeholders?.[key] || '';
     }).join(' ');
     priceSuffix.textContent = priceSuffixContent;
   }

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -61,7 +61,7 @@ function getPriceElementSuffix(placeholders, placeholderArr, response) {
       const key = phText.replace('{{', '').replace('}}', '');
       return key.includes('vat') && !response.showVat
         ? ''
-        : placeholders[key] || '';
+        : placeholders?.[key] || '';
     })
     .join(' ');
 }

--- a/express/blocks/tabs-ax/tabs-ax.js
+++ b/express/blocks/tabs-ax/tabs-ax.js
@@ -183,12 +183,6 @@ const init = (block) => {
     tabListItems[0].parentElement.remove();
   }
 
-  // as of now tabs-ax is used above the fold and it's usually h1 default wrapper before it
-  // TODO: develop consistent padding/margin patterns for block/section
-  if (parentSection.previousElementSibling.classList.contains('hero', 'hero-noimage')) {
-    parentSection.previousElementSibling.style.paddingTop = '0';
-  }
-
   // Tab Sections
   const allSections = Array.from(rootElem.querySelectorAll('div.section[data-tab]'));
   allSections.forEach((e) => {


### PR DESCRIPTION
Allow cards' greybox height synching behavior to differ based on mobile/tablet/desktop. More specifically, when you resize or reload your window, it should sync heights on tablet/desktop, but cancel the behavior when on mobile when cards are stacked.

Resolves: https://jira.corp.adobe.com/browse/MWPW-147607?filter=381833

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/jinglhua/pricing-cards-grey-box?lighthouse=on
- After: https://pricing-cards-height--express--adobecom.hlx.page/drafts/jinglhua/pricing-cards-grey-box?lighthouse=on
