### PR TITLE
[PEP] Only Activate for Branch Links

### DIFF
--- a/express/scripts/express-delayed.js
+++ b/express/scripts/express-delayed.js
@@ -109,12 +109,17 @@ export async function getProfile() {
   });
 }
 
+const branchLinkOrigins = ['https://adobesparkpost.app.link/', 'https://adobesparkpost-web.app.link/'];
+function isBranchLink(url) {
+  return branchLinkOrigins.includes(new URL(url).origin);
+}
 // product entry prompt
 async function canPEP() {
   if (document.body.dataset.device !== 'desktop') return false;
   const pepSegment = getMetadata('pep-segment');
   if (!pepSegment) return false;
-  if (!getDestination()) return false;
+  const destination = getDestination();
+  if (!destination || !isBranchLink(destination)) return false;
   const placeholders = await fetchPlaceholders();
   if (!placeholders.cancel || !placeholders['pep-header'] || !placeholders['pep-cancel']) return false;
   const segments = getSegmentsFromAlloyResponse(await window.alloyLoader);

--- a/express/scripts/express-delayed.js
+++ b/express/scripts/express-delayed.js
@@ -109,7 +109,7 @@ export async function getProfile() {
   });
 }
 
-const branchLinkOrigins = ['https://adobesparkpost.app.link/', 'https://adobesparkpost-web.app.link/'];
+const branchLinkOrigins = ['https://adobesparkpost.app.link', 'https://adobesparkpost-web.app.link'];
 function isBranchLink(url) {
   return branchLinkOrigins.includes(new URL(url).origin);
 }


### PR DESCRIPTION
Only enable PEP when destinations are branch links. Unfortunately PEP won't work unless in stage/prod, so to verify it, you'll need to set up local overrides. But hopefully the code change is straightforward enough or you can set up break points to verify the logic.

Resolves: https://jira.corp.adobe.com/browse/MWPW-151471

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/?lighthouse=on
- After: https://pep-only-branch-links--express--adobecom.hlx.page/express/?lighthouse=on
