### PR TITLE
[Tech SEO EXPRESS - IN & UK] Update helix-sitemap.yaml

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -202,7 +202,7 @@ sitemaps:
       unitedkingdom:
         source: /uk/express/templates/default/metadata.json?sheet=sitemap
         destination: /uk/express/templates/sitemap.xml
-        hreflang: en-UK
+        hreflang: en-GB
         alternate: /uk/{path}
   
   colors:

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -169,6 +169,11 @@ sitemaps:
         destination: /it/express/templates/sitemap.xml
         hreflang: it
         alternate: /it/{path}
+      india:
+        source: /in/express/templates/default/metadata.json?sheet=sitemap
+        destination: /in/express/templates/sitemap.xml
+        hreflang: en-IN
+        alternate: /in/{path}
       japan:
         source: /jp/express/templates/default/metadata.json?sheet=sitemap
         destination: /jp/express/templates/sitemap.xml
@@ -194,11 +199,11 @@ sitemaps:
         destination: /nl/express/templates/sitemap.xml
         hreflang: nl
         alternate: /nl/{path}
-      # unitedkingdom:
-      #   source: /uk/express/templates/default/metadata.json?sheet=sitemap
-      #   destination: /uk/express/templates/sitemap.xml
-      #   hreflang: en-GB
-      #   alternate: /uk/{path}
+      unitedkingdom:
+        source: /uk/express/templates/default/metadata.json?sheet=sitemap
+        destination: /uk/express/templates/sitemap.xml
+        hreflang: en-UK
+        alternate: /uk/{path}
   
   colors:
     origin: https://www.adobe.com


### PR DESCRIPTION
Describe your specific features or fixes

Adds template sitemaps for UK and IN with updated href-lang tags

Resolves: [MWPW-152819](https://jira.corp.adobe.com/browse/MWPW-152819)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://seo-cleanup--express--adobecom.hlx.page/express/sitemap.xml
