### PR TITLE
Handle both Decoded and Encoded Branch Links for Gen-AI-Cards block

### DIFF
--- a/express/blocks/gen-ai-cards/gen-ai-cards.js
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.js
@@ -3,7 +3,7 @@ import { addTempWrapper } from '../../scripts/decorate.js';
 
 import buildCarousel from '../shared/carousel.js';
 
-const genAIPlaceholder = '%7B%7Bprompt-text%7D%7D';
+const promptToken = '(%7B%7B|{{)prompt-text(%7D%7D|}})';
 
 export function decorateTextWithTag(textSource, options = {}) {
   const {
@@ -65,7 +65,7 @@ export const windowHelper = {
 function handleGenAISubmit(form, link) {
   const input = form.querySelector('input');
   if (input.value.trim() === '') return;
-  const genAILink = link.replace(genAIPlaceholder, encodeURI(input.value).replaceAll(' ', '+'));
+  const genAILink = link.replace(promptToken, encodeURI(input.value).replaceAll(' ', '+'));
   if (genAILink) windowHelper.redirect(genAILink);
 }
 
@@ -140,7 +140,7 @@ async function decorateCards(block, { actions }) {
       }
     }
 
-    const hasGenAIForm = (new RegExp(genAIPlaceholder).test(ctaLinks?.[0]?.href));
+    const hasGenAIForm = (new RegExp(promptToken).test(ctaLinks?.[0]?.href));
 
     if (ctaLinks.length > 0) {
       if (hasGenAIForm) {


### PR DESCRIPTION
Currently Gen-AI-Cards won't handle branchlinks that are already decoded. It's RegExp should be updated to recognize both encoded and decoded branch links.
You should see gen-ai-cards on homepage starting to have the input form in the branch url.

Resolves: https://jira.corp.adobe.com/browse/MWPW-154344

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/?lighthouse=on
- After: https://fix-branch-link-decode--express--adobecom.hlx.page/express/?lighthouse=on
