### PR TITLE
[Templates] Fix Topics Query

### DIFF
--- a/express/scripts/template-ckg.js
+++ b/express/scripts/template-ckg.js
@@ -115,10 +115,10 @@ async function updateLinkList(container, linkPill, list) {
     list.forEach((d) => {
       const { prefix } = getConfig().locale;
       const topics = getMetadata('topics') !== '" "' ? `${getMetadata('topics')?.replace(/[$@%"]/g, '')}` : '';
-      const topicsQuery = `${topics} ${d.displayValue.toLowerCase()}`.split(' ')
-        .filter((item, i, allItems) => i === allItems.indexOf(item))
+      const topicsQuery = `${topics} ${d.displayValue.toLowerCase()}`
+        .split(' ')
         .join(' ')
-        .replace(currentTasks, '')
+        .replace(currentTasks === ' ' ? '' : currentTasks, '')
         .replace(currentTasksX, '')
         .trim();
 


### PR DESCRIPTION
As of now the CKG search topics constructed by combining url structure and CKG results can be weird like shown in the branch links (check the topics param of the first CKG pill under the marquee). This is to make it better, but we will later do a full Templates revamp where we remove all legacy and unneeded backward-compatability logic.

Resolves: https://jira.corp.adobe.com/browse/MWPW-147161

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/in/express/templates/advertisement/cyber-monday?lighthouse=on
- After: https://template-search-topics-fix--express--adobecom.hlx.page/in/express/templates/advertisement/cyber-monday?lighthouse=on
