### PR TITLE
MWPW-146525 add unav scopes to adobeid

### DIFF
--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -23,6 +23,15 @@ if (isHomepage && getConfig().env.ims === 'prod') {
 }
 let imsLibProm;
 
+// TODO remove all this when we go live with the unav
+const usp = new URLSearchParams(window.location.search);
+const unav = usp.get('unav')?.toLowerCase();
+if (unav === 'on' || unav === 'true') {
+  sessionStorage.setItem('unav', 'true');
+} else if (unav === 'off' || unav === 'false') {
+  sessionStorage.removeItem('unav');
+}
+
 async function checkRedirect(location, geoLookup) {
   const splits = location.pathname.split('/express/');
   splits[0] = '';
@@ -61,7 +70,7 @@ async function checkGeo(userGeo, userLocale, geoCheckForce) {
 async function loadIMS() {
   window.adobeid = {
     client_id: 'AdobeExpressWeb',
-    scope: 'AdobeID,openid',
+    scope: `AdobeID,openid${sessionStorage.getItem('unav') === 'true' ? ',pps.read,firefly_api,additional_info.roles,read_organizations' : ''}`,
     locale: getConfig().locale.region,
     environment: getConfig().env.ims,
   };
@@ -158,15 +167,6 @@ async function loadFEDS() {
   const fedsExp = isMegaNav
     ? 'adobe-express/ax-gnav-x'
     : 'adobe-express/ax-gnav-x-row';
-
-  // TODO remove all this when we go live with the unav
-  const usp = new URLSearchParams(window.location.search);
-  const unav = usp.get('unav')?.toLowerCase();
-  if (unav === 'on' || unav === 'true') {
-    sessionStorage.setItem('unav', 'true');
-  } else if (unav === 'off' || unav === 'false') {
-    sessionStorage.removeItem('unav');
-  }
 
   window.fedsConfig = {
     ...(window.fedsConfig || {}),


### PR DESCRIPTION
Forgot to add scopes as well to the unav. It "breaks" the unav, but we need them active to properly test for when the scopes are granted. 

Resolves: [MWPW-146525](https://jira.corp.adobe.com/browse/MWPW-146525)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/?unav=on
- After: https://unav-scopes--express--adobecom.hlx.page/express/?unav=on
