### PR TITLE
[MWPW-143269] Price Token Formatting Fix

### DIFF
--- a/express/blocks/marquee/marquee.js
+++ b/express/blocks/marquee/marquee.js
@@ -31,16 +31,17 @@ const breakpointConfig = [
   },
 ];
 
+const PRICE_TOKEN = '{{pricing}}';
+
 // Transforms a {{pricing}} tag into human readable format.
 async function handlePrice(block) {
-  const priceEl = block.querySelector('[title="{{pricing}}"]');
+  const priceEl = block.querySelector(`[title="${PRICE_TOKEN}"]`);
   if (!priceEl) return null;
-  priceEl.closest('p')?.classList.remove('button-container');
-  const parent = priceEl.parentElement;
+
   const newContainer = createTag('span');
+  priceEl.closest('p')?.classList.remove('button-container');
+  priceEl.after(newContainer)
   priceEl.remove();
-  parent.parentElement.append(newContainer);
-  parent.remove();
   try {
     const response = await fetchPlanOnePlans(priceEl?.href);
     newContainer.innerHTML = response.formatted;

--- a/express/blocks/marquee/marquee.js
+++ b/express/blocks/marquee/marquee.js
@@ -40,7 +40,7 @@ async function handlePrice(block) {
 
   const newContainer = createTag('span');
   priceEl.closest('p')?.classList.remove('button-container');
-  priceEl.after(newContainer)
+  priceEl.after(newContainer);
   priceEl.remove();
   try {
     const response = await fetchPlanOnePlans(priceEl?.href);


### PR DESCRIPTION
Describe your specific features or fixes

Changes the marquee price token so that it is not automatically sent to the end of the line.

Resolves: https://jira.corp.adobe.com/browse/MWPW-143269

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://pricing-token-line--express--adobecom.hlx.page/drafts/esallee/marketers-pricing-token-bug
<img width="1335" alt="Screenshot 2024-05-08 at 9 30 30 AM" src="https://github.com/adobecom/express/assets/159481679/6e7adbbb-e512-44fb-86dd-8e0ffa9a05bb">

