### PR TITLE
[BTS][SUSI-Light] ATC Triggers Redirect Directly to Destination if Already Signed in

### DIFF
--- a/express/blocks/susi-light/susi-light.js
+++ b/express/blocks/susi-light/susi-light.js
@@ -89,6 +89,12 @@ export default async function init(el) {
   if (isStage && ['new.express.adobe.com', 'express.adobe.com'].includes(destURL.hostname)) {
     destURL.hostname = 'stage.projectx.corp.adobe.com';
   }
+  const goDest = () => window.location.assign(destURL.toString());
+  if (window.feds?.utilities?.imslib) {
+    const { imslib } = window.feds.utilities;
+    imslib.isReady() && imslib.isSignedInUser() && goDest();
+    imslib.onReady().then(() => imslib.isSignedInUser() && goDest());
+  }
   el.innerHTML = '';
   await loadWrapper();
   const susi = createTag('susi-sentry-light');


### PR DESCRIPTION
Redirect users right away as we are loading SUSI-Light ATC and detecting that users are already signed in.

You can try signing in & out and clicking the primary CTA. When signed in, you should be redirected into the product right away. When signed out, you should get prompted for inputs on the ATC modal.

Resolves: https://jira.corp.adobe.com/browse/CCEDU-10713?filter=381833

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/learn/students
- After: https://susi-light--express--adobecom.hlx.page/express/learn/students
