### PR TITLE
[Print GA] Carousel Semantic Analytics

### DIFF
--- a/express/blocks/browse-by-category/browse-by-category.js
+++ b/express/blocks/browse-by-category/browse-by-category.js
@@ -39,10 +39,11 @@ export function decorateCategories(block, payload) {
     const categoryImageShadowWrapper = createTag('div', { class: 'browse-by-category-image-shadow-wrapper' });
     const categoryImageShadow = createTag('div', { class: 'browse-by-category-image-shadow' });
     const categoryImage = categoryCard.image;
-    const categoryTitle = createTag('h4', { class: 'browse-by-category-card-title' });
+    const categoryTitle = createTag('p', { class: 'browse-by-category-card-title' });
     const categoryAnchor = createTag('a', { class: 'browse-by-category-card-link' });
 
     categoryTitle.textContent = categoryCard.text;
+    categoryAnchor.title = categoryCard.text;
     categoryAnchor.href = categoryCard.link;
     categoryImageShadowWrapper.append(categoryImageShadow, categoryImage);
     categoryImageWrapper.append(categoryImageShadowWrapper);

--- a/express/blocks/shared/carousel.js
+++ b/express/blocks/shared/carousel.js
@@ -76,6 +76,8 @@ export function onCarouselCSSLoad(selector, parent, options) {
 
   const arrowLeft = createTag('a', { class: 'button carousel-arrow carousel-arrow-left' });
   const arrowRight = createTag('a', { class: 'button carousel-arrow carousel-arrow-right' });
+  arrowLeft.title = 'Carousel Left';
+  arrowRight.title = 'Carousel Right';
 
   platform.append(...carouselContent);
 


### PR DESCRIPTION
Carousel items are missing titles. Description for each item should also be using p rather than h4 due to locality. This also fixes a few analytics issues, such as carousel arrows not having proper daa-ll, and carousel CTAs' daa-ll having wrong headers.

Resolves: https://jira.corp.adobe.com/browse/MWPW-153981

Before:
![SC 2024-07-08 at 1 35 17 PM](https://github.com/adobecom/express/assets/32369333/efc44873-77fe-44aa-be2e-c3f2007a4a74)
After:
![SC 2024-07-08 at 1 35 33 PM](https://github.com/adobecom/express/assets/32369333/cafb9c6c-78fb-42bc-840d-edefbe67051b)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/drafts/yge/en/print/poster
- After: https://print-analytics--express--adobecom.hlx.page/drafts/yge/en/print/poster
