### PR TITLE
CTA-Carousel Prompt Link Fix

### DIFF
--- a/express/blocks/cta-carousel/cta-carousel.js
+++ b/express/blocks/cta-carousel/cta-carousel.js
@@ -58,7 +58,13 @@ function handleGenAISubmit(form, link) {
   const input = form.querySelector('.gen-ai-input');
 
   btn.disabled = true;
-  const genAILink = link.replace('%7B%7Bprompt-text%7D%7D', encodeURI(input.value).replaceAll(' ', '+'));
+ 
+  let promptToken = '{{prompt-text}}'
+  const legacyPromptToken = '%7B%7Bprompt-text%7D%7D';
+  if (link.indexOf(legacyPromptToken) > -1) {
+    promptToken = legacyPromptToken;
+  }
+  const genAILink = link.replace(promptToken, encodeURI(input.value).replaceAll(' ', '+'));
   if (genAILink !== '') window.location.assign(genAILink);
 }
 

--- a/express/blocks/cta-carousel/cta-carousel.js
+++ b/express/blocks/cta-carousel/cta-carousel.js
@@ -58,8 +58,8 @@ function handleGenAISubmit(form, link) {
   const input = form.querySelector('.gen-ai-input');
 
   btn.disabled = true;
- 
-  let promptToken = '{{prompt-text}}'
+
+  let promptToken = '{{prompt-text}}';
   const legacyPromptToken = '%7B%7Bprompt-text%7D%7D';
   if (link.indexOf(legacyPromptToken) > -1) {
     promptToken = legacyPromptToken;


### PR DESCRIPTION
Describe your specific features or fixes

Updates the CTA carousel gen ai cards to support links of the following format. 

https://adobesparkpost.app.link/c4bWARQhWAb?category=media&prompt={{prompt-text}}&action=text+to+image&width=1080&height=1080

The prompt token logic was only working with the following urls previously.

https://adobesparkpost.app.link/c4bWARQhWAb?category=media&prompt=%7B%7Bprompt-text%7D%7D&action=text+to+image&width=1080&height=1080

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://gen-ai-prompt-text--express--adobecom.hlx.page/express/
