### PR TITLE
ensure words do not break with hyphens on mobile

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -136,54 +136,6 @@ const listenAlloy = () => {
   }, 3000);
 };
 
-(function replaceHyphensInTextNodes() {
-  // Function to replace hyphens in text nodes with non-breaking hyphens
-  function replaceHyphensInElement(element) {
-    const treeWalker = document.createTreeWalker(
-      element,
-      NodeFilter.SHOW_TEXT,
-      {
-        acceptNode(node) {
-          // Ignore script and style elements
-          if (node.parentNode.nodeName !== 'SCRIPT' && node.parentNode.nodeName !== 'STYLE') {
-            return NodeFilter.FILTER_ACCEPT;
-          }
-          return NodeFilter.FILTER_REJECT;
-        },
-      },
-      false,
-    );
-
-    let currentNode = treeWalker.nextNode();
-    while (currentNode) {
-      // Replace hyphen with non-breaking hyphen
-      currentNode.nodeValue = currentNode.nodeValue.replace(/-/g, '\u2011');
-      currentNode = treeWalker.nextNode();
-    }
-  }
-
-  // Apply replacements once DOM is fully loaded
-  document.addEventListener('DOMContentLoaded', () => {
-    replaceHyphensInElement(document.body);
-
-    // Observe the document body for dynamically added content
-    const observer = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        mutation.addedNodes.forEach((node) => {
-          if (node.nodeType === Node.ELEMENT_NODE) {
-            replaceHyphensInElement(node);
-          }
-        });
-      });
-    });
-
-    observer.observe(document.body, {
-      childList: true,
-      subtree: true,
-    });
-  });
-}());
-
 (async function loadPage() {
   if (window.hlx.init || window.isTestEnv) return;
   window.hlx = window.hlx || {};

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -136,6 +136,38 @@ const listenAlloy = () => {
   }, 3000);
 };
 
+(function replaceHyphensInTextNodes() {
+  // replace hyphens in text nodes with non-breaking hyphens
+  function replaceHyphensInElement(element) {
+    const treeWalker = document.createTreeWalker(
+      element,
+      NodeFilter.SHOW_TEXT,
+      {
+        acceptNode(node) {
+          // ignore script and style elements
+          if (node.parentNode.nodeName !== 'SCRIPT' && node.parentNode.nodeName !== 'STYLE') {
+            return NodeFilter.FILTER_ACCEPT;
+          }
+          return NodeFilter.FILTER_REJECT;
+        },
+      },
+      false,
+    );
+
+    let currentNode = treeWalker.nextNode();
+    while (currentNode) {
+      // replace hyphen with non-breaking hyphen
+      currentNode.nodeValue = currentNode.nodeValue.replace(/-/g, '\u2011');
+      currentNode = treeWalker.nextNode();
+    }
+  }
+
+  // apply replacements once DOM is fully loaded
+  document.addEventListener('DOMContentLoaded', () => {
+    replaceHyphensInElement(document.body);
+  });
+}());
+
 (async function loadPage() {
   if (window.hlx.init || window.isTestEnv) return;
   window.hlx = window.hlx || {};

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -137,14 +137,14 @@ const listenAlloy = () => {
 };
 
 (function replaceHyphensInTextNodes() {
-  // replace hyphens in text nodes with non-breaking hyphens
+  // Function to replace hyphens in text nodes with non-breaking hyphens
   function replaceHyphensInElement(element) {
     const treeWalker = document.createTreeWalker(
       element,
       NodeFilter.SHOW_TEXT,
       {
         acceptNode(node) {
-          // ignore script and style elements
+          // Ignore script and style elements
           if (node.parentNode.nodeName !== 'SCRIPT' && node.parentNode.nodeName !== 'STYLE') {
             return NodeFilter.FILTER_ACCEPT;
           }
@@ -156,15 +156,31 @@ const listenAlloy = () => {
 
     let currentNode = treeWalker.nextNode();
     while (currentNode) {
-      // replace hyphen with non-breaking hyphen
+      // Replace hyphen with non-breaking hyphen
       currentNode.nodeValue = currentNode.nodeValue.replace(/-/g, '\u2011');
       currentNode = treeWalker.nextNode();
     }
   }
 
-  // apply replacements once DOM is fully loaded
+  // Apply replacements once DOM is fully loaded
   document.addEventListener('DOMContentLoaded', () => {
     replaceHyphensInElement(document.body);
+
+    // Observe the document body for dynamically added content
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        mutation.addedNodes.forEach((node) => {
+          if (node.nodeType === Node.ELEMENT_NODE) {
+            replaceHyphensInElement(node);
+          }
+        });
+      });
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
   });
 }());
 

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2550,13 +2550,11 @@ function fragmentBlocksToLinks(area) {
 }
 
 function replaceHyphensInText(area) {
-  document.addEventListener('DOMContentLoaded', () => {
-    [...area.querySelectorAll('h1, h2, h3, h4, h5, h6')]
-      .filter((header) => header.innerHTML.includes('-'))
-      .forEach((header) => {
-        header.innerHTML = header.innerHTML.replace(/-/g, '\u2011');
-      });
-  });
+  [...area.querySelectorAll('h1, h2, h3, h4, h5, h6')]
+    .filter((header) => header.innerHTML.includes('-'))
+    .forEach((header) => {
+      header.innerHTML = header.innerHTML.replace(/-/g, '\u2011');
+    });
 }
 
 export async function loadArea(area = document) {

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2549,6 +2549,16 @@ function fragmentBlocksToLinks(area) {
   });
 }
 
+function replaceHyphensInText(area) {
+  document.addEventListener('DOMContentLoaded', () => {
+    [...area.querySelectorAll('h1, h2, h3, h4, h5, h6')]
+      .filter((header) => header.innerHTML.includes('-'))
+      .forEach((header) => {
+        header.innerHTML = header.innerHTML.replace(/-/g, '\u2011');
+      });
+  });
+}
+
 export async function loadArea(area = document) {
   const isDoc = area === document;
 
@@ -2574,6 +2584,7 @@ export async function loadArea(area = document) {
 
   splitSections(area);
   decorateButtons(area);
+  replaceHyphensInText(area);
   await fixIcons(area);
   decorateSocialIcons(area);
 

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -104,7 +104,7 @@ body {
 }
 
 body[data-device="mobile"] {
-  h1, h2 {
+  h1, h2, h3, h4, h5, h6 {
     hyphens: none;
     overflow-wrap: break-word; 
     word-wrap: break-word;     

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -103,6 +103,14 @@ body {
   padding: 0;
 }
 
+body[data-device="mobile"] {
+  h1, h2 {
+    hyphens: none;
+    overflow-wrap: break-word; 
+    word-wrap: break-word;     
+  }
+}
+
 body.no-scroll {
   overflow-y: hidden;
   touch-action: none;


### PR DESCRIPTION
Mobile Only - Ensure long words never wrap to an additional line split with hyphens.

Resolves: [MWPW-154516](https://jira.corp.adobe.com/browse/MWPW-154516)

Test URLs:

Before: https://main--express--adobecom.hlx.page/in/express/
After: https://line-break-mobile--express--adobecom.hlx.page/in/express/
