### PR TITLE
CSS changes for localization fixes

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -251,6 +251,7 @@ End border style variants
   display: flex;
   flex-direction: row-reverse;
   gap: 8px;
+  text-align: left;
 }
 
 .pricing-cards .card-header img {
@@ -284,6 +285,8 @@ End border style variants
   color: #5258E4;
   height: 20px;
   font-style: normal;
+  height: auto;
+  max-width: 240px;
 }
 
 .pricing-cards .card-offer a {
@@ -293,6 +296,7 @@ End border style variants
 /** pricing styles start **/
 .pricing-cards .pricing-row {
   max-width: 330px;
+  margin-top: 20px;
 }
 
 .pricing-cards .pricing-base-price,

--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -388,7 +388,7 @@ End border style variants
   gap: 12px;
   align-items: center;
   font-size: var(--body-font-size-s);
-  margin-bottom: 4px;
+  margin-bottom: 12px;
 }
 
 .pricing-cards .billing-toggle button {


### PR DESCRIPTION
1. Adds max-width to purple eyebrow offer text on pricing-cards while preserving price and CTA alignment throughout the pricing cards.
2. Adds left alignment to h2 at top of cards.

Resolves: [MWPW-154130](https://jira.corp.adobe.com/browse/MWPW-154130)

Test URLs Eyebrow Changes:
- Before: https://www.stage.adobe.com/fr/express/pricing?country=fr
- After: https://pricing-locale--express--adobecom.hlx.page/fr/express/pricing?country=fr%20

Test URLs Left Alignment Changes
- Before: https://www.stage.adobe.com/jp/express/pricing?country=jp&tab=3
- After: https://pricing-locale--express--adobecom.hlx.page/jp/express/pricing?country=jp&tab=3