### PR TITLE
[Analytics] [Modal] Added Daa-ll for Modal Close Button

### DIFF
--- a/express/blocks/modal/modal.js
+++ b/express/blocks/modal/modal.js
@@ -72,7 +72,13 @@ export async function getModal(details, custom) {
   if (custom) getCustomModal(custom, dialog);
   if (details) await getPathModal(details.path, dialog);
 
-  const close = createTag('button', { class: 'dialog-close', 'aria-label': 'Close' });
+  const localeModal = id?.includes('locale-modal') ? 'localeModal' : 'milo';
+  const analyticsEventName = window.location.hash ? window.location.hash.replace('#', '') : localeModal;
+  const close = createTag('button', {
+    class: 'dialog-close',
+    'aria-label': 'Close',
+    'daa-ll': `${analyticsEventName}:modalClose:buttonClose`,
+  });
   close.append(getIconElement('close-button-x'));
 
   const focusVisible = { focusVisible: true };


### PR DESCRIPTION
Closing modals right now is not being tracked. This PR will append daa-ll like in Milo and keep the close action recorded.

Resolves: https://jira.corp.adobe.com/browse/MWPW-152574

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/jinglhua/susi-light?gnav=off#susi-light-1
- After: https://modal-close-analytics--express--adobecom.hlx.page/drafts/jinglhua/susi-light?gnav=off#susi-light-1
