### PR TITLE
Pricing Cards Year 2 Pricing Token Hotfix

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -65,7 +65,7 @@ function handleYear2PricingToken(pricingArea, y2p, priceSuffix) {
     );
     if (!year2PricingToken) return;
     if (y2p) {
-      year2PricingToken.textContent = year2PricingToken.textContent.replace(
+      year2PricingToken.innerHTML = year2PricingToken.innerHTML.replace(
         YEAR_2_PRICING_TOKEN,
         `${y2p} ${priceSuffix}`,
       );


### PR DESCRIPTION
Describe your specific features or fixes

Fixes issue with year 2 pricing tokens breaking the formatting of the text block it is embedded in. By using innerHTML instead of textContent, we preserve any HTML elements embedded in the text, such as links.

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before:   [https://stage--express--adobecom.hlx.page/drafts/esallee/2-year-price-draft](https://stage--express--adobecom.hlx.page/drafts/esallee/2-year-price-draft)
- After: [https://pricing-card-y2p-fix--express--adobecom.hlx.page/drafts/esallee/2-year-price-draft](https://pricing-card-y2p-fix--express--adobecom.hlx.page/drafts/esallee/2-year-price-draft)


<img width="1337" alt="Screenshot 2024-06-20 at 3 30 20 PM" src="https://github.com/adobecom/express/assets/159481679/4217c18a-0f11-476c-89b2-8c1778a7dc8b">
