### PR TITLE
feat: add browser preferred language to RUM data

### DIFF
--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -300,3 +300,6 @@ if (!window.hlx || window.hlx.gnav) {
 /* Core Web Vitals RUM collection */
 
 sampleRUM('cwv');
+
+/* collect browser preferred language in RUM */
+sampleRUM('lang', { source: document.documentElement.lang, target: navigator.languages.join(',') });

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -293,4 +293,5 @@ if (!window.hlx || window.hlx.gnav) {
 sampleRUM('cwv');
 
 /* collect browser preferred language in RUM */
-sampleRUM('lang', { source: document.documentElement.lang, target: navigator.languages.join(',') });
+sampleRUM('audiences', { source: 'page-language', target: document.documentElement.lang });
+sampleRUM('audiences', { source: 'preferred-languages', target: navigator.languages.join(',') });


### PR DESCRIPTION
Describe your specific features or fixes

Resolves: [SITES-22899](https://jira.corp.adobe.com/browse/SITES-22899)

`lang` checkpoint isn't in the allow list of checkpoints, so we'll be using the `audiences` checkpoint for this information for now.

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://rum-browser-lang--express--adobecom.hlx.page/express/
