### PR TITLE
Inline CTAs For Fullscreen Marquee

### DIFF
--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -236,9 +236,8 @@
 }
 
 .block.fullscreen-marquee .button-container.free-plan-container {
-  flex-direction: row;
-  width: auto;
-  justify-content: left;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .block.fullscreen-marquee .button-container.free-plan-container a.button {

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -25,10 +25,10 @@
 }
 
 .fullscreen-marquee .fullscreen-marquee-heading {
-  display: flex;
+  /* display: flex;
   flex-direction: column;
   align-items: flex-start;
-  justify-content: center;
+  justify-content: center; */
 }
 
 .fullscreen-marquee .fullscreen-marquee-heading h1 {
@@ -47,7 +47,9 @@
 .fullscreen-marquee .fullscreen-marquee-heading .button-container {
   align-items: center;
   display: none;
+  ;
 }
+
 
 .fullscreen-marquee-heading h1.budoux {
   display: flex;
@@ -254,6 +256,10 @@
   margin: 0;
 }
 
+.block.fullscreen-marquee .cta-container {
+  display: flex;
+}
+
 @media (min-width: 900px) {
   .section > .fullscreen-marquee {
     padding-bottom: 40px;
@@ -277,8 +283,12 @@
     text-align: center;
   }
 
+  .fullscreen-marquee .fullscreen-marquee-heading p:first-of-type {
+    margin: 10px auto 0px auto;
+  }
+
   .fullscreen-marquee .fullscreen-marquee-heading .button-container {
-    display: flex;
+    display: inline-block;
   }
 
   .fullscreen-marquee .fullscreen-marquee-app-frame {

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -40,7 +40,6 @@
 .fullscreen-marquee .fullscreen-marquee-heading .button-container {
   align-items: center;
   display: none;
-  ;
 }
 
 

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -24,13 +24,6 @@
   padding-bottom: 160px;
 }
 
-.fullscreen-marquee .fullscreen-marquee-heading {
-  /* display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: center; */
-}
-
 .fullscreen-marquee .fullscreen-marquee-heading h1 {
   font-size: var(--heading-font-size-l);
   text-align: left;

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.js
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.js
@@ -42,6 +42,27 @@ function buildBackground(block, background) {
   return background;
 }
 
+// Adds the first CTA to the middle of the marquee image
+async function addMarqueeCenterCTA(block, appFrame) {
+  const buttons = block.querySelectorAll('p a');
+  if (buttons.length === 0) return;
+  for (const cta of buttons) {
+    cta.classList.add('xlarge');
+  }
+  const cta = buttons[0];
+
+  const highlightCta = cta.cloneNode(true);
+  const appHighlight = createTag('a', {
+    class: 'fullscreen-marquee-app-frame-highlight',
+    href: cta.href,
+  });
+
+  await addFreePlanWidget(cta.parentElement);
+
+  appHighlight.append(highlightCta);
+  appFrame.append(appHighlight);
+}
+
 async function buildApp(block, content) {
   const appBackground = createTag('div', { class: 'fullscreen-marquee-app-background' });
   const appFrame = createTag('div', { class: 'fullscreen-marquee-app-frame' });
@@ -115,31 +136,8 @@ async function buildApp(block, content) {
   appFrame.append(app);
   appFrame.append(appBackground);
   app.append(editor);
-  addMarqueeCenterCTA(block, appFrame)
+  addMarqueeCenterCTA(block, appFrame);
   return appFrame;
-}
-
-// Adds the first CTA to the middle of the marquee image
-async function addMarqueeCenterCTA(block, appFrame) {
-  const buttons = block.querySelectorAll('p a');
-  if (buttons.length === 0) return;
-  for (let cta of buttons){
-    cta.classList.add('xlarge')
-  }
-  const cta = buttons[0] 
-
-  const highlightCta = cta.cloneNode(true);
-  const appHighlight = createTag('a', {
-    class: 'fullscreen-marquee-app-frame-highlight',
-    href: cta.href,
-  });
-
-  await addFreePlanWidget(cta.parentElement);
-
-  appHighlight.append(highlightCta);
-  appFrame.append(appHighlight);
-
-
 }
 
 export default async function decorate(block) {

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.js
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.js
@@ -47,7 +47,7 @@ async function buildApp(block, content) {
   const appFrame = createTag('div', { class: 'fullscreen-marquee-app-frame' });
   const app = createTag('div', { class: 'fullscreen-marquee-app' });
   const contentContainer = createTag('div', { class: 'fullscreen-marquee-app-content-container' });
-  const cta = block.querySelector('p a');
+
   let appImage;
   let editor;
   let variant;
@@ -115,23 +115,31 @@ async function buildApp(block, content) {
   appFrame.append(app);
   appFrame.append(appBackground);
   app.append(editor);
-
-  if (cta) {
-    cta.classList.add('xlarge');
-
-    const highlightCta = cta.cloneNode(true);
-    const appHighlight = createTag('a', {
-      class: 'fullscreen-marquee-app-frame-highlight',
-      href: cta.href,
-    });
-
-    await addFreePlanWidget(cta.parentElement);
-
-    appHighlight.append(highlightCta);
-    appFrame.append(appHighlight);
-  }
-
+  addMarqueeCenterCTA(block, appFrame)
   return appFrame;
+}
+
+// Adds the first CTA to the middle of the marquee image
+async function addMarqueeCenterCTA(block, appFrame) {
+  const buttons = block.querySelectorAll('p a');
+  if (buttons.length === 0) return;
+  for (let cta of buttons){
+    cta.classList.add('xlarge')
+  }
+  const cta = buttons[0] 
+
+  const highlightCta = cta.cloneNode(true);
+  const appHighlight = createTag('a', {
+    class: 'fullscreen-marquee-app-frame-highlight',
+    href: cta.href,
+  });
+
+  await addFreePlanWidget(cta.parentElement);
+
+  appHighlight.append(highlightCta);
+  appFrame.append(appHighlight);
+
+
 }
 
 export default async function decorate(block) {


### PR DESCRIPTION


Describe your specific features or fixes

Transforms CTAs in fullscreen-marquee to using display:inline-block so that they float next to each other. This allows multiple CTAs to be supported.

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-152925)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://fullscreen-marquee-cta--express--adobecom.hlx.page/express/create/flyer

<img width="974" alt="Screenshot 2024-06-25 at 11 06 15 AM" src="https://github.com/adobecom/express/assets/159481679/1421f455-abc2-48de-95ba-69c925dc807f">
