### PR TITLE
[MEP] Remove Sections Post pageReplacement

### DIFF
--- a/express/features/personalization/personalization.js
+++ b/express/features/personalization/personalization.js
@@ -559,12 +559,14 @@ const checkForParamMatch = (paramStr) => {
 };
 
 async function getPersonalizationVariant(manifestPath, variantNames = [], variantLabel = null) {
+  const trimNames = (arr) => arr.map((v) => v.trim()).filter(Boolean);
   const variantInfo = variantNames.reduce((acc, name) => {
     let nameArr = [name];
     if (!name.startsWith(TARGET_EXP_PREFIX)) nameArr = name.split(',');
-    const vNames = nameArr.map((v) => v.trim()).filter(Boolean);
+    const vNames = trimNames(nameArr);
     acc[name] = vNames;
-    acc.allNames = [...acc.allNames, ...vNames];
+    // TODO: this line different from Milo. Will raise a PR to Milo soon
+    acc.allNames = [...acc.allNames, ...trimNames(name.split(/[,&]/))];
     return acc;
   }, { allNames: [] });
 

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1445,7 +1445,7 @@ export function loadIms() {
       loadScript('https://auth.services.adobe.com/imslib/imslib.min.js');
     }
   }).then(() => {
-    if (!window.adobeIMS?.isSignedInUser() && !getMetadata('xlg-entitlements')) {
+    if (!window.adobeIMS?.isSignedInUser() && getMetadata('xlg-entitlements') !== 'on') {
       getConfig().entitlements([]);
     } else {
       setTimeout(async () => {

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2563,6 +2563,7 @@ export async function loadArea(area = document) {
   const main = area.querySelector('main');
   if (isDoc) {
     await checkForPageMods();
+    removeIrrelevantSections(main);
     if (getMetadata('template-search-page') === 'Y') {
       const { default: redirect } = await import('./template-redirect.js');
       await redirect();

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1454,6 +1454,8 @@ export function loadIms() {
         }
       }, 3000);
     }
+  }).catch(() => {
+    getConfig().entitlements([]);
   });
 
   return imsLoaded;


### PR DESCRIPTION
Run removeIrrelevantSections() after MEP, because one scenario would be it invokes replacePage replacing the whole main element. In summary, there are a few scenarios where we perform this, one in scripts.js where we want to find the correct LCP element, one after whole page replacement in FEP, and one for replacePage in MEP.
This PR also addresses one bug in MEP when entitlements are used with operators. A PR will go into Milo later.

Resolves: https://jira.corp.adobe.com/browse/MWPW-147091

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/experiments/mep-playground/entitled-home
- After: https://rm-secs-post-mep--express--adobecom.hlx.page/express/experiments/mep-playground/entitled-home
