### PR TITLE
Fix author layout in the quotes block

### DIFF
--- a/express/blocks/quotes/quotes.css
+++ b/express/blocks/quotes/quotes.css
@@ -34,7 +34,9 @@ main .quotes .quote .content::before {
   font-weight: 900;
 }
 
-main .quotes .quote .author { 
+main .quotes .quote .author {
+  display: flex;
+  flex-wrap: nowrap;
   margin-top: 16px;
   align-items: center;
   align-self: baseline;
@@ -85,7 +87,6 @@ main .section.quotes-inverted-container .quote {
   background-color: var(--color-black);
   color: var(--color-white);
 }
-
 
 main .section.quotes-container h2,
 main .section.quotes-container h3,


### PR DESCRIPTION
Describe your specific features or fixes

Resolves: https://jira.corp.adobe.com/browse/MWPW-154291

In the `quotes` block, the author layout should be as spec'ed.

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/create/flyer?lighthouse=on
- After: https://quotes-author--express--adobecom.hlx.page/express/create/flyer?lighthouse=on
