### PR TITLE
increase height so border not cut off

### DIFF
--- a/express/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -59,7 +59,7 @@
     border-radius: 20px;
     box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.3);
     width: 630px;
-    height: 271px;
+    height: 284px;
 }
 
 .frictionless-quick-action.block .dropzone-bg {


### PR DESCRIPTION
Fix top and bottom of dotted dropzone border being cut off

Resolves: https://jira.corp.adobe.com/browse/MWPW-154935

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/jp/express/feature/image/remove-background
- <img width="1439" alt="before" src="https://github.com/user-attachments/assets/18b73728-9a6c-4786-bd57-dea5fbf4f63d">

- After: https://feature-page-block--express--adobecom.hlx.page/jp/express/feature/image/remove-background
<img width="1481" alt="after" src="https://github.com/user-attachments/assets/345e1aa4-a811-4b5b-b1b4-bb15ffb69e01">