### PR TITLE
Search Marquee Text Centering.

### DIFF
--- a/express/blocks/search-marquee/search-marquee.css
+++ b/express/blocks/search-marquee/search-marquee.css
@@ -35,6 +35,8 @@ main .search-marquee > div:first-of-type h1 {
 main .search-marquee > div:first-of-type p {
     font-size: var(--body-font-size-m);
     max-width: 640px;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 main .search-marquee .search-marquee-bg {
@@ -251,3 +253,4 @@ main .search-marquee .hidden {
         max-height: 216px;
     }
 }
+


### PR DESCRIPTION
Describe your specific features or fixes

Hotfix for centering search marquee content. For longer titles + longer paragraphs the current CSS does not automatically center the text.

Resolves: https://jira.corp.adobe.com/browse/DOTCOM-131456

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://center-search-marquee--express--adobecom.hlx.page/it/express/templates

<img width="1785" alt="Screenshot 2024-08-12 at 10 53 07 AM" src="https://github.com/user-attachments/assets/fb4b5855-34ff-410e-8e4c-e7bd432aabc7">

