### PR TITLE
allow bgColor for quotes block

### DIFF
--- a/express/blocks/quotes/quotes.js
+++ b/express/blocks/quotes/quotes.js
@@ -1,9 +1,15 @@
 // eslint-disable-next-line import/no-unresolved
 import { addTempWrapper } from '../../scripts/decorate.js';
-import { createTag } from '../../scripts/utils.js';
+import { createTag, getMetadata } from '../../scripts/utils.js';
 
 export default function decorate($block) {
   addTempWrapper($block, 'quotes');
+
+  const sectionContainer = $block.closest('.section.section-wrapper.quotes-container');
+  const quotesBgColor = getMetadata('quotes-background-color');
+  if (quotesBgColor) {
+    sectionContainer.style.background = quotesBgColor;
+  }
 
   $block.querySelectorAll(':scope>div').forEach(($card) => {
     $card.classList.add('quote');


### PR DESCRIPTION
Allow Authors to Change Background Color of Quotes Block

Resolves: [MWPW-154774](https://jira.corp.adobe.com/browse/MWPW-154774)

Test URLs:
- Before: https://main--express--adobecom.hlx.page/in/express/business
<img width="1590" alt="before" src="https://github.com/user-attachments/assets/7074e3e2-44d5-4fdb-95eb-26c818af1fe5">

- After: https://bgcolor-quotes-business--express--adobecom.hlx.page/in/express/business

<img width="631" alt="quotes-background-color" src="https://github.com/user-attachments/assets/0fc8911f-019a-469e-8594-d47d8d9e6b30">
<img width="1654" alt="bg" src="https://github.com/user-attachments/assets/1005082c-0353-4e1e-bcc1-ace09c89fd39">

