### PR TITLE
[Modal][Milo Migration] Sync Modal with Milo

### DIFF
--- a/express/blocks/modal/modal.css
+++ b/express/blocks/modal/modal.css
@@ -21,6 +21,71 @@
   z-index: 102;
 }
 
+.dialog-modal.commerce-frame {
+  z-index: 103;
+}
+
+.dialog-modal.delayed-modal {
+  width: 300px;
+  max-width: none;
+  border-radius: var(--l-rounded-corners);
+}
+
+@media (min-width: 430px) and (orientation: portrait) {
+  .dialog-modal.delayed-modal {
+    width: 370px;
+  }
+}
+
+@media (min-width: 430px) and (orientation: landscape) {
+  .dialog-modal.delayed-modal {
+    width: 600px;
+  }
+}
+
+@media (min-width: 576px) and (orientation: portrait) {
+  .dialog-modal.delayed-modal {
+    width: 516px;
+  }
+}
+
+@media (min-width: 768px) {
+  .dialog-modal.delayed-modal {
+    width: 600px;
+  }
+}
+
+@media (min-width: 829px) {
+  .dialog-modal.delayed-modal {
+    width: 800px;
+  }
+}
+
+@media (min-width: 1366px) {
+  .dialog-modal.delayed-modal {
+    width: 900px;
+  }
+}
+
+.dialog-modal.upgrade-flow-modal {
+  height: 100%;
+  width: 100%;
+  max-height: 100%;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.upgrade-flow-modal .dialog-close {
+  display: none;
+}
+
+.upgrade-flow-modal .upgrade-flow-iframe {
+  overflow: hidden;
+  height: 100%;
+  width: 100%;
+  box-sizing: border-box; 
+}
+
 .modal-curtain.is-open {
   position: fixed;
   top: 0;
@@ -38,29 +103,19 @@
   cursor: pointer;
   background: none;
   border-radius: 50%;
-  height: 50px;
-  width: 50px;
-  right: 1px;
-  top: -40px;
+  height: 26px;
+  right: 5px;
+  top: 5px;
+  width: 26px;
   z-index: 1;
-  /* express uses a different positioned icon for close */
-  outline: none;
 }
 
-.dialog-modal button.dialog-close img {
-  padding: 12px;
-  background-color: white;
-  border-radius: 50px;
-  box-shadow: 0px 4px 20px #0000001A;
-  position: fixed;
-  height: 16px;
-  width: 16px;
-  margin-left: 6px;
-}
-
-/* express uses a different positioned icon for close */
-.dialog-modal button.dialog-close:focus-visible img{
+.dialog-close:focus-visible {
   outline: 2px solid var(--modal-focus-color);
+}
+
+.dialog-modal .section > .content {
+  max-width: initial;
 }
 
 .dialog-modal > .fragment > .section > .content > *:last-child {
@@ -80,7 +135,7 @@
   margin: 12px;
 }
 
-.locale-modal{
+.locale-modal {
   text-align: center;
   padding: 48px 32px 30px;
 }
@@ -151,8 +206,13 @@
   margin: 0;
 }
 
+/* stylelint-disable-next-line no-descending-specificity */
 .region-selector .content {
   column-count: 1;
+}
+
+.commerce-modal-open {
+  overflow: hidden;
 }
 
 @media (min-width: 600px) {
@@ -164,9 +224,46 @@
   .region-selector .content {
     column-count: 3;
   }
+
+  .upgrade-flow-modal .upgrade-flow-iframe {
+    padding: 0 0 10px;
+  }
+}
+
+@media (max-width: 1199px) {
+  .dialog-modal.commerce-frame {
+    width: 100%;
+    max-width: 100%;
+    max-height: 100%;
+  }
+  
+  .dialog-modal.upgrade-flow-modal {
+    border-radius: 0;
+  }
+
+  .dialog-modal.commerce-frame > .fragment,
+  .dialog-modal.commerce-frame > .section,
+  .dialog-modal.commerce-frame > .fragment > .section {
+    height: 100vh;
+  }
+
+  .dialog-modal.xl-size,
+  .dialog-modal.xl-size > .fragment,
+  .dialog-modal.xl-size > .fragment > .section {
+    height: 100%;
+  }
+
+  .dialog-modal.xl-size .milo-iframe {
+    height: 100%;
+    padding-bottom: 0;
+  }
 }
 
 @media (min-width: 1200px) {
+  .dialog-modal.s-size {
+    max-width: 650px;
+  }
+
   .region-selector .content {
     column-count: 5;
   }
@@ -175,4 +272,46 @@
     width: 1200px;
     max-width: calc((100% - 6px) - 2em);
   }
+
+  .dialog-modal.commerce-frame {
+    width: 1024px;
+    height: 850px;
+  }
+
+  .dialog-modal.commerce-frame > .fragment,
+  .dialog-modal.commerce-frame > .section,
+  .dialog-modal.commerce-frame > .fragment > .section {
+    height: 100%;
+  }
+
+  .dialog-modal.commerce-frame .milo-iframe {
+    padding-bottom: 0;
+    height: 100%;
+  }
+
+  .dialog-modal.commerce-frame.height-fit-content {
+    height: auto;
+    max-height: 850px;
+    min-width: 1000px;
+  }
+
+  .dialog-modal.commerce-frame.height-fit-content .milo-iframe {
+    height: 100%;
+    max-height: 845px;
+  }
+
+  .dialog-modal.commerce-frame .milo-iframe iframe {
+    height: 0%;
+  }
+  
+  .dialog-modal.upgrade-flow-modal {
+    height: 820px;
+    max-width: 1100px;
+    overflow: hidden;
+    width: 80%;
+  }
+}
+
+.disable-scroll {
+  overflow: hidden;
 }

--- a/express/blocks/modal/modal.js
+++ b/express/blocks/modal/modal.js
@@ -1,7 +1,17 @@
 /* eslint-disable max-len */
-import { loadStyle, createTag, getIconElement } from '../../scripts/utils.js';
+import { createTag, getMetadata, localizeLink, loadStyle, getConfig } from '../../scripts/utils.js';
 
-const FOCUSABLES = 'a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]';
+const FOCUSABLES = 'a:not(.hide-video), button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]';
+const CLOSE_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+  <g transform="translate(-10500 3403)">
+    <circle cx="10" cy="10" r="10" transform="translate(10500 -3403)" fill="#707070"/>
+    <line y1="8" x2="8" transform="translate(10506 -3397)" fill="none" stroke="#fff" stroke-width="2"/>
+    <line x1="8" y1="8" transform="translate(10506 -3397)" fill="none" stroke="#fff" stroke-width="2"/>
+  </g>
+</svg>`;
+
+let isDelayedModal = false;
+let prevHash = '';
 
 const openedModals = { cnt: 0 };
 

--- a/express/blocks/modal/modal.js
+++ b/express/blocks/modal/modal.js
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /* eslint-disable no-underscore-dangle */
 // eslint-disable-next-line object-curly-newline
 import { createTag, getMetadata, localizeLink, loadStyle, getConfig } from '../../scripts/utils.js';
@@ -238,17 +237,11 @@ export function delayedModal(el) {
   return true;
 }
 
-const loadedPaths = new Set();
 // Deep link-based
 export default function init(el) {
   const { modalHash } = el.dataset;
   if (delayedModal(el) || window.location.hash !== modalHash || document.querySelector(`div.dialog-modal${modalHash}`)) return null;
   const details = findDetails(window.location.hash, el);
-  if (details.path) {
-    // TODO: diff in Milo. Depends on AX authoring fix to deprecate
-    if (loadedPaths.has(details.path)) return null;
-    loadedPaths.add(details.path);
-  }
   return details ? getModal(details) : null;
 }
 

--- a/express/blocks/modal/modal.js
+++ b/express/blocks/modal/modal.js
@@ -1,4 +1,6 @@
 /* eslint-disable max-len */
+/* eslint-disable no-underscore-dangle */
+// eslint-disable-next-line object-curly-newline
 import { createTag, getMetadata, localizeLink, loadStyle, getConfig } from '../../scripts/utils.js';
 
 const FOCUSABLES = 'a:not(.hide-video), button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]';
@@ -13,33 +15,62 @@ const CLOSE_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="2
 let isDelayedModal = false;
 let prevHash = '';
 
-const openedModals = { cnt: 0 };
-
 export function findDetails(hash, el) {
   const id = hash.replace('#', '');
   const a = el || document.querySelector(`a[data-modal-hash="${hash}"]`);
-  const path = a?.dataset.modalPath;
+  const path = a?.dataset.modalPath || localizeLink(getMetadata(`-${id}`));
   return { id, path, isHash: hash === window.location.hash };
 }
 
-function closeModal(modal) {
+function fireAnalyticsEvent(event) {
+  const data = {
+    xdm: {},
+    data: { web: { webInteraction: { name: event?.type } } },
+  };
+  if (event?.data) data.data._adobe_corpnew = { digitalData: event.data };
+  window._satellite?.track('event', data);
+}
+
+export function sendAnalytics(event) {
+  if (window._satellite?.track) {
+    fireAnalyticsEvent(event);
+  } else {
+    window.addEventListener('alloy_sendEvent', () => {
+      fireAnalyticsEvent(event);
+    }, { once: true });
+  }
+}
+
+export function closeModal(modal) {
   const { id } = modal;
-  const closeEvent = new Event(`milo:modal:closed:${id}`);
+  const closeEvent = new Event('milo:modal:closed');
   window.dispatchEvent(closeEvent);
-  openedModals.cnt -= 1;
 
   document.querySelectorAll(`#${id}`).forEach((mod) => {
-    if (mod.nextElementSibling?.classList.contains('modal-curtain')) {
-      mod.nextElementSibling.remove();
-    }
     if (mod.classList.contains('dialog-modal')) {
+      const modalCurtain = document.querySelector(`#${id}~.modal-curtain`);
+      if (modalCurtain) {
+        modalCurtain.remove();
+      }
       mod.remove();
     }
     document.querySelector(`[data-modal-hash="#${mod.id}"]`)?.focus();
   });
 
+  if (!document.querySelectorAll('.modal-curtain').length) {
+    document.body.classList.remove('disable-scroll');
+  }
+
+  [...document.querySelectorAll('header, main, footer')]
+    .forEach((element) => element.removeAttribute('aria-disabled'));
+
   const hashId = window.location.hash.replace('#', '');
   if (hashId === modal.id) window.history.pushState('', document.title, `${window.location.pathname}${window.location.search}`);
+  isDelayedModal = false;
+  if (prevHash) {
+    window.location.hash = prevHash;
+    prevHash = '';
+  }
 }
 
 function isElementInView(element) {
@@ -53,7 +84,8 @@ function isElementInView(element) {
 }
 
 function getCustomModal(custom, dialog) {
-  loadStyle('/express/blocks/modal/modal.css');
+  const { miloLibs, codeRoot } = getConfig();
+  loadStyle(`${miloLibs || codeRoot}/blocks/modal/modal.css`);
   if (custom.id) dialog.id = custom.id;
   if (custom.class) dialog.classList.add(custom.class);
   if (custom.closeEvent) {
@@ -65,7 +97,7 @@ function getCustomModal(custom, dialog) {
 }
 
 async function getPathModal(path, dialog) {
-  const block = createTag('a', { href: path }, path);
+  const block = createTag('a', { href: path });
   dialog.append(block);
 
   const { default: getFragment } = await import('../fragment/fragment.js');
@@ -77,10 +109,20 @@ export async function getModal(details, custom) {
   const { id } = details || custom;
 
   const dialog = createTag('div', { class: 'dialog-modal', id });
-  const loadedEvent = new Event(`milo:modal:loaded:${id}`);
+  const loadedEvent = new Event('milo:modal:loaded');
 
   if (custom) getCustomModal(custom, dialog);
   if (details) await getPathModal(details.path, dialog);
+  if (isDelayedModal) {
+    dialog.classList.add('delayed-modal');
+    const mediaBlock = dialog.querySelector('div.media');
+    if (mediaBlock) {
+      mediaBlock.classList.add('in-modal');
+      const { miloLibs, codeRoot } = getConfig();
+      const base = miloLibs || codeRoot;
+      loadStyle(`${base}/styles/rounded-corners.css`);
+    }
+  }
 
   const localeModal = id?.includes('locale-modal') ? 'localeModal' : 'milo';
   const analyticsEventName = window.location.hash ? window.location.hash.replace('#', '') : localeModal;
@@ -88,8 +130,7 @@ export async function getModal(details, custom) {
     class: 'dialog-close',
     'aria-label': 'Close',
     'daa-ll': `${analyticsEventName}:modalClose:buttonClose`,
-  });
-  close.append(getIconElement('close-button-x'));
+  }, CLOSE_ICON);
 
   const focusVisible = { focusVisible: true };
   const focusablesOnLoad = [...dialog.querySelectorAll(FOCUSABLES)];
@@ -138,6 +179,7 @@ export async function getModal(details, custom) {
   window.dispatchEvent(loadedEvent);
 
   if (!dialog.classList.contains('curtain-off')) {
+    document.body.classList.add('disable-scroll');
     const curtain = createTag('div', { class: 'modal-curtain is-open' });
     curtain.addEventListener('click', (e) => {
       if (e.target === curtain) closeModal(dialog);
@@ -147,34 +189,80 @@ export async function getModal(details, custom) {
       .forEach((element) => element.setAttribute('aria-disabled', 'true'));
   }
 
+  const iframe = dialog.querySelector('iframe');
+  // TODO: different from milo as we are not using commerce-frame
+  if (iframe) {
+    /* Initially iframe height is set to 0% in CSS for the height auto adjustment feature.
+    For modals without the 'commerce-frame' class height auto adjustment is not applicable */
+    iframe.style.height = '100%';
+  }
+
   return dialog;
+}
+
+export function getHashParams(hashStr) {
+  if (!hashStr) return {};
+  return hashStr.split(':').reduce((params, part) => {
+    if (part.startsWith('#')) {
+      params.hash = part;
+    } else {
+      const [key, val] = part.split('=');
+      if (key === 'delay' && parseInt(val, 10) > 0) {
+        params.delay = parseInt(val, 10) * 1000;
+      }
+    }
+    return params;
+  }, {});
+}
+
+export function delayedModal(el) {
+  const { hash, delay } = getHashParams(el?.dataset.modalHash);
+  if (!delay || !hash) return false;
+  isDelayedModal = true;
+  el.classList.add('hide-block');
+  const modalOpenEvent = new Event(`${hash}:modalOpen`);
+  const pagesModalWasShownOn = window.sessionStorage.getItem(`shown:${hash}`);
+  el.dataset.modalHash = hash;
+  el.href = hash;
+  if (!pagesModalWasShownOn?.includes(window.location.pathname)) {
+    setTimeout(() => {
+      window.location.replace(hash);
+      sendAnalytics(modalOpenEvent);
+      window.sessionStorage.setItem(`shown:${hash}`, `${pagesModalWasShownOn || ''} ${window.location.pathname}`);
+    }, delay);
+  }
+  return true;
 }
 
 const loadedPaths = new Set();
 // Deep link-based
 export default function init(el) {
   const { modalHash } = el.dataset;
-  if (window.location.hash === modalHash) {
-    const details = findDetails(window.location.hash, el);
-    if (details.path) {
-      if (loadedPaths.has(details.path)) return null;
-      loadedPaths.add(details.path);
-    }
-    if (details) return getModal(details);
+  if (delayedModal(el) || window.location.hash !== modalHash || document.querySelector(`div.dialog-modal${modalHash}`)) return null;
+  const details = findDetails(window.location.hash, el);
+  if (details.path) {
+    // TODO: diff in Milo. Depends on AX authoring fix to deprecate
+    if (loadedPaths.has(details.path)) return null;
+    loadedPaths.add(details.path);
   }
-  return null;
-}
-
-async function onHashChange(e) {
-  if (!window.location.hash) {
-    const url = new URL(e.oldURL);
-    const dialog = document.querySelector(`.dialog-modal${url.hash}`);
-    if (dialog) closeModal(dialog);
-  } else {
-    const details = findDetails(window.location.hash, null);
-    if (details) await getModal(details);
-  }
+  return details ? getModal(details) : null;
 }
 
 // Click-based modal
-window.addEventListener('hashchange', onHashChange);
+window.addEventListener('hashchange', (e) => {
+  if (!window.location.hash) {
+    try {
+      const url = new URL(e.oldURL);
+      const dialog = document.querySelector(`.dialog-modal${url.hash}`);
+      if (dialog) closeModal(dialog);
+    } catch (error) {
+      /* do nothing */
+    }
+  } else {
+    const details = findDetails(window.location.hash, null);
+    if (details) getModal(details);
+    if (e.oldURL?.includes('#')) {
+      prevHash = new URL(e.oldURL).hash;
+    }
+  }
+});

--- a/express/blocks/modal/modal.js
+++ b/express/blocks/modal/modal.js
@@ -190,11 +190,15 @@ export async function getModal(details, custom) {
   }
 
   const iframe = dialog.querySelector('iframe');
-  // TODO: different from milo as we are not using commerce-frame
   if (iframe) {
-    /* Initially iframe height is set to 0% in CSS for the height auto adjustment feature.
-    For modals without the 'commerce-frame' class height auto adjustment is not applicable */
-    iframe.style.height = '100%';
+    if (dialog.classList.contains('commerce-frame')) {
+      const { default: enableCommerceFrameFeatures } = await import('./modal.merch.js');
+      await enableCommerceFrameFeatures({ dialog, iframe });
+    } else {
+      /* Initially iframe height is set to 0% in CSS for the height auto adjustment feature.
+      For modals without the 'commerce-frame' class height auto adjustment is not applicable */
+      iframe.style.height = '100%';
+    }
   }
 
   return dialog;

--- a/express/blocks/modal/modal.merch.js
+++ b/express/blocks/modal/modal.merch.js
@@ -1,0 +1,87 @@
+import { debounce } from '../../scripts/utils/action.js';
+
+export const MOBILE_MAX = 599;
+export const TABLET_MAX = 1199;
+
+window.addEventListener('pageshow', (event) => {
+  // if there is a commerce modal with an iframe open, reload the page to avoid bfcache issues.
+  if (event.persisted && document.querySelector('.dialog-modal.commerce-frame iframe')) {
+    window.location.reload();
+  }
+});
+
+export function adjustModalHeight(contentHeight) {
+  if (!(window.location.hash || document.getElementById('checkout-link-modal'))) return;
+  let selector = '#checkout-link-modal';
+  if (!/=/.test(window.location.hash)) selector = `${selector},div.dialog-modal.commerce-frame${window.location.hash}`;
+  const dialog = document.querySelector(selector);
+  const iframe = dialog?.querySelector('iframe');
+  const iframeWrapper = dialog?.querySelector('.milo-iframe');
+  if (!contentHeight || !iframe || !iframeWrapper) return;
+  if (contentHeight === '100%') {
+    iframe.style.height = '100%';
+    iframeWrapper.style.removeProperty('height');
+    dialog.style.removeProperty('height');
+  } else {
+    const verticalMargins = 20;
+    const clientHeight = document.documentElement.clientHeight - verticalMargins;
+    if (clientHeight <= 0) return;
+    const newHeight = contentHeight > clientHeight ? clientHeight : contentHeight;
+    iframe.style.height = '100%';
+    iframeWrapper.style.height = `${newHeight}px`;
+    dialog.style.height = `${newHeight}px`;
+  }
+}
+
+export function sendViewportDimensionsToIframe(source) {
+  const viewportWidth = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0);
+  source.postMessage({ mobileMax: MOBILE_MAX, tabletMax: TABLET_MAX, viewportWidth }, '*');
+}
+
+export function sendViewportDimensionsOnRequest(source) {
+  sendViewportDimensionsToIframe(source);
+  window.addEventListener('resize', debounce(() => sendViewportDimensionsToIframe(source), 10));
+}
+
+function reactToMessage({ data, source }) {
+  if (data === 'viewportWidth' && source) {
+    /* If the page inside iframe comes from another domain, it won't be able to retrieve
+    the viewport dimensions, so it sends a request to receive the viewport dimensions
+    from the parent window. */
+    sendViewportDimensionsOnRequest(source);
+  }
+
+  if (data?.contentHeight) {
+    /* If the page inside iframe sends the postMessage with its content height,
+    we activate the height auto adjustment to eliminate the blank space at the bottom of the modal.
+    For this we set the iframe height to 0% in CSS to let the page inside iframe
+    to measure its content height properly.
+    Then we set the modal height to be the same as the content height we received.
+    For the modal height adjustment to work the following conditions must be met:
+    1. The modal must have the class 'commerce-frame';
+    2. The page inside iframe must send a postMessage with the contentHeight (in px, or '100%); */
+    adjustModalHeight(data?.contentHeight);
+  }
+}
+
+export function adjustStyles({ dialog, iframe }) {
+  const isAutoHeightAdjustment = /\/mini-plans\/.*mid=ft.*web=1/.test(iframe.src); // matches e.g. https://www.adobe.com/mini-plans/photoshop.html?mid=ft&web=1
+  if (isAutoHeightAdjustment) {
+    dialog.classList.add('height-fit-content');
+    // fail safe.
+    setTimeout(() => {
+      const { height } = window.getComputedStyle(iframe);
+      if (height === '0px') {
+        iframe.style.height = '100%';
+      }
+    }, 2000);
+  } else {
+    iframe.style.height = '100%';
+  }
+}
+
+export default async function enableCommerceFrameFeatures({ dialog, iframe }) {
+  if (!dialog || !iframe) return;
+  adjustStyles({ dialog, iframe });
+  window.addEventListener('message', reactToMessage);
+}

--- a/express/scripts/express-delayed.js
+++ b/express/scripts/express-delayed.js
@@ -4,7 +4,6 @@ import {
   getMetadata,
   getConfig,
   loadStyle,
-  loadLink,
 } from './utils.js';
 import BlockMediator from './block-mediator.js';
 
@@ -145,14 +144,10 @@ function preloadSUSILight() {
     preloadTag.setAttribute('data-stage', 'true');
   }
   import('../blocks/susi-light/susi-light.js')
-    .then((mod) => mod.loadWrapper())
-    .then(() => {
-      document.head.append(preloadTag);
-    });
+    .then(({ loadWrapper }) => loadWrapper())
+    .then(() => document.head.append(preloadTag));
   loadStyle('/express/blocks/susi-light/susi-light.css');
   import('../blocks/fragment/fragment.js');
-  loadLink('/express/icons/close-button-x.svg', { rel: 'preload', as: 'image' });
-  loadLink('/express/icons/cc-express.svg', { rel: 'preload', as: 'image' });
 }
 
 /**

--- a/express/scripts/utils/action.js
+++ b/express/scripts/utils/action.js
@@ -1,0 +1,12 @@
+export function debounce(callback, time = 300) {
+  if (typeof callback !== 'function') return undefined;
+
+  let timer = null;
+
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => callback(...args), time);
+  };
+}
+
+export default { debounce };

--- a/express/styles/rounded-corners.css
+++ b/express/styles/rounded-corners.css
@@ -1,0 +1,35 @@
+:root {
+  /* border-radius sizes */
+  --s-rounded-corners: 4px;
+  --m-rounded-corners: 8px;
+  --l-rounded-corners: 16px;
+  --full-rounded-corners: 50%;
+}
+
+.rounded-corners,
+.rounded-corners > .background img,
+.rounded-corners-image .foreground .image picture img {
+  border-radius: var(--m-rounded-corners);
+}
+
+.s-rounded-corners,
+.s-rounded-corners > .background img,
+.s-rounded-corners-image .foreground .image picture img {
+  border-radius: var(--s-rounded-corners);
+}
+
+.m-rounded-corners,
+.m-rounded-corners > .background img,
+.m-rounded-corners-image .foreground .image picture img {
+  border-radius: var(--m-rounded-corners);
+}
+
+.l-rounded-corners,
+.l-rounded-corners > .background img,
+.l-rounded-corners-image .foreground .image picture img {
+  border-radius: var(--l-rounded-corners);
+}
+
+.full-rounded-corners-image .foreground .image picture img {
+  border-radius: var(--full-rounded-corners);
+}


### PR DESCRIPTION
Our modal has the close button truncated on Safari. This PR will get us using almost a pure copy of Milo's modal (https://github.com/adobecom/milo/blob/stage/libs/blocks/modal/modal.js). There are still 2 differences: 

1. Our fragments work slightly different from Milo, and this is blocking us from also copying over Milo's unit tests. This can be resolved once we take the next steps to convert our fragments
2. Different lint rules

Resolves: https://jira.corp.adobe.com/browse/CCEDU-10613

On Safari you should see that the button is truncated on stage, but fixed in the branch url. Note that to test the new modal with FaaS, we had to get it to stage as that's where FaaS will load correctly.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/spotlight/education?martech=off#susi-light-1
- After: https://sync-milo-modal--express--adobecom.hlx.page/express/spotlight/education?martech=off#susi-light-1
