### PR TITLE
[Create Pages] [Pictures] Remove Unwanted Attributes

### DIFF
--- a/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.js
+++ b/express/blocks/fullscreen-marquee-desktop/fullscreen-marquee-desktop.js
@@ -20,6 +20,11 @@ function buildContent(content) {
 
     if (contentImage) {
       formattedContent = contentImage;
+      const img = formattedContent.querySelector('img');
+      if (img) {
+        img.removeAttribute('width');
+        img.removeAttribute('height');
+      }
     }
   }
 

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.js
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.js
@@ -19,6 +19,11 @@ function buildContent(content) {
 
     if (contentImage) {
       formattedContent = contentImage;
+      const img = formattedContent.querySelector('img');
+      if (img) {
+        img.removeAttribute('width');
+        img.removeAttribute('height');
+      }
     }
   }
 

--- a/express/blocks/how-to-steps-carousel/how-to-steps-carousel.js
+++ b/express/blocks/how-to-steps-carousel/how-to-steps-carousel.js
@@ -285,6 +285,8 @@ export default async function decorate(block) {
 
     templateImg.style.visibility = 'hidden';
     templateImg.style.position = 'absolute';
+    templateImg.removeAttribute('width');
+    templateImg.removeAttribute('height');
     backgroundPicImg.style.width = `${canvasWidth}px`;
     if (window.screen.width < 600) backgroundPicImg.style.height = `${window.screen.width * 0.536}px`;
     picture = backgroundPic;


### PR DESCRIPTION
Due to the new way we createOptimizedImages, blocks that expect images to not have width/height attributes will now need to clean up themselves.

You should expect to see the image content in fullscreen-marquee and the below how-to-steps-carousel having a better ratio.

Resolves: https://jira.corp.adobe.com/browse/MWPW-154458

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/create/photo-collage/family?lighthouse=on
- After: https://fix-create-picture-scale--express--adobecom.hlx.page/express/create/photo-collage/family?lighthouse=on
