### PR TITLE
Update Argentine Peso With Custom Currency Symbol.

### DIFF
--- a/express/scripts/utils/pricing.js
+++ b/express/scripts/utils/pricing.js
@@ -266,11 +266,11 @@ export const formatSalesPhoneNumber = (() => {
 
 export async function formatPrice(price, currency) {
   if (price === '') return null;
-
   const customSymbols = {
     SAR: 'SR',
     CA: 'CAD',
     EGP: 'LE',
+    ARS: 'Ar$'
   };
   const locale = ['USD', 'TWD'].includes(currency)
     ? 'en-GB' // use en-GB for intl $ symbol formatting
@@ -346,11 +346,13 @@ export const getOfferOnePlans = (() => {
   return async (offerId) => {
     let country = await getCountry();
     if (!country) country = 'us';
-    let currency = getCurrency(country);
+    
+    let currency = getCurrency(country); 
     if (!currency) {
       country = 'us';
       currency = 'USD';
     }
+   
     if (!json) {
       const resp = await fetch('/express/system/offers-one.json?limit=5000');
       if (!resp.ok) return {};
@@ -430,6 +432,7 @@ export async function fetchPlanOnePlans(planUrl) {
     }
 
     const offer = await getOfferOnePlans(plan.offerId);
+    
     if (offer) {
       plan.currency = offer.currency;
       plan.price = offer.unitPrice;
@@ -459,7 +462,6 @@ export async function fetchPlanOnePlans(planUrl) {
       }
       plan.y2p = offer.y2p;
     }
-
     window.pricingPlans[planUrl] = plan;
   }
   return plan;

--- a/express/scripts/utils/pricing.js
+++ b/express/scripts/utils/pricing.js
@@ -270,7 +270,7 @@ export async function formatPrice(price, currency) {
     SAR: 'SR',
     CA: 'CAD',
     EGP: 'LE',
-    ARS: 'Ar$'
+    ARS: 'Ar$',
   };
   const locale = ['USD', 'TWD'].includes(currency)
     ? 'en-GB' // use en-GB for intl $ symbol formatting
@@ -346,13 +346,13 @@ export const getOfferOnePlans = (() => {
   return async (offerId) => {
     let country = await getCountry();
     if (!country) country = 'us';
-    
-    let currency = getCurrency(country); 
+
+    let currency = getCurrency(country);
     if (!currency) {
       country = 'us';
       currency = 'USD';
     }
-   
+
     if (!json) {
       const resp = await fetch('/express/system/offers-one.json?limit=5000');
       if (!resp.ok) return {};
@@ -432,7 +432,7 @@ export async function fetchPlanOnePlans(planUrl) {
     }
 
     const offer = await getOfferOnePlans(plan.offerId);
-    
+
     if (offer) {
       plan.currency = offer.currency;
       plan.price = offer.unitPrice;


### PR DESCRIPTION
Describe your specific features or fixes

Resolves: https://jira.corp.adobe.com/browse/DOTCOM-127741

Updates the symbol used for the Argentine Peso to be "Ar$".

<img width="979" alt="Screenshot 2024-07-16 at 8 44 02 AM" src="https://github.com/user-attachments/assets/56ffb7de-9f17-4e1a-90a9-1c9f30a12663">

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://price-formatting-ar--express--adobecom.hlx.page/express/pricing?country=ar
