### PR TITLE
[Analytics] [Milo-Migration] Enable Milo Tagging

### DIFF
--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2516,11 +2516,10 @@ export async function loadArea(area = document) {
     import('../features/links.js').then((mod) => mod.default(path, area));
   }
 
-  if (['on', 'yes'].includes(getMetadata('milo-analytics')?.toLowerCase()) || params.get('milo-analytics') === 'on') {
-    import('./attributes.js').then((analytics) => {
-      document.querySelectorAll('main > div').forEach((section, idx) => analytics.decorateSectionAnalytics(section, idx, config));
-    });
-  }
+  import('./attributes.js').then((analytics) => {
+    document.querySelectorAll('main > div').forEach((section, idx) => analytics.decorateSectionAnalytics(section, idx, config));
+  });
+
   window.hlx.martechLoaded?.then(() => import('./legacy-analytics.js')).then(({ default: decorateTrackingEvents }) => {
     decorateTrackingEvents();
   });


### PR DESCRIPTION
We have received confirmation that we can go ahead and enable the new tagging approach on all pages and let 2 systems work in parallel as we retire the old one. This PR will turn the used-to-be-flagged milo-analytics feature on for all pages.

It should have no visual impacts and have minimal impacts of visitor experience and performance.

You can follow https://milo.adobe.com/docs/authoring/analytics-review and install https://chromewebstore.google.com/detail/adobe-hawkeye-link-audito/ffiidihjbbghpfelfplkcgbdjkjdcajj and use it to verify most links are tagged correctly.

Resolves: https://jira.corp.adobe.com/browse/MWPW-139851

Test URLs:
- Before: https://main--express--adobecom.hlx.live/express/
- After: https://enable-milo-tagging--express--adobecom.hlx.live/express/
