### PR TITLE
preserve hyphen replacement without affecting pricing cards gradient

### DIFF
--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -7,6 +7,7 @@ import {
   getIconElement,
   addHeaderSizing,
   getMetadata,
+  replaceHyphensInText,
 } from '../../scripts/utils.js';
 import { addTempWrapper } from '../../scripts/decorate.js';
 import { addFreePlanWidget } from '../../scripts/utils/free-plan.js';
@@ -145,6 +146,8 @@ const handleVideos = (cell, a, block, thumbnail) => {
 };
 
 export default async function decorate(block) {
+  document.body.dataset.device === 'mobile' && replaceHyphensInText(document);
+
   addTempWrapper(block, 'columns');
 
   const rows = Array.from(block.children);

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -146,7 +146,7 @@ const handleVideos = (cell, a, block, thumbnail) => {
 };
 
 export default async function decorate(block) {
-  document.body.dataset.device === 'mobile' && replaceHyphensInText(document);
+  document.body.dataset.device === 'mobile' && replaceHyphensInText(block);
 
   addTempWrapper(block, 'columns');
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -9,7 +9,6 @@ import {
   setConfig,
   createTag,
   getConfig,
-  replaceHyphensInText,
 } from './utils.js';
 
 const locales = {
@@ -160,7 +159,6 @@ const listenAlloy = () => {
   loadLana({ clientId: 'express' });
   listenAlloy();
   await loadArea();
-  replaceHyphensInText(document);
 
   import('./express-delayed.js').then((mod) => {
     mod.default();

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -9,6 +9,7 @@ import {
   setConfig,
   createTag,
   getConfig,
+  replaceHyphensInText,
 } from './utils.js';
 
 const locales = {
@@ -159,6 +160,7 @@ const listenAlloy = () => {
   loadLana({ clientId: 'express' });
   listenAlloy();
   await loadArea();
+  replaceHyphensInText(document);
 
   import('./express-delayed.js').then((mod) => {
     mod.default();

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2400,6 +2400,7 @@ export async function loadTemplate() {
       try {
         await import(`${base}/templates/${name}/${name}.js`);
       } catch (err) {
+        // eslint-disable-next-line no-console
         console.log(`failed to load module for ${name}`, err);
       }
       resolve();
@@ -2551,9 +2552,9 @@ function fragmentBlocksToLinks(area) {
 
 export function replaceHyphensInText(area) {
   [...area.querySelectorAll('h1, h2, h3, h4, h5, h6')]
-    .filter((header) => header.innerHTML.includes('-'))
+    .filter((header) => header.textContent.includes('-'))
     .forEach((header) => {
-      header.innerHTML = header.innerHTML.replace(/-/g, '\u2011');
+      header.textContent = header.textContent.replace(/-/g, '\u2011');
     });
 }
 

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2549,13 +2549,13 @@ function fragmentBlocksToLinks(area) {
   });
 }
 
-// function replaceHyphensInText(area) {
-//   [...area.querySelectorAll('h1, h2, h3, h4, h5, h6')]
-//     .filter((header) => header.innerHTML.includes('-'))
-//     .forEach((header) => {
-//       header.innerHTML = header.innerHTML.replace(/-/g, '\u2011');
-//     });
-// }
+export function replaceHyphensInText(area) {
+  [...area.querySelectorAll('h1, h2, h3, h4, h5, h6')]
+    .filter((header) => header.innerHTML.includes('-'))
+    .forEach((header) => {
+      header.innerHTML = header.innerHTML.replace(/-/g, '\u2011');
+    });
+}
 
 export async function loadArea(area = document) {
   const isDoc = area === document;
@@ -2582,7 +2582,6 @@ export async function loadArea(area = document) {
 
   splitSections(area);
   decorateButtons(area);
-  // replaceHyphensInText(area);
   await fixIcons(area);
   decorateSocialIcons(area);
 


### PR DESCRIPTION
These changes hyper target the columns block only. This prevents a known side effect seen in pricing-cards where the gradient is broken when hyphens in header elements are replaced.

Resolves: [MWPW-154516](https://jira.corp.adobe.com/browse/MWPW-154516)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://pricing-cards-hyphen--express--adobecom.hlx.page/express/
