### PR TITLE
[Enterprise] Added Enterprise Variant for Icon-List and Columns

### DIFF
--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -21,6 +21,19 @@ main .columns-top-container > div {
   max-width: 350px;
 }
 
+.section.columns-enterprise-container .default-content-wrapper h2 {
+  margin-top: 0;
+  padding-top: 80px;
+}
+
+.columns-enterprise-container .columns-wrapper {
+  max-width: unset;
+}
+
+.columns.enterprise > div {
+  gap: 40px;
+}
+
 main .columns-highlight-container,
 main .columns-dark-container {
   padding-bottom: 120px;
@@ -159,11 +172,13 @@ main .columns > div {
   padding: 40px 0;
 }
 
-main .columns.center .column {
+main .columns.center .column,
+main .columns.enterprise .column {
   text-align: center;
 }
 
-main .columns.center .column p.button-container {
+main .columns.center .column p.button-container,
+main .columns.enterprise .column p.button-container {
   text-align: center;
 }
 
@@ -308,7 +323,15 @@ main .columns.center .column h2,
 main .columns.center .column h3,
 main .columns.center .column h4,
 main .columns.center .column h5,
-main .columns.center .column h6 {
+main .columns.center .column h6,
+main .columns.enterprise .column,
+main .columns.enterprise .column p.button-container,
+main .columns.enterprise .column h1,
+main .columns.enterprise .column h2,
+main .columns.enterprise .column h3,
+main .columns.enterprise .column h4,
+main .columns.enterprise .column h5,
+main .columns.enterprise .column h6 {
   text-align: center;
 }
 
@@ -860,6 +883,10 @@ main .columns.fullsize.top .column .columns-iconlist .columns-iconlist-descripti
 
   main .columns-video .column-picture .column-video-overlay {
     width: 50%;
+  }
+
+  .section.columns-enterprise-container .column h2 {
+    font-size: var(--heading-font-size-xxl);
   }
 }
 

--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -21,12 +21,16 @@ main .columns-top-container > div {
   max-width: 350px;
 }
 
+ 
+
 .section.columns-enterprise-container .default-content-wrapper h2 {
   margin-top: 0;
   padding-top: 80px;
 }
 
 .columns-enterprise-container .columns-wrapper {
+  padding-left: 80px;
+  padding-right: 80px;
   max-width: unset;
 }
 
@@ -674,6 +678,18 @@ main .columns.fullsize.top .column .columns-iconlist .columns-iconlist-descripti
 
   :lang(ja) main .columns h2.columns-heading-x-long {
     font-size: var(--heading-font-size-m);
+  }
+
+  .secion.columns-enterprise-container .columns-wrapper {
+    padding-left: auto;
+    padding-right: auto;
+
+  }
+  
+  .section.columns-enterprise-container .default-content-wrapper h2 {
+      padding-left: 20px;
+      padding-right: 20px;
+      word-break: auto-phrase;
   }
 }
 

--- a/express/blocks/icon-list/icon-list.css
+++ b/express/blocks/icon-list/icon-list.css
@@ -163,6 +163,15 @@ main .icon-list-center-container ~ .columns-highlight-container {
   margin-top: 120px;
 }
 
+.section.icon-list-enterprise-container .default-content-wrapper h4 {
+  padding-top: 120px;
+  font-size: var(--heading-font-size-l);
+}
+
+.icon-list.enterprise {
+  padding-bottom: 120px;
+}
+
 @media (min-width:900px) {
   main .icon-list.two-column {
     flex-wrap: nowrap;


### PR DESCRIPTION
Added a very specific variant for icon-list and columns. They are already very brittle blocks due to how much they modify and depend on their section and block wrappers. We should plan for a refactor or reduce the usage on them.

Resolves: https://jira.corp.adobe.com/browse/MWPW-148328

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/business
- After: https://enterprise-padding--express--adobecom.hlx.page/express/business?lighthouse=on
