### PR TITLE
Handle both Decoded and Encoded Branch Links for Gen-AI-Cards block

### DIFF
--- a/express/blocks/gen-ai-cards/gen-ai-cards.js
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.js
@@ -3,7 +3,7 @@ import { addTempWrapper } from '../../scripts/decorate.js';
 
 import buildCarousel from '../shared/carousel.js';
 
-const genAIPlaceholder = '%7B%7Bprompt-text%7D%7D';
+const promptTokenRegex = new RegExp('(%7B%7B|{{)prompt-text(%7D%7D|}})');
 
 export function decorateTextWithTag(textSource, options = {}) {
   const {
@@ -65,7 +65,7 @@ export const windowHelper = {
 function handleGenAISubmit(form, link) {
   const input = form.querySelector('input');
   if (input.value.trim() === '') return;
-  const genAILink = link.replace(genAIPlaceholder, encodeURI(input.value).replaceAll(' ', '+'));
+  const genAILink = link.replace(promptTokenRegex, encodeURI(input.value).replaceAll(' ', '+'));
   if (genAILink) windowHelper.redirect(genAILink);
 }
 
@@ -140,7 +140,7 @@ async function decorateCards(block, { actions }) {
       }
     }
 
-    const hasGenAIForm = (new RegExp(genAIPlaceholder).test(ctaLinks?.[0]?.href));
+    const hasGenAIForm = promptTokenRegex.test(ctaLinks?.[0]?.href);
 
     if (ctaLinks.length > 0) {
       if (hasGenAIForm) {

--- a/test/unit/blocks/gen-ai-cards/gen-ai-cards.test.js
+++ b/test/unit/blocks/gen-ai-cards/gen-ai-cards.test.js
@@ -8,55 +8,57 @@ const { default: decorate, windowHelper } = await import(
 const testBody = await readFile({ path: './mocks/body.html' });
 
 describe('Gen AI Cards', () => {
-  beforeEach(() => {
+  let blocks;
+  before(async () => {
     window.isTestEnv = true;
     document.body.innerHTML = testBody;
     window.placeholders = { 'search-branch-links': 'https://adobesparkpost.app.link/c4bWARQhWAb' };
+    blocks = [...document.querySelectorAll('.gen-ai-cards')];
+    await Promise.all(blocks.map((bl) => decorate(bl)));
   });
-
   afterEach(() => {
     window.placeholders = undefined;
   });
 
   it('should have all things', async () => {
-    const block = document.querySelector('.gen-ai-cards');
-    await decorate(block);
-    expect(block).to.exist;
-    expect(block.querySelector('.gen-ai-cards-heading-section')).to.exist;
-    const cards = block.querySelector('.carousel-container .carousel-platform');
-    expect(cards).to.exist;
-    expect(cards.querySelectorAll('.card').length).to.equal(5);
-    expect(cards.querySelector('.card').classList.contains('gen-ai-action')).to.be.true;
-    expect(cards.querySelectorAll('.card')[1].classList.contains('gen-ai-action')).to.be.false;
-    expect(cards.querySelectorAll('.card')[2].classList.contains('gen-ai-action')).to.be.true;
-    expect(cards.querySelectorAll('.card')[3].classList.contains('gen-ai-action')).to.be.true;
+    for (const block of blocks) {
+      expect(block).to.exist;
+      expect(block.querySelector('.gen-ai-cards-heading-section')).to.exist;
+      const cards = block.querySelector('.carousel-container .carousel-platform');
+      expect(cards).to.exist;
+      expect(cards.querySelectorAll('.card').length).to.equal(5);
+      expect(cards.querySelector('.card').classList.contains('gen-ai-action')).to.be.true;
+      expect(cards.querySelectorAll('.card')[1].classList.contains('gen-ai-action')).to.be.false;
+      expect(cards.querySelectorAll('.card')[2].classList.contains('gen-ai-action')).to.be.true;
+      expect(cards.querySelectorAll('.card')[3].classList.contains('gen-ai-action')).to.be.true;
+    }
   });
 
   it('should have all cards with proper children', async () => {
-    const block = document.querySelector('.gen-ai-cards');
-    await decorate(block);
-    const cards = block.querySelector('.carousel-container .carousel-platform');
-    for (const card of cards.querySelectorAll('.card')) {
-      expect(card.querySelector('.text-wrapper .cta-card-desc')).to.exist;
-      expect(card.querySelector('.text-wrapper .cta-card-title')).to.exist;
-      expect(card.querySelector('.media-wrapper picture')).to.exist;
-    }
-    for (const card of cards.querySelectorAll('.card:not(.gen-ai-action)')) {
-      const cta = card.querySelector('.links-wrapper a');
-      expect(cta).to.exist;
-      expect(cta.textContent).to.exist;
-      expect(cta.href).to.exist;
-    }
-    for (const card of cards.querySelectorAll('.card.gen-ai-action')) {
-      const form = card.querySelector('.gen-ai-input-form');
-      expect(form).to.exist;
-      const input = form.querySelector('input');
-      const button = form.querySelector('button');
-      expect(input).to.exist;
-      expect(button).to.exist;
-      expect(input.placeholder).to.exist;
-      expect(button.textContent).to.exist;
-      expect(button.classList.contains('gen-ai-submit')).to.be.true;
+    for (const block of blocks) {
+      const cards = block.querySelector('.carousel-container .carousel-platform');
+      for (const card of cards.querySelectorAll('.card')) {
+        expect(card.querySelector('.text-wrapper .cta-card-desc')).to.exist;
+        expect(card.querySelector('.text-wrapper .cta-card-title')).to.exist;
+        expect(card.querySelector('.media-wrapper picture')).to.exist;
+      }
+      for (const card of cards.querySelectorAll('.card:not(.gen-ai-action)')) {
+        const cta = card.querySelector('.links-wrapper a');
+        expect(cta).to.exist;
+        expect(cta.textContent).to.exist;
+        expect(cta.href).to.exist;
+      }
+      for (const card of cards.querySelectorAll('.card.gen-ai-action')) {
+        const form = card.querySelector('.gen-ai-input-form');
+        expect(form).to.exist;
+        const input = form.querySelector('input');
+        const button = form.querySelector('button');
+        expect(input).to.exist;
+        expect(button).to.exist;
+        expect(input.placeholder).to.exist;
+        expect(button.textContent).to.exist;
+        expect(button.classList.contains('gen-ai-submit')).to.be.true;
+      }
     }
   });
 
@@ -67,43 +69,43 @@ describe('Gen AI Cards', () => {
   }
 
   it('should toggle submit button disabled based on input content', async () => {
-    const block = document.querySelector('.gen-ai-cards');
-    await decorate(block);
-    const cards = block.querySelector('.carousel-container .carousel-platform');
-    const card = cards.querySelector('.card.gen-ai-action');
-    const form = card.querySelector('.gen-ai-input-form');
-    const input = form.querySelector('input');
-    const button = form.querySelector('button');
-    const stub = sinon.stub(windowHelper, 'redirect');
-    expect(button.disabled).to.be.true;
-    const enterEvent = new KeyboardEvent('keyup', {
-      key: 'Enter',
-      code: 'Enter',
-      keyCode: 13,
-      which: 13,
-      bubbles: true,
-      cancelable: true,
-    });
-    input.dispatchEvent(enterEvent);
-    expect(button.disabled).to.be.true;
-    expect(stub.called).to.be.false;
-    form.dispatchEvent(new Event('submit'));
-    expect(stub.called).to.be.false;
+    for (const block of blocks) {
+      const cards = block.querySelector('.carousel-container .carousel-platform');
+      const card = cards.querySelector('.card.gen-ai-action');
+      const form = card.querySelector('.gen-ai-input-form');
+      const input = form.querySelector('input');
+      const button = form.querySelector('button');
+      const stub = sinon.stub(windowHelper, 'redirect');
+      expect(button.disabled).to.be.true;
+      const enterEvent = new KeyboardEvent('keyup', {
+        key: 'Enter',
+        code: 'Enter',
+        keyCode: 13,
+        which: 13,
+        bubbles: true,
+        cancelable: true,
+      });
+      input.dispatchEvent(enterEvent);
+      expect(button.disabled).to.be.true;
+      expect(stub.called).to.be.false;
+      form.dispatchEvent(new Event('submit'));
+      expect(stub.called).to.be.false;
 
-    input.value = 'test';
-    input.dispatchEvent(new Event('input'));
-    expect(button.disabled).to.be.false;
+      input.value = 'test';
+      input.dispatchEvent(new Event('input'));
+      expect(button.disabled).to.be.false;
 
-    input.value = '';
-    input.dispatchEvent(new Event('input'));
-    expect(button.disabled).to.be.true;
-    input.value = 'fakeInput';
-    input.dispatchEvent(enterEvent);
-    expect(stub.called).to.be.true;
-    expect(decodeHTMLEntities(stub.firstCall.args[0])).to.equal(
-      decodeHTMLEntities('https://new.express.adobe.com/new?category=media&#x26;prompt=fakeInput&#x26;action=text+to+image&#x26;width=1080&#x26;height=1080'),
-    );
+      input.value = '';
+      input.dispatchEvent(new Event('input'));
+      expect(button.disabled).to.be.true;
+      input.value = 'fakeInput';
+      input.dispatchEvent(enterEvent);
+      expect(stub.called).to.be.true;
+      expect(decodeHTMLEntities(stub.firstCall.args[0])).to.equal(
+        decodeHTMLEntities('https://new.express.adobe.com/new?category=media&#x26;prompt=fakeInput&#x26;action=text+to+image&#x26;width=1080&#x26;height=1080'),
+      );
 
-    stub.restore();
+      stub.restore();
+    }
   });
 });

--- a/test/unit/blocks/gen-ai-cards/mocks/body.html
+++ b/test/unit/blocks/gen-ai-cards/mocks/body.html
@@ -96,6 +96,94 @@
             </div>
           </div>
         </div>
+        <div class="gen-ai-cards">
+          <div>
+            <div>
+              <h2 id="this-is-a-good-one">This is a good one.</h2>
+              <p>Unlock your imagination with generative AI. Experiment, imagine, and create an infinite range of content in Adobe Express with generative AI features.</p>
+              <p><a href="https://new.express.adobe.com/">Adobe Generative AI Terms</a></p>
+            </div>
+          </div>
+          <div>
+            <div>
+              <picture>
+                <source type="image/webp" srcset="./media_1eabf8ecd1872f91a16c46caf47990ce0036260fb.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
+                <source type="image/webp" srcset="./media_1eabf8ecd1872f91a16c46caf47990ce0036260fb.png?width=750&#x26;format=webply&#x26;optimize=medium">
+                <source type="image/png" srcset="./media_1eabf8ecd1872f91a16c46caf47990ce0036260fb.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 600px)">
+                <img loading="lazy" alt="" src="./media_1eabf8ecd1872f91a16c46caf47990ce0036260fb.png?width=750&#x26;format=png&#x26;optimize=medium" width="400" height="264">
+              </picture>
+            </div>
+            <div>
+              <p><strong><a href="https://new.express.adobe.com/new?category=media&#x26;prompt={{prompt-text}}&#x26;action=text+to+image&#x26;width=1080&#x26;height=1080">Generate</a></strong></p>
+              <p><strong>Text to image</strong></p>
+              <p>Generate images from a detailed text description.</p>
+              <p><em>Try describing people, places, and things</em></p>
+            </div>
+          </div>
+          <div>
+            <div>
+              <picture>
+                <source type="image/webp" srcset="./media_17aeaf9ec02bd5ba0c27fdd58cea152d3a556a98d.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
+                <source type="image/webp" srcset="./media_17aeaf9ec02bd5ba0c27fdd58cea152d3a556a98d.png?width=750&#x26;format=webply&#x26;optimize=medium">
+                <source type="image/png" srcset="./media_17aeaf9ec02bd5ba0c27fdd58cea152d3a556a98d.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 600px)">
+                <img loading="lazy" alt="" src="./media_17aeaf9ec02bd5ba0c27fdd58cea152d3a556a98d.png?width=750&#x26;format=png&#x26;optimize=medium" width="400" height="264">
+              </picture>
+            </div>
+            <div>
+              <p><strong><a href="https://new.express.adobe.com/new?width=2560&#x26;height=2560&#x26;unit=px&#x26;aspectRatioLock=false">Upload image to start</a></strong></p>
+              <p><strong>Generative Fill</strong></p>
+              <p>Add or remove elements with a text prompt.</p>
+            </div>
+          </div>
+          <div>
+            <div>
+              <picture>
+                <source type="image/webp" srcset="./media_17aeaf9ec02bd5ba0c27fdd58cea152d3a556a98d.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
+                <source type="image/webp" srcset="./media_17aeaf9ec02bd5ba0c27fdd58cea152d3a556a98d.png?width=750&#x26;format=webply&#x26;optimize=medium">
+                <source type="image/png" srcset="./media_17aeaf9ec02bd5ba0c27fdd58cea152d3a556a98d.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 600px)">
+                <img loading="lazy" alt="" src="./media_17aeaf9ec02bd5ba0c27fdd58cea152d3a556a98d.png?width=750&#x26;format=png&#x26;optimize=medium" width="400" height="264">
+              </picture>
+            </div>
+            <div>
+              <p><strong><a href="https://new.express.adobe.com/new?category=media&#x26;prompt={{prompt-text}}&#x26;action=text+to+template&#x26;width=1080&#x26;height=1080">Generate</a></strong></p>
+              <p><strong>Text to template</strong></p>
+              <p>Add or remove elements with a text prompt.</p>
+              <p><em>Describe the template you want to make</em></p>
+            </div>
+          </div>
+          <div>
+            <div>
+              <picture>
+                <source type="image/webp" srcset="./media_17aeaf9ec02bd5ba0c27fdd58cea152d3a556a98d.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
+                <source type="image/webp" srcset="./media_17aeaf9ec02bd5ba0c27fdd58cea152d3a556a98d.png?width=750&#x26;format=webply&#x26;optimize=medium">
+                <source type="image/png" srcset="./media_17aeaf9ec02bd5ba0c27fdd58cea152d3a556a98d.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 600px)">
+                <img loading="lazy" alt="" src="./media_17aeaf9ec02bd5ba0c27fdd58cea152d3a556a98d.png?width=750&#x26;format=png&#x26;optimize=medium" width="400" height="264">
+              </picture>
+            </div>
+            <div>
+              <p><strong><a href="https://new.express.adobe.com/new?category=media&#x26;prompt={{prompt-text}}&#x26;action=text+to+image&#x26;width=1080&#x26;height=1080">Generate</a></strong></p>
+              <p><strong>Text effects</strong></p>
+              <p>Apply styles or textures to text with a text prompt.</p>
+              <p><em>Describe the text effect you want to make</em></p>
+            </div>
+          </div>
+
+          <div>
+            <div>
+              <picture>
+                <source type="image/webp" srcset="./media_17aeaf9ec02bd5ba0c27fdd58cea152d3a556a98d.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
+                <source type="image/webp" srcset="./media_17aeaf9ec02bd5ba0c27fdd58cea152d3a556a98d.png?width=750&#x26;format=webply&#x26;optimize=medium">
+                <source type="image/png" srcset="./media_17aeaf9ec02bd5ba0c27fdd58cea152d3a556a98d.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 600px)">
+                <img loading="lazy" alt="" src="./media_17aeaf9ec02bd5ba0c27fdd58cea152d3a556a98d.png?width=750&#x26;format=png&#x26;optimize=medium" width="400" height="264">
+              </picture>
+            </div>
+            <div>
+              <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Upload image to start</a></strong></p>
+              <p><strong>Generative Fill</strong></p>
+              <p>Add or remove elements with a text prompt.</p>
+            </div>
+          </div>
+        </div>
       </div>
     </main>
     <footer></footer>


### PR DESCRIPTION
Currently Gen-AI-Cards won't handle branchlinks that are already decoded. It's RegExp should be updated to recognize both encoded and decoded branch links.
You should see gen-ai-cards on homepage starting to have the input form in the branch url.

Resolves: https://jira.corp.adobe.com/browse/MWPW-154344

Test URLs:

Before: https://stage--express--adobecom.hlx.page/express/?lighthouse=on
After: https://fix-branch-link-decode--express--adobecom.hlx.page/express/?lighthouse=on