### PR TITLE
[Branch Links] Added Region along with Locale

### DIFF
--- a/express/scripts/branchlinks.js
+++ b/express/scripts/branchlinks.js
@@ -158,7 +158,9 @@ export default async function trackBranchParameters(links) {
       setParams('trackingid', trackingId);
       setParams('cgen', cgen);
       setParams('placement', placement);
-      setParams('locale', getConfig().locale.ietf);
+      const { locale: { ietf, region } } = getConfig();
+      setParams('locale', ietf);
+      setParams('contentRegion', region === 'uk' ? 'gb' : region);
 
       if (sKwcId) {
         const sKwcIdParameters = sKwcId.split('!');


### PR DESCRIPTION
Locale is used for Editor's UI language, and specifying landing template filtering language is tricky due to many languages not yet supported by the product. The current solution after discussion with the Product Globalization team is to keep locale for UI language and add contentRegion for template region boosting.

Resolves: https://jira.corp.adobe.com/browse/MWPW-154554

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/create/poster?lighthouse=on
- After: https://branch-link-language-region--express--adobecom.hlx.page/express/create/poster?lighthouse=on
