### PR TITLE
[Personalization][RTP] Merge Marquee-exp-1 into Marquee Entitled Variant

### DIFF
--- a/express/blocks/marquee/marquee.css
+++ b/express/blocks/marquee/marquee.css
@@ -91,9 +91,44 @@ body.no-desktop-brand-header header {
   margin: 0 0 8px 0;
 }
 
+.marquee.entitled .content-wrapper .eyebrow-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: auto;
+  max-width: max-content;
+}
+
+.marquee.entitled .content-wrapper .eyebrow-wrapper h3 {
+  font-size: var(--body-font-size-l);
+  font-weight: 400;
+  text-align: left;
+}
+
+.marquee.entitled .content-wrapper .eyebrow-wrapper img.icon {
+  width: 32px;
+  height: 32px;
+}
+
 .marquee .content-wrapper p {
   font-size: var(--body-font-size-m);
   margin: 16px 0;
+}
+
+.marquee.entitled .content-wrapper .buttons-wrapper.with-legal-copy {
+  align-items: center;
+}
+
+.marquee.entitled .content-wrapper .buttons-wrapper.with-legal-copy .entitled-cta-tag {
+  font-size: var(--body-font-size-m);
+  align-items: center;
+  display: flex;
+  text-align: left;
+}
+
+.marquee.entitled .content-wrapper .buttons-wrapper.with-legal-copy .entitled-cta-tag .icon {
+  margin-right: 8px;
+  display: block;
 }
 
 .marquee p > a {
@@ -278,6 +313,10 @@ body.no-desktop-brand-header header {
   .marquee .content-wrapper,
   .marquee .content-wrapper h2{
     text-align: left;
+  }
+
+  .marquee.entitled .content-wrapper .eyebrow-wrapper {
+    margin: unset;
   }
 
   .marquee .background-wrapper {

--- a/express/blocks/marquee/marquee.js
+++ b/express/blocks/marquee/marquee.js
@@ -352,6 +352,7 @@ async function handleAnimation(div, typeHint, block, animations) {
 const LOGO = 'adobe-express-logo';
 const LOGO_WHITE = 'adobe-express-logo-white';
 function injectExpressLogo(block, wrapper) {
+  if (block.classList.contains('entitled')) return;
   if (!['on', 'yes'].includes(getMetadata('marquee-inject-logo')?.toLowerCase())) return;
   const mediaQuery = window.matchMedia('(min-width: 900px)');
   const logo = getIconElement(block.classList.contains('dark') && mediaQuery.matches ? LOGO_WHITE : LOGO);
@@ -370,6 +371,33 @@ function injectExpressLogo(block, wrapper) {
     logo.classList.add('eyebrow-margin');
   }
   wrapper.prepend(logo);
+}
+
+function decorateEntitled(contentWrapper) {
+  const eyebrowText = contentWrapper.querySelector('h3');
+  const eyebrowIcon = contentWrapper.querySelector('p > img.icon');
+  const legalCopy = contentWrapper.querySelector('p.legal-copy');
+
+  if (eyebrowIcon && eyebrowText) {
+    const oldIconWrapper = eyebrowIcon.parentElement;
+    const eyebrowWrapper = createTag('div', { class: 'eyebrow-wrapper' });
+    eyebrowWrapper.append(eyebrowIcon, eyebrowText);
+    contentWrapper.prepend(eyebrowWrapper);
+
+    if (!oldIconWrapper.children.length) {
+      oldIconWrapper.remove();
+    }
+  }
+
+  if (legalCopy && legalCopy.previousElementSibling?.classList.contains('buttons-wrapper')) {
+    const btnContainer = legalCopy.previousElementSibling;
+    const legalText = createTag('span', {}, legalCopy.textContent.replace('**', '').trim());
+    legalCopy.innerHTML = '';
+    legalCopy.append(getIconElement('checkmark-green'), legalText);
+    legalCopy.className = 'entitled-cta-tag';
+    btnContainer.append(legalCopy);
+    btnContainer.classList.add('with-legal-copy');
+  }
 }
 
 async function handleContent(div, block, animations) {
@@ -456,6 +484,10 @@ async function handleContent(div, block, animations) {
         'with-inline-ctas',
       );
     }
+  }
+
+  if (block.classList.contains('entitled')) {
+    decorateEntitled(contentWrapper);
   }
 }
 


### PR DESCRIPTION
During ccx0167, a marquee-exp-1 block was created (https://github.com/adobecom/express/pull/593/files). Now that the test won and we are deploying the personalization, we should merge its special content handling js and css into the entitled variant of the marquee block.

Resolves: https://jira.corp.adobe.com/browse/MWPW-154594?filter=381833

It should have no impacts to non-entitled marquee we currently have. With entitled variant, it should look the same as marquee-exp-1.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/jinglhua/marquee-entitled?lighthouse=on
- After: https://entitled-marquee--express--adobecom.hlx.page/drafts/jinglhua/marquee-entitled?lighthouse=on
