### PR TITLE
[FloatingCTA][Modal] Decorate FloatingCTA Links

### DIFF
--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -6,7 +6,6 @@ import {
   getMobileOperatingSystem,
   lazyLoadLottiePlayer,
   loadStyle,
-  decorateLinks,
 } from '../../scripts/utils.js';
 
 import BlockMediator from '../../scripts/block-mediator.min.js';
@@ -303,7 +302,6 @@ export function createFloatingButton(block, audience, data) {
     document.dispatchEvent(new CustomEvent('linkspopulated', { detail: [floatButtonLink] }));
   }
 
-  decorateLinks(floatButtonWrapper);
   return floatButtonWrapper;
 }
 

--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -6,6 +6,7 @@ import {
   getMobileOperatingSystem,
   lazyLoadLottiePlayer,
   loadStyle,
+  decorateLinks,
 } from '../../scripts/utils.js';
 
 import BlockMediator from '../../scripts/block-mediator.min.js';
@@ -302,6 +303,7 @@ export function createFloatingButton(block, audience, data) {
     document.dispatchEvent(new CustomEvent('linkspopulated', { detail: [floatButtonLink] }));
   }
 
+  decorateLinks(floatButtonWrapper);
   return floatButtonWrapper;
 }
 

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1927,6 +1927,7 @@ async function buildAutoBlocks(main) {
       const button = buildBlock(blockName, device);
       button.classList.add('metadata-powered');
       lastDiv.append(button);
+      decorateLinks(lastDiv);
       BlockMediator.set('floatingCtasLoaded', true);
     }
   }


### PR DESCRIPTION
As of now, modal links authored in floatingCTA won't get decorated or autoblocked, because our floatingCTA's dynamic content lives outside of the section/block flow. This PR aims to add a decorateLinks() call after floating-cta has been dynamically constructed.

Resolves: https://jira.corp.adobe.com/browse/MWPW-154757

In stage, you should see that the floatingCTA's link did not get decorated and the autoblock for the modal did not happen. In the branch, it should have been processed properly.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/learn/students?lighthouse=on
- After: https://decorate-fcta-links--express--adobecom.hlx.page/express/learn/students?lighthouse=on
