### PR TITLE
[MWPW-147736] Quotes + Italic Link Fix

### DIFF
--- a/express/blocks/quotes/quotes.css
+++ b/express/blocks/quotes/quotes.css
@@ -34,12 +34,8 @@ main .quotes .quote .content::before {
   font-weight: 900;
 }
 
-main .quotes .quote .author {
-  display: flex;
+main .quotes .quote .author { 
   margin-top: 16px;
-  width: 100%;
-  flex-direction: row;
-  flex-wrap: nowrap;
   align-items: center;
   align-self: baseline;
 }


### PR DESCRIPTION
Describe your specific features or fixes

Using italics / bold characters can cause a space to be deleted when used inline with text. This was due to unnecessary flexbox styling for the element. 

Resolves: [MWPW-147736](https://jira.corp.adobe.com/browse/MWPW-147736)
Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://italic-quote-align--express--adobecom.hlx.page/express/discover/quotes/mental-health
<img width="1242" alt="Screenshot 2024-05-20 at 1 47 17 PM" src="https://github.com/adobecom/express/assets/159481679/92c0d725-4dd4-4bd4-b1b0-4b2138ee8136">
<img width="1033" alt="Screenshot 2024-05-20 at 1 47 23 PM" src="https://github.com/adobecom/express/assets/159481679/70b2e314-82fb-47d5-aafe-b4b9ed33c64e">

