### PR TITLE
[Templates] Update Sitemap for UK Templates

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -13,6 +13,7 @@ folders:
   /kr/express/templates/: /kr/express/templates/default
   /nl/express/templates/: /nl/express/templates/default
   /tw/express/templates/: /tw/express/templates/default
+  /uk/express/templates/: /uk/express/templates/default
   /express/colors/: /express/colors/default
   /br/express/colors/: /br/express/colors/default
   /cn/express/colors/: /cn/express/colors/default

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -194,11 +194,11 @@ sitemaps:
         destination: /nl/express/templates/sitemap.xml
         hreflang: nl
         alternate: /nl/{path}
-      unitedkingdom:
-        source: /uk/express/templates/default/metadata.json?sheet=sitemap
-        destination: /uk/express/templates/sitemap.xml
-        hreflang: en-GB
-        alternate: /uk/{path}
+      # unitedkingdom:
+      #   source: /uk/express/templates/default/metadata.json?sheet=sitemap
+      #   destination: /uk/express/templates/sitemap.xml
+      #   hreflang: en-GB
+      #   alternate: /uk/{path}
   
   colors:
     origin: https://www.adobe.com

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -194,6 +194,11 @@ sitemaps:
         destination: /nl/express/templates/sitemap.xml
         hreflang: nl
         alternate: /nl/{path}
+      unitedkingdom:
+        source: /uk/express/templates/default/metadata.json?sheet=sitemap
+        destination: /uk/express/templates/sitemap.xml
+        hreflang: en-GB
+        alternate: /uk/{path}
   
   colors:
     origin: https://www.adobe.com


### PR DESCRIPTION
Enable UK to start adding template pages. This should have no impact yet. Once some of the pages become ready to go live, we'll update and verify the sitemap then. Note that we can't start authoring UK template pages yet, before the fstab update reaches main.

Resolves: https://jira.corp.adobe.com/browse/MWPW-146394

Test URLs:
- Before: https://main--express--adobecom.hlx.page/uk/express/templates/?lighthouse=on
- After: https://uk-templates-sitemap--express--adobecom.hlx.page/uk/express/templates/?lighthouse=on
