### PR TITLE
[Mobile Web] Target Opt Out in Alloy

### DIFF
--- a/express/scripts/martech.js
+++ b/express/scripts/martech.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line object-curly-newline
-import { getConfig, getMetadata, loadIms, loadLink, loadScript } from './utils.js';
+import { getConfig, getMetadata, loadIms, loadLink, loadScript, getMobileOperatingSystem } from './utils.js';
 
 const ALLOY_SEND_EVENT = 'alloy_sendEvent';
 const ALLOY_SEND_EVENT_ERROR = 'alloy_sendEvent_error';
@@ -213,6 +213,13 @@ const loadMartechFiles = async (config, url, edgeConfigId) => {
       milo: true,
     };
     window.edgeConfigId = edgeConfigId;
+
+    // TODO: remove after aexg4848
+    if (getMetadata('target-only-mobile-web') === 'on'
+      && !(navigator.userAgent.includes('Mobile') && getMobileOperatingSystem() === 'Android' && navigator.deviceMemory >= 4)
+    ) {
+      setDeep(window, 'alloy_all.data.__adobe.target.mobile_web_enough_ram', false);
+    }
 
     const env = ['stage', 'local'].includes(config.env.name) ? '.qa' : '';
     // TODO: milo is hosting their own martech script in repo

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -9,7 +9,6 @@ import {
   createTag,
   getConfig,
   decorateArea,
-  getMobileOperatingSystem,
 } from './utils.js';
 
 const locales = {
@@ -90,12 +89,6 @@ const eagerLoad = (img) => {
     fqaMeta.setAttribute('name', 'fqa-on');
   }
   document.head.append(fqaMeta);
-  if (getMetadata('target-only-mobile-web') === 'on'
-    && getMetadata('target') === 'on'
-    && !(userAgent.includes('Mobile') && getMobileOperatingSystem() === 'Android' && navigator.deviceMemory >= 4)
-  ) {
-    document.head.querySelector('meta[name=target]').content = 'off';
-  }
 }());
 
 decorateArea();


### PR DESCRIPTION
Instead of metadata, we now would pass the message of target-no-enroll into alloy.

Resolves: https://jira.corp.adobe.com/browse/OPT-28184

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/jinglhua/target-mobile-web
- After: https://target-mobile-web-update--express--adobecom.hlx.page/drafts/jinglhua/target-mobile-web
