### PR TITLE
adds medium-header class to reduce size of flyer header via word doc variant

### DIFF
--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -278,6 +278,12 @@
     text-align: center;
   }
 
+  .fullscreen-marquee.medium-header .fullscreen-marquee-heading h1 {
+    font-size: 45px;
+    line-height: 90px;
+    text-align: center;
+  }
+
   .fullscreen-marquee .fullscreen-marquee-heading p {
     font-size: var(--body-font-size-l);
     line-height: 30px;


### PR DESCRIPTION
adds medium-header class to reduce size of flyer header via word doc variant

Resolves: MWPW-153062](https://jira.corp.adobe.com/browse/MWPW-153062)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/jp/express/create/flyer
- After: https://long-form-seo--express--adobecom.hlx.page/jp/express/create/flyer
**The variant class must be added to the word doc for this page to take affect i.e. fullscreen-marquee(.medium-header)**