### PR TITLE
[Templates] 404 Error Handling

### DIFF
--- a/express/scripts/content-replace.js
+++ b/express/scripts/content-replace.js
@@ -1,6 +1,6 @@
 import {
   fetchPlaceholders,
-  getHelixEnv,
+  getConfig,
   getMetadata,
   titleCase,
   yieldToMain,
@@ -191,19 +191,24 @@ async function updateNonBladeContent(main) {
   }
 }
 
-function validatePage() {
-  const env = getHelixEnv();
+async function validatePage() {
+  const { env } = getConfig();
   const title = document.querySelector('title');
-  if ((env && env.name !== 'stage') && getMetadata('live') === 'N') {
-    window.location.replace('/express/templates/');
-  }
 
-  if (title && title.innerText.match(/{{(.*?)}}/)) {
-    window.location.replace('/404');
-  }
+  const path = window.location.pathname.replace(`${getConfig().locale.prefix}/express/`, '');
+  const pageNotFound = (env && env.name === 'prod' && getMetadata('live') === 'N') || (title && title.innerText.match(/{{(.*?)}}/));
 
-  if (env && env.name !== 'stage' && window.location.pathname.endsWith('/express/templates/default')) {
-    window.location.replace('/404');
+  if (pageNotFound && !!getConfig().locale.prefix) {
+    window.location.replace(`/express/${path}`);
+  } else if (pageNotFound || (env && env.name === 'prod' && window.location.pathname.endsWith('/express/templates/default'))) {
+    const errorPage = await fetch('/express/404');
+    const html = await errorPage.text();
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    const newHTMLContent = doc.documentElement.outerHTML;
+    document.open();
+    document.write(newHTMLContent);
+    document.close();
   }
 }
 


### PR DESCRIPTION
Improve the 404 experience on non-EN template pages. We will redirect to the EN counter part first, and if still not found, load the 404 html code content. Thanks @vhargrave and @qiyundai  for the idea. In the future we might want to migrate the Milo way.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/in/templates/business-hello?lighthouse=on
- After: https://template-404--express--adobecom.hlx.page/express/in/templates/business-hello?lighthouse=on
