### PR TITLE
[Modal][Accessibility] Modal Close Button Outline When Focused

### DIFF
--- a/express/blocks/modal/modal.css
+++ b/express/blocks/modal/modal.css
@@ -43,6 +43,8 @@
   right: 1px;
   top: -40px;
   z-index: 1;
+  /* express uses a different positioned icon for close */
+  outline: none;
 }
 
 .dialog-modal button.dialog-close img {
@@ -56,7 +58,8 @@
   margin-left: 6px;
 }
 
-.dialog-close:focus-visible {
+/* express uses a different positioned icon for close */
+.dialog-modal button.dialog-close:focus-visible img{
   outline: 2px solid var(--modal-focus-color);
 }
 


### PR DESCRIPTION
Our modal varies from the Milo's one in how we decorate the close button's icon, which is positioned fixed. This can lead to scenarios that when focused, the outline gets applied in a weird place. This PR is to address that. You can reproduce by tabbing onto the close button. Getting this out will be good before the EDU launch as the SUSI-Light modal will be heavily used.

Resolves: https://jira.corp.adobe.com/browse/MWPW-147350

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/spotlight/education#susi-light-3
- After: https://modal-accessible--express--adobecom.hlx.page/express/spotlight/education#susi-light-3
