### PR TITLE
[SUSI-Light] Preload Modal Dependencies

### DIFF
--- a/express/scripts/express-delayed.js
+++ b/express/scripts/express-delayed.js
@@ -150,7 +150,7 @@ function preloadSUSILight() {
       document.head.append(preloadTag);
     });
   loadStyle('/express/blocks/susi-light/susi-light.css');
-  loadLink('/express/blocks/fragment/fragment.js', { rel: 'preload', as: 'script' });
+  import('../blocks/fragment/fragment.js');
   loadLink('/express/icons/close-button-x.svg', { rel: 'preload', as: 'image' });
   loadLink('/express/icons/cc-express.svg', { rel: 'preload', as: 'image' });
 }

--- a/express/scripts/express-delayed.js
+++ b/express/scripts/express-delayed.js
@@ -150,8 +150,9 @@ function preloadSUSILight() {
       document.head.append(preloadTag);
     });
   loadStyle('/express/blocks/susi-light/susi-light.css');
-  loadLink('/express/blocks/fragment/fragment.js', { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
-  loadLink('/express/icons/close-button-x.svg', { rel: 'preload', as: 'icon', crossorigin: 'anonymous' });
+  loadLink('/express/blocks/fragment/fragment.js', { rel: 'preload', as: 'script' });
+  loadLink('/express/icons/close-button-x.svg', { rel: 'preload', as: 'image' });
+  loadLink('/express/icons/cc-express.svg', { rel: 'preload', as: 'image' });
 }
 
 /**


### PR DESCRIPTION
Preload more elements in response of the preload-susi-light metadata, including fragment.js, 2 svgs, and a css file. Also removed the Editor Preload as it hasn't proven to be significant so far but can affect our CWV.

Screenshots on my laptop slow3g:
![image (18)](https://github.com/adobecom/express/assets/32369333/1483da81-7e05-4f71-8c17-0c3408a5500f)
![image (19)](https://github.com/adobecom/express/assets/32369333/ff84c094-ab2b-4d58-9f11-1f623efb26b3)
![SC 2024-06-21 at 1 08 57 PM](https://github.com/adobecom/express/assets/32369333/ac99dbb3-03dd-42cf-98e7-1289e817d647)
![SC 2024-06-21 at 1 17 21 PM](https://github.com/adobecom/express/assets/32369333/e006c20a-ea1c-47a6-8c95-5386441f44b6)


Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/spotlight/education?lighthouse=on
- After: https://preload-susi-light--express--adobecom.hlx.page/express/spotlight/education?lighthouse=on
