### PR TITLE
Template International Dedup and More Supported Languages

### DIFF
--- a/express/blocks/template-x/template-search-api-v3.js
+++ b/express/blocks/template-x/template-search-api-v3.js
@@ -4,20 +4,34 @@ import { memoize } from '../../scripts/hofs.js';
 
 // supported by content api
 const supportedLanguages = [
-  'en-US',
-  'fr-FR',
-  'de-DE',
-  'it-IT',
+  'ar-SA',
+  'cs-CZ',
   'da-DK',
+  'de-DE',
   'es-ES',
+  'el-GR',
+  'en-US',
   'fi-FI',
+  'fil-PH',
+  'fr-FR',
+  'hi-IN',
+  'id-ID',
+  'it-IT',
+  'i-DEFAULT',
   'ja-JP',
   'ko-KR',
+  'MS-MY',
   'nb-NO',
   'nl-NL',
+  'pl-PL',
   'pt-BR',
+  'ro-RO',
+  'ru-RU',
   'sv-SE',
   'th-TH',
+  'tr-TR',
+  'uk-UA',
+  'vi-VN',
   'zh-Hant-TW',
   'zh-Hans-CN',
 ];
@@ -171,7 +185,10 @@ async function fetchTemplatesNoToolbar(props) {
   if (prefLangRes.items?.length >= limit) return { response: prefLangRes };
 
   const backupLangRes = await backupLangPromise;
-  const mergedItems = [...prefLangRes.items, ...backupLangRes.items].slice(0, limit);
+  const mergedItems = [...prefLangRes.items, ...backupLangRes.items]
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .filter((item, i, items) => !i || item.id !== items[i - 1].id) // dedup
+    .slice(0, limit);
   return {
     response: {
       metadata: {


### PR DESCRIPTION
Address scenarios where not enough templates exist in global collection leading to duplicate results. Also added more supported locales following the API's recent updates

Resolves: https://jira.corp.adobe.com/browse/DOTCOM-126397

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/in/express/create/cover/wattpad?lighthouse=on
- After: https://template-intl-update--express--adobecom.hlx.page/in/express/create/cover/wattpad?lighthouse=on
