### PR TITLE
[Floating-CTA] Handle Authored Invalid Urls

### DIFF
--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -650,12 +650,17 @@ export function removeIrrelevantSections(main) {
     if (textToTarget || linkToTarget) {
       const sameUrlCTAs = Array.from(main.querySelectorAll('a:any-link'))
         .filter((a) => {
-          const sameText = a.textContent.trim() === textToTarget;
-          const samePathname = new URL(a.href).pathname === new URL(linkToTarget)?.pathname;
-          const isNotInFloatingCta = !a.closest('.block')?.classList.contains('floating-button');
-          const notFloatingCtaIgnore = !a.classList.contains('floating-cta-ignore');
+          try {
+            const sameText = a.textContent.trim() === textToTarget;
+            const samePathname = new URL(a.href).pathname === new URL(linkToTarget)?.pathname;
+            const isNotInFloatingCta = !a.closest('.block')?.classList.contains('floating-button');
+            const notFloatingCtaIgnore = !a.classList.contains('floating-cta-ignore');
 
-          return (sameText || samePathname) && isNotInFloatingCta && notFloatingCtaIgnore;
+            return (sameText || samePathname) && isNotInFloatingCta && notFloatingCtaIgnore;
+          } catch (err) {
+            window.lana?.log(err);
+            return false;
+          }
         });
 
       sameUrlCTAs.forEach((cta) => {


### PR DESCRIPTION
Right now the page can crash when an invalid url is authored in the floatingCTA sheet. Added handlers to at least show page content.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/es/express/create/book/employee-handbook?lighthouse=on
- After: https://floating-cta-handle-missing-link--express--adobecom.hlx.page/es/express/create/book/employee-handbook?lighthouse=on
