### PR TITLE
[Modal] Dedup Milo Modal Hashes

### DIFF
--- a/express/blocks/modal/modal.js
+++ b/express/blocks/modal/modal.js
@@ -13,6 +13,7 @@ const CLOSE_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="2
 
 let isDelayedModal = false;
 let prevHash = '';
+const dialogLoadingSet = new Set();
 
 export function findDetails(hash, el) {
   const id = hash.replace('#', '');
@@ -107,6 +108,7 @@ export async function getModal(details, custom) {
   if (!(details?.path || custom)) return null;
   const { id } = details || custom;
 
+  dialogLoadingSet.add(id);
   const dialog = createTag('div', { class: 'dialog-modal', id });
   const loadedEvent = new Event('milo:modal:loaded');
 
@@ -174,6 +176,7 @@ export async function getModal(details, custom) {
 
   dialog.append(close);
   document.body.append(dialog);
+  dialogLoadingSet.delete(id);
   firstFocusable.focus({ preventScroll: true, ...focusVisible });
   window.dispatchEvent(loadedEvent);
 
@@ -241,6 +244,7 @@ export function delayedModal(el) {
 export default function init(el) {
   const { modalHash } = el.dataset;
   if (delayedModal(el) || window.location.hash !== modalHash || document.querySelector(`div.dialog-modal${modalHash}`)) return null;
+  if (dialogLoadingSet.has(modalHash.replace('#', ''))) return null;
   const details = findDetails(window.location.hash, el);
   return details ? getModal(details) : null;
 }

--- a/express/blocks/modal/modal.js
+++ b/express/blocks/modal/modal.js
@@ -244,7 +244,7 @@ export function delayedModal(el) {
 export default function init(el) {
   const { modalHash } = el.dataset;
   if (delayedModal(el) || window.location.hash !== modalHash || document.querySelector(`div.dialog-modal${modalHash}`)) return null;
-  if (dialogLoadingSet.has(modalHash.replace('#', ''))) return null;
+  if (dialogLoadingSet.has(modalHash?.replace('#', ''))) return null;
   const details = findDetails(window.location.hash, el);
   return details ? getModal(details) : null;
 }


### PR DESCRIPTION
There exists a race condition when the same modal hashes appear multiple times on the page, and the same fragment could be loaded more than once. Namely, after the first hash change, there is a period where the first modal needs network fetches to retrieve its content while the dialog-modal hasn't been appended to document yet. If another modal on the page gets its init() called during this period, all current safeguard will fail. This PR aims to cover this condition by keeping track of what dialogs are being loaded but not yet appended.

A bug/pull request will also be raised to Milo. But since we have a dependency on this for the current stage->main, we should merge it in now. If Milo takes a different approach, we will sync again.

In terms of reproducing it more reliably, locally or using overrides, in modal.js, you can fake a longer getPathModal() call by making it into `await Promise.all([getPathModal(details.path, dialog), new Promise((r) => setTimeout(r, 4000))]);`. Then to delay the second modal, make it async, add `if (document.querySelector('a.modal') !== el) {
    await new Promise((r) => setTimeout(r, 2000));
  }` tot the first line of init. Then clicking the primary CTA should make the FaaS act buggy.

Resolves: https://jira.corp.adobe.com/browse/MWPW-147304

Test URLs:
- Before: https://www.stage.adobe.com/express/business?lighthouse=on
- After: https://modal-hash-dedup--express--adobecom.hlx.page/express/business?lighthouse=on
