### PR TITLE
Use placeholders and Distinct BranchLinks from SearchBranchLinks

### DIFF
--- a/express/blocks/cta-carousel/cta-carousel.js
+++ b/express/blocks/cta-carousel/cta-carousel.js
@@ -169,9 +169,9 @@ async function decorateCards(block, payload) {
         a.textContent = '';
         a.classList.add('clickable-overlay');
       }
-
+      const searchBranchLinks = placeholders['search-branch-links']?.replace(/\s/g, '')?.split(',');
       cta.ctaLinks.forEach((a) => {
-        if (a.href && a.href.match('adobesparkpost.app.link')) {
+        if (a.href && searchBranchLinks.includes(a.href)) {
           const btnUrl = new URL(a.href);
           if (placeholders?.['search-branch-links']?.replace(/\s/g, '').split(',').includes(`${btnUrl.origin}${btnUrl.pathname}`)) {
             btnUrl.searchParams.set('q', cta.text);

--- a/express/scripts/branchlinks.js
+++ b/express/scripts/branchlinks.js
@@ -83,7 +83,7 @@ export default async function trackBranchParameters(links) {
   ];
 
   links.forEach((a) => {
-    if (a.href && a.href.match('adobesparkpost.app.link')) {
+    if (a.href && a.href.includes('adobesparkpost')) {
       a.rel = 'nofollow';
       const btnUrl = new URL(a.href);
       const isSearchBranchLink = placeholders['search-branch-links']?.replace(/\s/g, '').split(',').includes(`${btnUrl.origin}${btnUrl.pathname}`);

--- a/express/scripts/branchlinks.js
+++ b/express/scripts/branchlinks.js
@@ -83,7 +83,7 @@ export default async function trackBranchParameters(links) {
   ];
 
   links.forEach((a) => {
-    if (a.href && a.href.includes('adobesparkpost')) {
+    if (a.href && a.href.match(/adobesparkpost(-web)?\.app\.link/)) {
       a.rel = 'nofollow';
       const btnUrl = new URL(a.href);
       const isSearchBranchLink = placeholders['search-branch-links']?.replace(/\s/g, '').split(',').includes(`${btnUrl.origin}${btnUrl.pathname}`);

--- a/express/scripts/branchlinks.js
+++ b/express/scripts/branchlinks.js
@@ -103,6 +103,10 @@ export default async function trackBranchParameters(links) {
         setParams('category', category || 'templates');
         setParams('taskID', taskID);
         setParams('assetCollection', assetCollection);
+        setParams('height', canvasHeight);
+        setParams('width', canvasWidth);
+        setParams('unit', canvasUnit);
+        setParams('sceneline', sceneline);
 
         if (searchCategory) {
           setParams('searchCategory', searchCategory);
@@ -117,10 +121,6 @@ export default async function trackBranchParameters(links) {
 
       setParams('referrer', referrer);
       setParams('url', pageUrl);
-      setParams('height', canvasHeight);
-      setParams('width', canvasWidth);
-      setParams('unit', canvasUnit);
-      setParams('sceneline', sceneline);
       setParams('sdid', sdid);
       setParams('mv', mv);
       setParams('mv2', mv2);

--- a/express/scripts/express-delayed.js
+++ b/express/scripts/express-delayed.js
@@ -109,9 +109,9 @@ export async function getProfile() {
   });
 }
 
-const branchLinkOrigins = ['https://adobesparkpost.app.link', 'https://adobesparkpost-web.app.link'];
+const branchLinkOriginPattern = /^https:\/\/adobesparkpost(-web)?\.app\.link/;
 function isBranchLink(url) {
-  return branchLinkOrigins.includes(new URL(url).origin);
+  return branchLinkOriginPattern.test(new URL(url).origin);
 }
 // product entry prompt
 async function canPEP() {

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2525,7 +2525,7 @@ export async function loadArea(area = document) {
       }
     }
   }
-  const links = isDoc ? area.querySelectorAll('main a[href*="adobesparkpost.app.link"]') : area.querySelectorAll(':scope a[href*="adobesparkpost.app.link"]');
+  const links = isDoc ? area.querySelectorAll('main a[href*="adobesparkpost"]') : area.querySelectorAll(':scope a[href*="adobesparkpost"]');
   if (links.length) {
     import('./branchlinks.js').then((mod) => mod.default(links));
   }

--- a/express/scripts/utils/pricing.js
+++ b/express/scripts/utils/pricing.js
@@ -407,7 +407,7 @@ export async function fetchPlanOnePlans(planUrl) {
     plan.symbol = '$';
 
     // TODO: Remove '/sp/ once confirmed with stakeholders
-    const allowedHosts = ['new.express.adobe.com', 'express.adobe.com', 'adobesparkpost.app.link'];
+    const allowedHosts = ['new.express.adobe.com', 'express.adobe.com', 'adobesparkpost.app.link', 'adobesparkpost-web.app.link'];
     const { host } = new URL(planUrl);
     if (allowedHosts.includes(host) || planUrl.includes('/sp/')) {
       plan.offerId = 'FREE0';
@@ -485,7 +485,7 @@ export async function fetchPlan(planUrl) {
     plan.symbol = '$';
 
     // TODO: Remove '/sp/ once confirmed with stakeholders
-    const allowedHosts = ['new.express.adobe.com', 'express.adobe.com', 'adobesparkpost.app.link'];
+    const allowedHosts = ['new.express.adobe.com', 'express.adobe.com', 'adobesparkpost.app.link', 'adobesparkpost-web.app.link'];
     const { host } = new URL(planUrl);
     if (allowedHosts.includes(host) || planUrl.includes('/sp/')) {
       plan.offerId = 'FREE0';


### PR DESCRIPTION
We only append tracking parameters to search branch links, which are authored in placeholders. However, some other logic still apply to all branch links (app and web).

Resolves: [MWPW-141920](https://jira.corp.adobe.com/browse/MWPW-141920)

Test URLs:

- Before: https://MWPW-141920-martech-refactoring--express--adobecom.hlx.page/express/
- After: https://update-branch-links--express--adobecom.hlx.page/express/

Content-toggle

- Before: https://MWPW-141920-martech-refactoring--express--adobecom.hlx.page/education/express/deployment
- After: https://update-branch-links--express--adobecom.hlx.page/education/express/deployment

Columns

- Before: https://MWPW-141920-martech-refactoring--express--adobecom.hlx.page/drafts/Anuj/55775#watch-now
- After: https://update-branch-links--express--adobecom.hlx.page/drafts/Anuj/55775#watch-now

Toggle-bar

- Before: https://MWPW-141920-martech-refactoring--express--adobecom.hlx.page/express/
- After: https://update-branch-links--express--adobecom.hlx.page/express/

Tabs-ax

- Before: https://MWPW-141920-martech-refactoring--express--adobecom.hlx.page/express/pricing
- After: https://update-branch-links--express--adobecom.hlx.page/express/pricing

Pricing-table

- Before: https://MWPW-141920-martech-refactoring--express--adobecom.hlx.page/express/pricing
- After: https://update-branch-links--express--adobecom.hlx.page/express/pricing
