### PR TITLE
[Enhancement] Update Pricing Blocks Billing Toggle

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -324,6 +324,10 @@ End border style variants
   padding-left: 4px;
 }
 
+.pricing-cards .billing-button-wrapper {
+  display: flex;
+}
+
 .pricing-cards .pricing-section {
   width: 100%;
   display: flex;
@@ -382,13 +386,13 @@ End border style variants
   
 } 
 
-.pricing-cards .billing-toggle {
-  display: flex;
-  justify-content: center;
-  gap: 12px;
-  align-items: center;
-  font-size: var(--body-font-size-s);
-  margin-bottom: 12px;
+.pricing-cards .billing-toggle { 
+    gap: 12px; 
+    font-size: var(--body-font-size-s);
+    margin-bottom: 12px;
+    margin-right: auto;
+    display: flex;
+    flex-direction: column;
 }
 
 .pricing-cards .billing-toggle button {

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -426,7 +426,7 @@ async function decorateCard({
   yPricingSection.classList.add('annually', 'hide');
   const groupID = `${Date.now()}:${header.textContent.replace(/\s/g, '').trim()}`;
   const toggle = createToggle(placeholders, [mPricingSection, yPricingSection], groupID,
-    adjustElementPosition);
+    adjustElementPosition, header.innerText.includes("Teams"));
   card.append(toggle, mPricingSection, yPricingSection);
   decorateBasicTextSection(featureList, 'card-feature-list', card);
   decorateCompareSection(compare, el, card);

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -410,10 +410,10 @@ async function decorateCard({
   yCtaGroup,
   featureList,
   compare,
-}, el, placeholders, legacyVersion) {
+}, el, placeholders, legacyVersion, index) {
   const card = createTag('div', { class: 'card' });
   const cardBorder = createTag('div', { class: 'card-border' });
-  const isTeams = header.innerText.includes('(');
+  const isTeams = header.innerText.includes('(') || index === 2;
   const { specialPromo, cardWrapper } = legacyVersion
     ? decorateLegacyHeader(header, card)
     : decorateHeader(header, borderParams, card, cardBorder);
@@ -463,7 +463,7 @@ export default async function init(el) {
   const cardsContainer = createTag('div', { class: 'cards-container' });
   const placeholders = await fetchPlaceholders();
   const decoratedCards = await Promise.all(
-    cards.map((card) => decorateCard(card, el, placeholders, legacyVersion)),
+    cards.map((card, index) => decorateCard(card, el, placeholders, legacyVersion, index)),
   );
   decoratedCards.forEach((card) => cardsContainer.append(card));
 

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -413,7 +413,7 @@ async function decorateCard({
 }, el, placeholders, legacyVersion) {
   const card = createTag('div', { class: 'card' });
   const cardBorder = createTag('div', { class: 'card-border' });
-  const isTeams = header.innerText.includes("(")
+  const isTeams = header.innerText.includes('(');
   const { specialPromo, cardWrapper } = legacyVersion
     ? decorateLegacyHeader(header, card)
     : decorateHeader(header, borderParams, card, cardBorder);

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -413,6 +413,7 @@ async function decorateCard({
 }, el, placeholders, legacyVersion) {
   const card = createTag('div', { class: 'card' });
   const cardBorder = createTag('div', { class: 'card-border' });
+  const isTeams = header.innerText.includes("(")
   const { specialPromo, cardWrapper } = legacyVersion
     ? decorateLegacyHeader(header, card)
     : decorateHeader(header, borderParams, card, cardBorder);
@@ -426,7 +427,7 @@ async function decorateCard({
   yPricingSection.classList.add('annually', 'hide');
   const groupID = `${Date.now()}:${header.textContent.replace(/\s/g, '').trim()}`;
   const toggle = createToggle(placeholders, [mPricingSection, yPricingSection], groupID,
-    adjustElementPosition, header.innerText.includes("Teams"));
+    adjustElementPosition, isTeams);
   card.append(toggle, mPricingSection, yPricingSection);
   decorateBasicTextSection(featureList, 'card-feature-list', card);
   decorateCompareSection(compare, el, card);

--- a/express/blocks/pricing-cards/pricing-toggle.js
+++ b/express/blocks/pricing-cards/pricing-toggle.js
@@ -88,7 +88,7 @@ export function tagFreePlan(cardContainer) {
 }
 
 export default function createToggle(
-  placeholders, pricingSections, groupID, adjElemPos, isTeams
+  placeholders, pricingSections, groupID, adjElemPos, isTeams,
 ) {
   const subDesc = placeholders?.['subscription-type'] || 'Subscription Type:';
   const toggleWrapper = createTag('div', { class: 'billing-toggle' });
@@ -97,7 +97,8 @@ export default function createToggle(
   toggleWrapper.setAttribute('aria-labelledby', groupID);
   const groupLabel = toggleWrapper.children[0];
   groupLabel.setAttribute('id', groupID);
-  const buttons = PLANS.map((plan, i) => {
+  const buttons = PLANS.map((base_plan, i) => {
+    let plan = base_plan;
     const buttonID = `${groupID}:${plan}`;
     const defaultChecked = i === 0;
     const button = createTag('button', {
@@ -109,10 +110,10 @@ export default function createToggle(
     button.appendChild(createTag('span'));
     button.setAttribute('aria-checked', defaultChecked);
     button.setAttribute('aria-labeledby', buttonID);
-    if (isTeams && plan === "monthly") {
-      plan = "annual-billed-monthly"
+    if (isTeams && plan === 'monthly') {
+      plan = 'annual-billed-monthly';
     }
-    const label = placeholders?.[plan] || "Annual, Billed Monthly"
+    const label = placeholders?.[plan] || 'Annual, Billed Monthly';
     button.append(createTag('div', { id: `${buttonID}:radio` }, label));
     button.setAttribute('role', 'radio');
     button.addEventListener('click', () => {
@@ -125,7 +126,8 @@ export default function createToggle(
   toggleWrapper.addEventListener('keydown', (e) => {
     onKeyDown(e, pricingSections, buttons, toggleWrapper);
   });
-
-  toggleWrapper.append(...buttons);
+  const buttonWrapper = createTag('div', {class : 'billing-button-wrapper'})
+  buttonWrapper.append(...buttons)
+  toggleWrapper.append(buttonWrapper);
   return toggleWrapper;
 }

--- a/express/blocks/pricing-cards/pricing-toggle.js
+++ b/express/blocks/pricing-cards/pricing-toggle.js
@@ -110,7 +110,7 @@ export default function createToggle(
     button.setAttribute('aria-checked', defaultChecked);
     button.setAttribute('aria-labeledby', buttonID);
     if (isTeams && plan === "monthly") {
-      plan = "annual_billed_monthly"
+      plan = "annual-billed-monthly"
     }
     const label = placeholders?.[plan]
     button.append(createTag('div', { id: `${buttonID}:radio` }, label));

--- a/express/blocks/pricing-cards/pricing-toggle.js
+++ b/express/blocks/pricing-cards/pricing-toggle.js
@@ -97,8 +97,8 @@ export default function createToggle(
   toggleWrapper.setAttribute('aria-labelledby', groupID);
   const groupLabel = toggleWrapper.children[0];
   groupLabel.setAttribute('id', groupID);
-  const buttons = PLANS.map((base_plan, i) => {
-    let plan = base_plan;
+  const buttons = PLANS.map((basePlan, i) => {
+    let plan = basePlan;
     const buttonID = `${groupID}:${plan}`;
     const defaultChecked = i === 0;
     const button = createTag('button', {
@@ -126,8 +126,8 @@ export default function createToggle(
   toggleWrapper.addEventListener('keydown', (e) => {
     onKeyDown(e, pricingSections, buttons, toggleWrapper);
   });
-  const buttonWrapper = createTag('div', {class : 'billing-button-wrapper'})
-  buttonWrapper.append(...buttons)
+  const buttonWrapper = createTag('div', { class: 'billing-button-wrapper' });
+  buttonWrapper.append(...buttons);
   toggleWrapper.append(buttonWrapper);
   return toggleWrapper;
 }

--- a/express/blocks/pricing-cards/pricing-toggle.js
+++ b/express/blocks/pricing-cards/pricing-toggle.js
@@ -112,7 +112,7 @@ export default function createToggle(
     if (isTeams && plan === "monthly") {
       plan = "annual-billed-monthly"
     }
-    const label = placeholders?.[plan]
+    const label = placeholders?.[plan] || "Annual, Billed Monthly"
     button.append(createTag('div', { id: `${buttonID}:radio` }, label));
     button.setAttribute('role', 'radio');
     button.addEventListener('click', () => {

--- a/express/blocks/pricing-cards/pricing-toggle.js
+++ b/express/blocks/pricing-cards/pricing-toggle.js
@@ -88,7 +88,7 @@ export function tagFreePlan(cardContainer) {
 }
 
 export default function createToggle(
-  placeholders, pricingSections, groupID, adjElemPos,
+  placeholders, pricingSections, groupID, adjElemPos, isTeams
 ) {
   const subDesc = placeholders?.['subscription-type'] || 'Subscription Type:';
   const toggleWrapper = createTag('div', { class: 'billing-toggle' });
@@ -109,7 +109,10 @@ export default function createToggle(
     button.appendChild(createTag('span'));
     button.setAttribute('aria-checked', defaultChecked);
     button.setAttribute('aria-labeledby', buttonID);
-    const label = placeholders?.[plan] || plan[0].toUpperCase() + plan.slice(1).toLowerCase();
+    if (isTeams && plan === "monthly") {
+      plan = "annual_billed_monthly"
+    }
+    const label = placeholders?.[plan]
     button.append(createTag('div', { id: `${buttonID}:radio` }, label));
     button.setAttribute('role', 'radio');
     button.addEventListener('click', () => {


### PR DESCRIPTION
Describe your specific features or fixes

For Teams plans, the user is locked in for a year but the plan is paid for in monthly installments. This must be made clear when the user is looking through the pricing cards billing toggle. This change detects whether a plan is a Teams plan by looking at whether a multiple headcount parenthesis is included or not. 

This change will require authoring to all placeholder sheets but will not require changes to the document itself.

<img width="815" alt="Screenshot 2024-08-13 at 10 26 25 AM" src="https://github.com/user-attachments/assets/af72a6ed-3676-40a9-8748-9505dfee2e45">

<img width="1126" alt="Screenshot 2024-08-13 at 10 26 21 AM" src="https://github.com/user-attachments/assets/182bf6a2-fabe-45c9-ba28-e8d4179ff7e7">




Resolves: https://jira.corp.adobe.com/projects/MWPW/issues/MWPW-156088

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://additional-billing-toggle--express--adobecom.hlx.page/express/pricing
