### PR TITLE
[Milo Migration] [MEP] Change how Sections are Cleaned Up

### DIFF
--- a/express/scripts/martech.js
+++ b/express/scripts/martech.js
@@ -207,7 +207,7 @@ const loadMartechFiles = async (config, url, edgeConfigId) => {
       adobe: {
         launch: { url, controlPageLoad: true },
         alloy: { edgeConfigId },
-        target: false, // TODO: express uses checkTesting()
+        target: false,
         audienceManager: true, // FIXME: deprecate audienceManager
       },
       milo: true,

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1,6 +1,5 @@
 import {
   sampleRUM,
-  removeIrrelevantSections,
   loadArea,
   loadLana,
   getMetadata,

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -9,6 +9,7 @@ import {
   setConfig,
   createTag,
   getConfig,
+  decorateArea,
 } from './utils.js';
 
 const locales = {
@@ -53,6 +54,7 @@ const config = {
     onDemand: !jarvisImmediatelyVisible,
   },
   links: 'on',
+  decorateArea,
   imsClientId: 'AdobeExpressWeb',
   imsScope: 'AdobeID,openid,pps.read,firefly_api,additional_info.roles,read_organizations',
 };
@@ -90,9 +92,10 @@ const eagerLoad = (img) => {
   document.head.append(fqaMeta);
 }());
 
+decorateArea();
+
 (function loadLCPImage() {
   const main = document.body.querySelector('main');
-  removeIrrelevantSections(main);
   const firstDiv = main.querySelector('div:nth-child(1) > div');
   if (firstDiv?.classList.contains('marquee')) {
     firstDiv.querySelectorAll('img').forEach(eagerLoad);

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -568,9 +568,10 @@ export function yieldToMain() {
   });
 }
 
-export function removeIrrelevantSections(main) {
-  if (!main) return;
-  main.querySelectorAll(':scope > div').forEach((section) => {
+export function removeIrrelevantSections(area) {
+  if (!area) return;
+  const selector = area === document ? 'body > main > div' : ':scope > div';
+  area.querySelectorAll(selector).forEach((section) => {
     const sectionMetaBlock = section.querySelector('div.section-metadata');
     if (sectionMetaBlock) {
       const sectionMeta = readBlockConfig(sectionMetaBlock);
@@ -2237,6 +2238,10 @@ export function addHeaderSizing($block, classPrefix = 'heading', selector = 'h1,
       if (length >= size.threshold) h.classList.add(`${classPrefix}-${size.name}`);
     });
   });
+}
+
+export function decorateArea(area = document) {
+  removeIrrelevantSections(area);
 }
 
 /**

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1593,10 +1593,6 @@ export function decorateButtons(el = document) {
   });
 }
 
-export function checkTesting() {
-  return (getMetadata('testing').toLowerCase() === 'on');
-}
-
 /**
  * Sanitizes a string and turns it into camel case.
  * @param {*} name The unsanitized string
@@ -1754,11 +1750,6 @@ async function decorateTesting() {
       if (config && (toCamelCase(config.status) === 'active' || forcedExperiment)) {
         await loadAndRunExp(config, forcedExperiment, forcedVariant);
       }
-    }
-    const martech = usp.get('martech');
-    if ((checkTesting() && (martech !== 'off') && (martech !== 'delay')) || martech === 'rush') {
-      // eslint-disable-next-line no-console
-      console.log('rushing martech');
     }
   } catch (e) {
     // eslint-disable-next-line no-console

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -601,7 +601,7 @@ export function removeIrrelevantSections(area) {
     const linkToTarget = getMetadata(`${device}-floating-cta-link`)?.trim() || getMetadata('main-cta-link')?.trim();
     if (textToTarget || linkToTarget) {
       const linkToTargetURL = new URL(linkToTarget);
-      const sameUrlCTAs = Array.from(main.querySelectorAll('a:any-link'))
+      const sameUrlCTAs = Array.from(area.querySelectorAll('a:any-link'))
         .filter((a) => {
           try {
             const currURL = new URL(a.href);

--- a/tools/preview/preview.js
+++ b/tools/preview/preview.js
@@ -5,7 +5,6 @@ import {
   toClassName,
   getMetadata,
   getExperimentConfig,
-  checkTesting,
 } from '../../express/scripts/utils.js';
 
 /**
@@ -13,7 +12,7 @@ import {
  * @return {Object} returns a badge or empty string
  */
 function createTesting() {
-  if (checkTesting()) {
+  if (getMetadata('testing').toLowerCase() === 'on') {
     const div = document.createElement('div');
     div.className = 'hlx-testing hlx-badge';
     div.innerHTML = '<span title="This Page is part of an A/B Test run in Adobe Target">Testing On</span>';


### PR DESCRIPTION
Sync with the express-milo repo and refactor using Milo's decorateArea hook so that area decoration can automatically handle irrelevant (mobile/desktop) section removal.

This should have no visual/functional changes to all our live pages.

Resolves: https://jira.corp.adobe.com/browse/MWPW-155495

Pages that we should check that have not had a regression include:

- https://jingle--vic--express--adobecom.hlx.live/express/
- https://jingle--vic--express--adobecom.hlx.live/express/templates/
- https://jingle--vic--express--adobecom.hlx.live/express/create/flyer
- https://jingle--vic--express--adobecom.hlx.live/express/create/business

Fragment links that should continue functioning include:

- https://jingle--vic--express--adobecom.hlx.live/express/business#sales-contact-form-1
- https://jingle-vic--express--adobecom.hlx.page/express/learn/students#susi-light-1

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/
- After: https://jingle-vic--express--adobecom.hlx.page/express/
