### PR TITLE
[Floating-CTA] Add Hash to sameCTA Comparisons

### DIFF
--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -158,9 +158,11 @@ export function createFloatingButton(block, audience, data) {
   new ResizeObserver(outputsize).observe(floatButtonLink);
 
   // Hide CTAs with same url & text as the Floating CTA && is NOT a Floating CTA (in mobile/tablet)
+  const aTagURL = new URL(aTag.href);
   const sameUrlCTAs = Array.from(main.querySelectorAll('a.button:any-link'))
-    .filter((a) => (a.textContent.trim() === aTag.textContent.trim()
-      || new URL(a.href).pathname === new URL(aTag.href).pathname)
+    .filter((a) => (
+      a.textContent.trim() === aTag.textContent.trim()
+      || (new URL(a.href).pathname === aTagURL.pathname && new URL(a.href).hash === aTagURL.hash))
       && !a.parentElement.parentElement.classList.contains('floating-button') && !a.classList.contains('floating-cta-ignore'));
   sameUrlCTAs.forEach((cta) => {
     cta.classList.add('same-as-floating-button-CTA');

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -648,15 +648,19 @@ export function removeIrrelevantSections(main) {
     const textToTarget = getMetadata(`${device}-floating-cta-text`)?.trim() || getMetadata('main-cta-text')?.trim();
     const linkToTarget = getMetadata(`${device}-floating-cta-link`)?.trim() || getMetadata('main-cta-link')?.trim();
     if (textToTarget || linkToTarget) {
+      const linkToTargetURL = new URL(linkToTarget);
       const sameUrlCTAs = Array.from(main.querySelectorAll('a:any-link'))
         .filter((a) => {
           try {
+            const currURL = new URL(a.href);
             const sameText = a.textContent.trim() === textToTarget;
-            const samePathname = new URL(a.href).pathname === new URL(linkToTarget)?.pathname;
+            const samePathname = currURL.pathname === linkToTargetURL?.pathname;
+            const sameHash = currURL.hash === linkToTargetURL?.pathname;
             const isNotInFloatingCta = !a.closest('.block')?.classList.contains('floating-button');
             const notFloatingCtaIgnore = !a.classList.contains('floating-cta-ignore');
 
-            return (sameText || samePathname) && isNotInFloatingCta && notFloatingCtaIgnore;
+            return (sameText || (samePathname && sameHash))
+              && isNotInFloatingCta && notFloatingCtaIgnore;
           } catch (err) {
             window.lana?.log(err);
             return false;

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -655,7 +655,7 @@ export function removeIrrelevantSections(main) {
             const currURL = new URL(a.href);
             const sameText = a.textContent.trim() === textToTarget;
             const samePathname = currURL.pathname === linkToTargetURL?.pathname;
-            const sameHash = currURL.hash === linkToTargetURL?.pathname;
+            const sameHash = currURL.hash === linkToTargetURL?.hash;
             const isNotInFloatingCta = !a.closest('.block')?.classList.contains('floating-button');
             const notFloatingCtaIgnore = !a.classList.contains('floating-cta-ignore');
 


### PR DESCRIPTION
As of now we only compare pathname. This PR will also require hash to match to qualify for the floatingCTA's sameCTA hiding mechanism.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/business?lighthouse=on
- After: https://fcta-hash--express--adobecom.hlx.page/express/business?lighthouse=on
