### PR TITLE
[Template Tracking Analytics] EventName Use Singular 

### DIFF
--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -975,7 +975,7 @@ async function initFilterSort(block, props, toolBar) {
             });
             trackSearch('search-inspire');
             await redrawTemplates(block, props, toolBar);
-            trackSearch('view-search-results', BlockMediator.get('templateSearchSpecs').search_id);
+            trackSearch('view-search-result', BlockMediator.get('templateSearchSpecs').search_id);
           }
         });
       });
@@ -1326,7 +1326,7 @@ async function decorateTemplates(block, props) {
     result_count: props.total,
     content_category: 'templates',
   });
-  if (searchId) trackSearch('view-search-results', searchId);
+  if (searchId) trackSearch('view-search-result', searchId);
 
   document.dispatchEvent(linksPopulated);
 }

--- a/express/scripts/template-search-api-v3.js
+++ b/express/scripts/template-search-api-v3.js
@@ -152,7 +152,7 @@ function cleanPayload(impression, eventType) {
     }
   }
 
-  if (eventType === 'view-search-results') {
+  if (eventType === 'view-search-result') {
     delete impression.content_id;
     delete impression.keyword_rank;
     delete impression.prefix_query;


### PR DESCRIPTION
Update event name view-search-results to view-search-result to match query in the backend. This should have no visual/functional impact on any pages.

Resolves: https://jira.corp.adobe.com/browse/MWPW-156514

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/templates/
- After: https://template-tracking-update--express--adobecom.hlx.page/express/templates/
