### PR TITLE
[Target] New Metadata to Turn Off Target for Mobile Web Testing

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -9,6 +9,7 @@ import {
   setConfig,
   createTag,
   getConfig,
+  getMobileOperatingSystem,
 } from './utils.js';
 
 const locales = {
@@ -88,6 +89,12 @@ const eagerLoad = (img) => {
     fqaMeta.setAttribute('name', 'fqa-on');
   }
   document.head.append(fqaMeta);
+  if (getMetadata('target-only-mobile-web') === 'on'
+    && getMetadata('target') === 'on'
+    && !(userAgent.includes('Mobile') && getMobileOperatingSystem() === 'Android' && navigator.deviceMemory >= 4)
+  ) {
+    document.head.querySelector('meta[name=target]').content = 'off';
+  }
 }());
 
 (function loadLCPImage() {


### PR DESCRIPTION
We are going to launch a test that only targets Android devices with more than 4gb RAM. Due to RAM detection not yet supported as a Target audience, the final approach we agreed upon is to tag pages running this test with a special metadata, and we turn off target for visitors not qualifying for the test. This way Target won't need to handle the memory split.

You can test using a non-qualified phone via BrowserStack Real Device. One example would be Galaxy A10. You should see head metadata target being set to off once you inspect.

After this test, this code could be deprecated and cleaned up.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/jinglhua/target-mobile-web
- After: https://mobile-web-targeting--express--adobecom.hlx.page/drafts/jinglhua/target-mobile-web
