### PR TITLE
[EDU][Modal] SUSI-Light Modal Initial Size

### DIFF
--- a/express/blocks/susi-light/susi-light.css
+++ b/express/blocks/susi-light/susi-light.css
@@ -1,4 +1,5 @@
+/* preserving modal space for ux */
 .dialog-modal:has(.susi-light) {
   width: 360px;
-  min-height: 413px;
+  min-height: 529.28px;
 }


### PR DESCRIPTION
Social buttons are recently added, so we would want to preserve more space in our modal so that it doesn't resize in front of users.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/spotlight/education?martech=off#susi-light-1
- After: https://susi-light-modal--express--adobecom.hlx.page/express/spotlight/education?martech=off#susi-light-1
