### PR TITLE
Tooltip Pointer Events Fix

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -177,6 +177,7 @@ End border style variants
 
 }
 .pricing-cards .tooltip-text {
+  pointer-events: none;
   opacity: 0;
   padding: 8px;
   z-index: 10;
@@ -231,6 +232,7 @@ End border style variants
 
 .pricing-cards .tooltip .icon:hover~.tooltip-text {
   opacity: 1;
+  pointer-events: inherit;
 }
 
 .pricing-cards .card-border .hide {

--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -232,7 +232,7 @@ End border style variants
 
 .pricing-cards .tooltip .icon:hover~.tooltip-text {
   opacity: 1;
-  pointer-events: inherit;
+  pointer-events: visible;
 }
 
 .pricing-cards .card-border .hide {

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -65,7 +65,7 @@ function handleYear2PricingToken(pricingArea, y2p, priceSuffix) {
     );
     if (!year2PricingToken) return;
     if (y2p) {
-      year2PricingToken.textContent = year2PricingToken.textContent.replace(
+      year2PricingToken.innerHTML = year2PricingToken.innerHTML.replace(
         YEAR_2_PRICING_TOKEN,
         `${y2p} ${priceSuffix}`,
       );


### PR DESCRIPTION
Describe your specific features or fixes

Disables pointer events for the tooltip when it is hidden. On mobile resolutions, the tooltip element could block the link or other UI elements since it gets bunched up due to the smaller screen size.

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/drafts/esallee/2-year-price-draft
- After: https://pricing-card-y2p-fix--express--adobecom.hlx.page/drafts/esallee/2-year-price-draft
