### PR TITLE
[MWPW-149151] Update Norway Language Flag

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -83,7 +83,7 @@ sitemaps:
       norway:
         source: /no/express/query-index.json
         destination: /no/express/sitemap.xml
-        hreflang: nb
+        hreflang: no
         alternate: /no/{path}
       sweden:
         source: /se/express/query-index.json


### PR DESCRIPTION
Describe your specific features or fixes

Updates the language flag in Norway href links from nb to no

Resolves: [MWPW-149151](https://jira.corp.adobe.com/browse/MWPW-149151)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://norway-language-change--express--adobecom.hlx.page/express/
