### PR TITLE
MWPW-156461 fix fragments

### DIFF
--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2546,7 +2546,7 @@ function fragmentBlocksToLinks(area) {
         const firstDiv = blk.querySelector('div');
         const textContent = firstDiv?.textContent?.trim();
         const fragURL = new URL(textContent, window.location.origin);
-        firstDiv.innerHTML = '';
+        firstDiv.textContent = '';
         fragLink = createTag('a', { href: fragURL.href });
       } catch (error) {
         blk.remove();

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2540,7 +2540,19 @@ async function decorateExpressPage(main) {
 
 function fragmentBlocksToLinks(area) {
   area.querySelectorAll('div.fragment').forEach((blk) => {
-    const fragLink = blk.querySelector('a');
+    let fragLink = blk.querySelector('a');
+    if (!fragLink) {
+      try {
+        const firstDiv = blk.querySelector('div');
+        const textContent = firstDiv?.textContent?.trim();
+        const fragURL = new URL(textContent, window.location.origin);
+        firstDiv.innerHTML = '';
+        fragLink = createTag('a', { href: fragURL.href });
+      } catch (error) {
+        blk.remove();
+        window.lana.log(`Failed creating a url from an old fragment block: ${error.message}`);
+      }
+    }
     if (fragLink) {
       blk.parentElement.replaceChild(fragLink, blk);
       fragLink.setAttribute('ax-old-fragment', 'on');


### PR DESCRIPTION
Fix app-banner loading on our create pages.
For a comprehensive list of pages see the task  

Resolves: [MWPW-156461](https://jira.corp.adobe.com/browse/MWPW-156461)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://MWPW-156461-fix-fragments--express--adobecom.hlx.page/express/

- Before: https://main--express--adobecom.hlx.page/express/create/advertisement/facebook
- After: https://MWPW-156461-fix-fragments--express--adobecom.hlx.page/express/create/advertisement/facebook


- Before: https://main--express--adobecom.hlx.page/kr/express/create/logo/circle
- After: https://MWPW-156461-fix-fragments--express--adobecom.hlx.page/kr/express/create/logo/circle