### PR TITLE
[FloatingCTA] Shorter classname

### DIFF
--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -165,7 +165,7 @@ export function createFloatingButton(block, audience, data) {
       || (new URL(a.href).pathname === aTagURL.pathname && new URL(a.href).hash === aTagURL.hash))
       && !a.parentElement.parentElement.classList.contains('floating-button'));
   sameUrlCTAs.forEach((cta) => {
-    cta.classList.add('same-as-floating-button-CTA');
+    cta.classList.add('same-fcta');
   });
 
   const floatButtonWrapperOld = aTag.closest('.floating-button-wrapper');
@@ -256,7 +256,7 @@ export function createFloatingButton(block, audience, data) {
     },
   }));
 
-  const heroCTA = document.querySelector('a.button.same-as-floating-button-CTA');
+  const heroCTA = document.querySelector('a.button.same-fcta');
   if (heroCTA) {
     const hideButtonWhenIntersecting = new IntersectionObserver(([e]) => {
       if (e.boundingClientRect.top > window.innerHeight - 40 || e.boundingClientRect.top === 0) {

--- a/express/blocks/split-action/split-action.js
+++ b/express/blocks/split-action/split-action.js
@@ -87,7 +87,7 @@ export default function decorate(block) {
       const buttons = document.querySelectorAll('.button.primaryCTA');
       const matchingButtons = Array.from(buttons).filter((button) => button.href === anchor.href);
 
-      if (anchor.classList.contains('same-as-floating-button-CTA') || matchingButtons.length > 0) {
+      if (anchor.classList.contains('same-fcta') || matchingButtons.length > 0) {
         anchor.classList.add('no-event');
         anchor.target = '_self';
         hrefHolder = anchor.href;

--- a/express/scripts/express-delayed.js
+++ b/express/scripts/express-delayed.js
@@ -10,7 +10,7 @@ import BlockMediator from './block-mediator.js';
 export function getDestination() {
   const pepDestinationMeta = getMetadata('pep-destination');
   return pepDestinationMeta || BlockMediator.get('primaryCtaUrl')
-    || document.querySelector('a.button.xlarge.same-as-floating-button-CTA, a.primaryCTA')?.href;
+    || document.querySelector('a.button.xlarge.same-fcta, a.primaryCTA')?.href;
 }
 
 function getSegmentsFromAlloyResponse(response) {

--- a/express/scripts/google-yolo.js
+++ b/express/scripts/google-yolo.js
@@ -3,7 +3,7 @@ import BlockMediator from './block-mediator.min.js';
 
 function getRedirectUri() {
   const primaryCtaUrl = BlockMediator.get('primaryCtaUrl')
-    || document.querySelector('a.button.xlarge.same-as-floating-button-CTA, a.primaryCTA')?.href;
+    || document.querySelector('a.button.xlarge.same-fcta, a.primaryCTA')?.href;
   if (primaryCtaUrl) {
     return primaryCtaUrl;
   }

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -619,7 +619,7 @@ export function removeIrrelevantSections(main) {
         });
 
       sameUrlCTAs.forEach((cta) => {
-        cta.classList.add('same-as-floating-button-CTA');
+        cta.classList.add('same-fcta');
       });
     }
   }
@@ -662,8 +662,9 @@ export async function decorateBlock(block) {
     // split and add options with a dash
     // (fullscreen-center -> fullscreen-center + fullscreen + center)
     const extra = [];
+    const skipList = ['same-fcta'];
     block.classList.forEach((className, index) => {
-      if (index === 0) return; // block name, no split
+      if (index === 0 || skipList.includes(className)) return; // block name or skip, no split
       const split = className.split('-');
       if (split.length > 1) {
         split.forEach((part) => {

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -951,11 +951,11 @@ main .free-plan-widget .plan-widget-tag img.icon.icon-checkmark {
 }
 
 /* floating-cta main CTA suppression */
-body[data-device="mobile"] main .floating-button-wrapper[data-audience="mobile"][data-section-status="loaded"] .same-as-floating-button-CTA {
+body[data-device="mobile"] main .floating-button-wrapper[data-audience="mobile"][data-section-status="loaded"] .same-fcta {
   display: block;
 }
 
-main > div:not(.banner-container) .block:not(.pricing-summary, .pricing-cards, .pricing-table, .puf, .split-action, .link-list, .wayfinder, .ratings) a.button.same-as-floating-button-CTA {
+main > div:not(.banner-container) .block:not(.pricing-summary, .pricing-cards, .pricing-table, .puf, .split-action, .link-list, .wayfinder, .ratings) a.button.same-fcta {
   display: none;
 }
 
@@ -983,7 +983,7 @@ main > div:not(.banner-container) .block:not(.pricing-summary, .pricing-cards, .
     text-align: left;
   }
 
-  main > div:not(.banner-container) .block:not(.pricing-summary, .pricing-cards, .pricing-table, .puf, .link-list, .wayfinder, .ratings) a.button.same-as-floating-button-CTA {
+  main > div:not(.banner-container) .block:not(.pricing-summary, .pricing-cards, .pricing-table, .puf, .link-list, .wayfinder, .ratings) a.button.same-fcta {
     display: inline-block;
   }
 }

--- a/test/unit/blocks/toggle-bar/mocks/sticky.html
+++ b/test/unit/blocks/toggle-bar/mocks/sticky.html
@@ -4557,7 +4557,7 @@
                         <p class="button-container"><a
                                 href="https://adobesparkpost.app.link/GJrBPFUWBBb?url=/express/&amp;ctaid=banner"
                                 title="Get Adobe Express Free"
-                                class="button accent dark reverse same-as-floating-button-CTA">Get Adobe Express
+                                class="button accent dark reverse same-fcta">Get Adobe Express
                             Free</a></p>
                         <p class="button-container"><a href="https://helpx.adobe.com/express/express-faq.html"
                                                        title="Learn more" class="button accent dark reverse"


### PR DESCRIPTION
The old classname for flagging a colliding CTA with floatingCTA was unnecessarily long. This PR also prevents this classname to be splited by our block class logic.

No visual or functional changes.
Pages to check for regression:
- https://shorter-floating-class--express--adobecom.hlx.live/express/?martech=off
- https://shorter-floating-class--express--adobecom.hlx.live/express/create/flyer?martech=off
- https://shorter-floating-class--express--adobecom.hlx.live/express/create/video/instagram/reel?martech=off

Resolves: https://jira.corp.adobe.com/browse/MWPW-154659

Test URLs:
- Before: https://stage--express--adobecom.hlx.live/express/?martech=off
- After: https://shorter-floating-class--express--adobecom.hlx.live/express/?martech=off
