### PR TITLE
Update Jira Team name for Jira creation

### DIFF
--- a/.kodiak/config.yaml
+++ b/.kodiak/config.yaml
@@ -13,7 +13,7 @@ notifications:
       fields:
         customfield_11800: MWPW-145743 #epic link
         customfield_12900: 
-          value: Express Dev
+          value: Express dev
         watchers:
           - dstrong
           - vhargrave


### PR DESCRIPTION
Per Kodiak requirement, updating our team name for jira ticket creation. Should have no impact on our pages.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/
- After: https://kodiak-jira-team-name--express--adobecom.hlx.page/express/?lighthouse=on
