### PR TITLE
FloatingCTA Decorate Links

### DIFF
--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -6,6 +6,7 @@ import {
   getMobileOperatingSystem,
   lazyLoadLottiePlayer,
   loadStyle,
+  decorateLinks,
 } from '../../scripts/utils.js';
 
 import BlockMediator from '../../scripts/block-mediator.min.js';
@@ -302,6 +303,7 @@ export function createFloatingButton(block, audience, data) {
     document.dispatchEvent(new CustomEvent('linkspopulated', { detail: [floatButtonLink] }));
   }
 
+  decorateLinks(floatButtonWrapper);
   return floatButtonWrapper;
 }
 

--- a/test/unit/blocks/floating-button/floating-button.test.js
+++ b/test/unit/blocks/floating-button/floating-button.test.js
@@ -3,8 +3,10 @@
 
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
+import { setConfig } from '../../../../express/scripts/utils.js';
 
 const { default: decorate } = await import('../../../../express/blocks/floating-button/floating-button.js');
+setConfig({ autoBlocks: [{ fragment: '/express/fragments/' }] });
 
 describe('Floating Button', () => {
   before(() => {
@@ -17,6 +19,28 @@ describe('Floating Button', () => {
       },
     ];
     window.placeholders = { 'see-more': 'See More' };
+    document.head.innerHTML = `${document.head.innerHTML}<meta name="floating-cta-live" content="Y">
+    <meta name="desktop-floating-cta" content="floating-button">
+    <meta name="mobile-floating-cta" content="floating-button">
+    <meta name="show-floating-cta-app-store-badge" content="Y">
+    <meta name="use-floating-cta-lottie-arrow" content="N">
+    <meta name="floating-cta-bubble-sheet" content="fallback-bubbles-sheet">
+    <meta name="ctas-above-divider" content="2">
+    <meta name="main-cta-link" content="https://main--express--adobecom.hlx.page/express/fragments/susi-light-teacher#susi-light-2">
+    <meta name="main-cta-text" content="Create now">
+    <meta name="cta-1-icon" content="download-app-icon-22">
+    <meta name="cta-1-link" content="https://adobesparkpost.app.link/c4bWARQhWAb">
+    <meta name="cta-1-text" content="Download App">
+    <meta name="cta-2-icon" content="browse-icon-22">
+    <meta name="cta-2-link" content="https://adobesparkpost.app.link/lQEQ4Pi1YHb">
+    <meta name="cta-2-text" content="Browse all templates">
+    <meta name="cta-3-icon" content="scratch-icon-22">
+    <meta name="cta-3-link" content="https://adobesparkpost.app.link/c4bWARQhWAb">
+    <meta name="cta-3-text" content="Start from scratch">
+    <meta name="desktop-floating-cta-text" content="Get Adobe Express for free">
+    <meta name="mobile-floating-cta-text" content="Get Adobe Express for free">
+    <meta name="theme" content="No Brand Header">
+    <meta name="show-floating-cta" content="Yes">`;
   });
 
   it('Floating Button exists', async () => {


### PR DESCRIPTION
As of now, modal links authored in floatingCTA won't get decorated or autoblocked, because our floatingCTA's dynamic content lives outside of the section/block flow. This PR aims to add a decorateLinks() call after floating-cta has been dynamically constructed.

Resolves: https://jira.corp.adobe.com/browse/MWPW-154757

In stage, you should see that the floatingCTA's link did not get decorated and the autoblock for the modal did not happen. In the branch, it should have been processed properly.

Test URLs:

Before: https://stage--express--adobecom.hlx.page/express/learn/students?lighthouse=on
After: https://fcta-decorate-links--express--adobecom.hlx.page/express/learn/students?lighthouse=on