### PR TITLE
make dropzone wider to accommodate long text

### DIFF
--- a/express/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -58,7 +58,7 @@
     padding: 24px 0;
     border-radius: 20px;
     box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.3);
-    width: 600px;
+    width: 630px;
     height: 271px;
 }
 


### PR DESCRIPTION
Adds width to dropzone to allow space on either side of japanese text too wide for the container.

Resolves: [MWPW-154935](https://jira.corp.adobe.com/browse/MWPW-154935)

**Test URLs**:
- Before: https://www.adobe.com/jp/express/feature/image/remove-background
- After: https://remove-bg--express--adobecom.hlx.page/jp/express/feature/image/remove-background

==============================================================================

- Before: https://www.adobe.com/jp/express/feature/image/resize
- After: https://remove-bg--express--adobecom.hlx.page/jp/express/feature/image/resize

==============================================================================

- Before: https://www.adobe.com/jp/express/feature/image/convert/png-to-jpg
- After: https://remove-bg--express--adobecom.hlx.page/jp/express/feature/image/convert/png-to-jpg

==============================================================================

- Before: https://www.adobe.com/jp/express/feature/image/crop
- After: https://remove-bg--express--adobecom.hlx.page/jp/express/feature/image/crop