### PR TITLE
Tooltip Superscript

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -170,6 +170,7 @@ End border style variants
 .pricing-cards .tooltip-text {
   display: none;
   padding: 8px;
+  z-index: 10;
   background-color: #292929;
   color: white;
   border-radius: 8px;

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -174,7 +174,8 @@ function handleTooltip(pricingArea) {
     }
   });
   if (!tooltip) return;
-  tooltipDiv.textContent = tooltipDiv.textContent.replace(pattern, '');
+ 
+  tooltipDiv.innerHTML  = tooltipDiv.innerHTML.replace(pattern, '');
   const tooltipText = tooltip[2];
   tooltipDiv.classList.add('tooltip');
   const span = createTag('div', { class: 'tooltip-text' });

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -174,8 +174,8 @@ function handleTooltip(pricingArea) {
     }
   });
   if (!tooltip) return;
- 
-  tooltipDiv.innerHTML  = tooltipDiv.innerHTML.replace(pattern, '');
+
+  tooltipDiv.innerHTML = tooltipDiv.innerHTML.replace(pattern, '');
   const tooltipText = tooltip[2];
   tooltipDiv.classList.add('tooltip');
   const span = createTag('div', { class: 'tooltip-text' });

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -527,7 +527,7 @@ function getIcon(icons, alt, size = 44, altSrc) {
 
 export function getIconElement(icons, size, alt, additionalClassName, altSrc) {
   const icon = getIcon(icons, alt, size, altSrc);
-  if (additionalClassName) icon.className.add(additionalClassName);
+  if (additionalClassName) icon.classList.add(additionalClassName);
   return icon;
 }
 


### PR DESCRIPTION
Describe your specific features or fixes

Preserves the formatting of the tooltip paragraph in pricing cards instead of overwriting it.

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://tooltip-superscript--express--adobecom.hlx.page/drafts/esallee/teams-tooltip-draft
- 
<img width="1107" alt="Screenshot 2024-05-30 at 1 17 39 PM" src="https://github.com/adobecom/express/assets/159481679/e0019dc7-065e-40c4-8c0f-b0b1e34a11dc">

