### PR TITLE
[Branding] Search-Marquee Logo Injection

### DIFF
--- a/express/blocks/search-marquee/search-marquee.css
+++ b/express/blocks/search-marquee/search-marquee.css
@@ -22,6 +22,12 @@ main .search-marquee {
     align-items: center;
 }
 
+.search-marquee .express-logo {
+    width: unset;
+    height: 30px;
+    padding-bottom: 8px;
+}
+
 main .search-marquee > div:first-of-type h1 {
     font-size: var(--heading-font-size-l);
 }

--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -352,6 +352,9 @@ function decorateLinkList(block) {
 export default async function decorate(block) {
   addTempWrapper(block, 'search-marquee');
   decorateBackground(block);
+  const logo = getIconElement('adobe-express-logo');
+  logo.classList.add('express-logo');
+  block.prepend(logo);
   await decorateSearchFunctions(block);
   await buildSearchDropdown(block);
   initSearchFunction(block);

--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -352,9 +352,11 @@ function decorateLinkList(block) {
 export default async function decorate(block) {
   addTempWrapper(block, 'search-marquee');
   decorateBackground(block);
-  const logo = getIconElement('adobe-express-logo');
-  logo.classList.add('express-logo');
-  block.prepend(logo);
+  if (['on', 'yes'].includes(getMetadata('marquee-inject-logo')?.toLowerCase())) {
+    const logo = getIconElement('adobe-express-logo');
+    logo.classList.add('express-logo');
+    block.prepend(logo);
+  }
   await decorateSearchFunctions(block);
   await buildSearchDropdown(block);
   initSearchFunction(block);


### PR DESCRIPTION
Similar to this PR (https://github.com/adobecom/express/pull/985), we are beginning to inject Express logo into hero blocks, and search-marquee is the one for template pages.

Resolves: https://jira.corp.adobe.com/browse/MWPW-153729?filter=381833

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/templates/flyer?lighthouse=on
- After: https://search-marquee-logo--express--adobecom.hlx.page/express/templates/flyer?lighthouse=on
