### PR TITLE
[Template-X] Add Support for New Asset Type Webpage_Template

### DIFF
--- a/express/blocks/template-x/sample-template.json
+++ b/express/blocks/template-x/sample-template.json
@@ -1,0 +1,165 @@
+{
+            "id": "urn:aaid:sc:VA6C2:74f8db2e-e6b0-5c4d-acc0-b769b373ed54",
+            "parentDirectoryId": "urn:aaid:sc:VA6C2:9a95c444-ed0d-42fb-bfbb-2cb624fbbec6",
+            "ancestorAssetIds": [
+                "urn:aaid:directory:b5accaca-1f2d-4311-aa12-e9c537a8fad8",
+                "urn:aaid:directory:61acb9e9-a107-48e0-9e73-80c8031ede18",
+                "urn:aaid:sc:VA6C2:74c05c10-0945-5dd6-9c3d-22851a3d1903",
+                "urn:aaid:sc:VA6C2:b2b850c0-cab8-48be-89db-78909574db16",
+                "urn:aaid:sc:VA6C2:0fabaa0d-a1f7-4cbd-b603-89c6dc35a48a",
+                "urn:aaid:sc:VA6C2:74c60171-633c-4451-867e-d49e5f4e5884",
+                "urn:aaid:sc:VA6C2:1bb25287-eae8-476e-8dab-5c191e525e61",
+                "urn:aaid:sc:VA6C2:9a95c444-ed0d-42fb-bfbb-2cb624fbbec6"
+            ],
+            "path": "/content/assets/content/approved/ccx/template/ccx_content_partnerships/bdf81e9e-acc4-5351-bff9-4de5d0a95e27",
+            "contentType": "application/vnd.adobe.hz.express+dcx",
+            "createDate": "2024-06-28T19:32:56.868Z",
+            "modifyDate": "2024-06-28T19:32:57.193Z",
+            "name": "bdf81e9e-acc4-5351-bff9-4de5d0a95e27",
+            "status": "approved",
+            "dc:title": {
+                "i-default": "Pink Floral Workshop Flyer for Print by Huyen Dihn"
+            },
+            "etags": "\"51bef6458d7942178d8a22e015341e66\"",
+            "assetType": "Template",
+            "behaviors": [
+                "still"
+            ],
+            "topics": [
+                "artist",
+                "floral",
+                "flower",
+                "huyen dinh",
+                "huyendinh",
+                "print artist",
+                "workshop"
+            ],
+            "availabilityDate": "2024-07-10T02:42:50.175Z",
+            "licensingCategory": "free",
+            "language": "en-US",
+            "applicableRegions": [
+                "ZZ"
+            ],
+            "attribution": {
+                "vendor": "Adobe Express",
+                "submittedBy": "2BCD1E4C6619FCEC0A495FDD@c0b827b66271908b495fe8.e"
+            },
+            "pages": [
+                {
+                    "task": {
+                        "name": "flyer",
+                        "size": {
+                            "name": "letter"
+                        }
+                    },
+                    "extractedColors": [
+                        {
+                            "name": "dark gray",
+                            "coverage": 0.0619,
+                            "mode": "RGB",
+                            "value": {
+                                "r": 88,
+                                "g": 89,
+                                "b": 89
+                            }
+                        },
+                        {
+                            "name": "pink",
+                            "coverage": 0.8015,
+                            "mode": "RGB",
+                            "value": {
+                                "r": 251,
+                                "g": 225,
+                                "b": 235
+                            }
+                        },
+                        {
+                            "name": "white",
+                            "coverage": 0.0485,
+                            "mode": "RGB",
+                            "value": {
+                                "r": 251,
+                                "g": 238,
+                                "b": 246
+                            }
+                        },
+                        {
+                            "name": "lilac",
+                            "coverage": 0.0663,
+                            "mode": "RGB",
+                            "value": {
+                                "r": 235,
+                                "g": 194,
+                                "b": 233
+                            }
+                        },
+                        {
+                            "name": "gray",
+                            "coverage": 0.0219,
+                            "mode": "RGB",
+                            "value": {
+                                "r": 144,
+                                "g": 137,
+                                "b": 142
+                            }
+                        }
+                    ],
+                    "rendition": {
+                        "image": {
+                            "thumbnail": {
+                                "componentId": "fcb8f005-cd35-4826-94e5-c5faee5d54b3",
+                                "hzRevision": "19df1eea-9969-40d7-aa17-acfcb3ac5707",
+                                "width": 386,
+                                "height": 500,
+                                "mediaType": "image/webp"
+                            },
+                            "preview": {
+                                "componentId": "0d036589-3a8e-4df0-8b0c-890cc3b1cce5",
+                                "hzRevision": "f2ad33b7-1b4b-4879-b0ce-c41cf9eb6c88",
+                                "width": 927,
+                                "height": 1200,
+                                "mediaType": "image/webp"
+                            }
+                        }
+                    }
+                }
+            ],
+            "customLinks": {
+                "branchUrl": "https://adobesparkpost.app.link/uHF8ZOZG6Kb"
+            },
+            "stats": {
+                "remixCount": 65
+            },
+            "styles": [
+                "pop-art"
+            ],
+            "segments": [
+                "personal"
+            ],
+            "_links": {
+                "http://ns.adobe.com/adobecloud/rel/rendition": {
+                    "href": "https://design-assets.adobeprojectm.com/content/download/express/public/urn:aaid:sc:VA6C2:74f8db2e-e6b0-5c4d-acc0-b769b373ed54/rendition?assetType=TEMPLATE&etag=51bef6458d7942178d8a22e015341e66{&page,size,type,fragment}",
+                    "templated": true,
+                    "mode": "id",
+                    "name": "ACP"
+                },
+                "http://ns.adobe.com/adobecloud/rel/primary": {
+                    "href": "https://design-assets.adobeprojectm.com/content/download/express/public/urn:aaid:sc:VA6C2:74f8db2e-e6b0-5c4d-acc0-b769b373ed54/primary?assetType=TEMPLATE&etag=51bef6458d7942178d8a22e015341e66",
+                    "templated": false,
+                    "mode": "id",
+                    "name": "ACP"
+                },
+                "http://ns.adobe.com/adobecloud/rel/manifest": {
+                    "href": "https://design-assets.adobeprojectm.com/content/download/express/public/urn:aaid:sc:VA6C2:74f8db2e-e6b0-5c4d-acc0-b769b373ed54/manifest?assetType=TEMPLATE&etag=51bef6458d7942178d8a22e015341e66",
+                    "templated": false,
+                    "mode": "id",
+                    "name": "ACP"
+                },
+                "http://ns.adobe.com/adobecloud/rel/component": {
+                    "href": "https://design-assets.adobeprojectm.com/content/download/express/public/urn:aaid:sc:VA6C2:74f8db2e-e6b0-5c4d-acc0-b769b373ed54/component?assetType=TEMPLATE&etag=51bef6458d7942178d8a22e015341e66{&revision,component_id}",
+                    "templated": true,
+                    "mode": "id",
+                    "name": "ACP"
+                }
+            }
+        }

--- a/express/blocks/template-x/sample-webpage-template.json
+++ b/express/blocks/template-x/sample-webpage-template.json
@@ -1,0 +1,146 @@
+{
+    "id": "urn:aaid:sc:VA6C2:cd210180-70f1-5193-aca7-84eeb8a1bdd3",
+    "parentDirectoryId": "urn:aaid:sc:VA6C2:201252df-82cd-4397-90bd-87d18579b3fb",
+    "ancestorAssetIds": [
+        "urn:aaid:directory:b5accaca-1f2d-4311-aa12-e9c537a8fad8",
+        "urn:aaid:directory:61acb9e9-a107-48e0-9e73-80c8031ede18",
+        "urn:aaid:sc:VA6C2:74c05c10-0945-5dd6-9c3d-22851a3d1903",
+        "urn:aaid:sc:VA6C2:b2b850c0-cab8-48be-89db-78909574db16",
+        "urn:aaid:sc:VA6C2:0fabaa0d-a1f7-4cbd-b603-89c6dc35a48a",
+        "urn:aaid:sc:VA6C2:74c60171-633c-4451-867e-d49e5f4e5884",
+        "urn:aaid:sc:VA6C2:9c5613dc-9f25-4aa9-87fa-db80e6123fd6",
+        "urn:aaid:sc:VA6C2:201252df-82cd-4397-90bd-87d18579b3fb"
+    ],
+    "path": "/content/assets/content/approved/ccx/webpage_template/ccx_content/extracurricular_activities",
+    "contentType": "application/vnd.adobe.hztemp.page+dcx",
+    "createDate": "2024-07-24T19:03:44.830Z",
+    "modifyDate": "2024-07-24T19:03:45.114Z",
+    "name": "extracurricular_activities",
+    "status": "approved",
+    "dc:title": {
+        "i-default": "Extracurricular activities"
+    },
+    "dc:description": {
+        "en-US": "Bright colors and clear fonts get webpages made with this template noticed. Change text, add your own images or video, and get exactly the look you want. Use this fun, informal template to promote a wide variety of events from school outings to parties."
+    },
+    "etags": "\"23b75d99a3554908ae1f8baf96be58b2\"",
+    "assetType": "Webpage_Template",
+    "task": {
+        "name": "event-microsite",
+        "size": {
+            "name": "500x500px"
+        }
+    },
+    "features": [
+        "restricted"
+    ],
+    "behaviors": [
+        "still"
+    ],
+    "topics": [
+        "education",
+        "education resource",
+        "educator resource",
+        "event",
+        "extracurricular",
+        "landing",
+        "rsvp",
+        "scholastic event",
+        "student activity",
+        "website"
+    ],
+    "availabilityDate": "2024-08-09T02:16:31.760Z",
+    "licensingCategory": "free",
+    "language": "en-US",
+    "applicableRegions": [
+        "ZZ"
+    ],
+    "extractedColors": [
+        {
+            "name": "light blue",
+            "coverage": 0.4445,
+            "mode": "RGB",
+            "value": {
+                "r": 131,
+                "g": 181,
+                "b": 213
+            }
+        },
+        {
+            "name": "off white",
+            "coverage": 0.198,
+            "mode": "RGB",
+            "value": {
+                "r": 231,
+                "g": 231,
+                "b": 231
+            }
+        },
+        {
+            "name": "royal blue",
+            "coverage": 0.1482,
+            "mode": "RGB",
+            "value": {
+                "r": 24,
+                "g": 76,
+                "b": 149
+            }
+        },
+        {
+            "name": "dark blue",
+            "coverage": 0.1529,
+            "mode": "RGB",
+            "value": {
+                "r": 17,
+                "g": 37,
+                "b": 85
+            }
+        },
+        {
+            "name": "black",
+            "coverage": 0.0564,
+            "mode": "RGB",
+            "value": {
+                "r": 2,
+                "g": 2,
+                "b": 5
+            }
+        }
+    ],
+    "attribution": {
+        "vendor": "Adobe Express",
+        "submittedBy": "61D11F476369A4AC0A495FBE@c0b827b66271908b495fe8.e"
+    },
+    "customLinks": {
+        "branchUrl": "https://adobesparkpost.app.link/Q3DIFvesULb"
+    },
+    "segments": [
+        "all"
+    ],
+    "_links": {
+        "http://ns.adobe.com/adobecloud/rel/rendition": {
+            "href": "https://design-assets.adobeprojectm.com/content/download/express/public/urn:aaid:sc:VA6C2:cd210180-70f1-5193-aca7-84eeb8a1bdd3/rendition?assetType=WEBPAGE_TEMPLATE&etag=23b75d99a3554908ae1f8baf96be58b2{&page,size,type,fragment}",
+            "templated": true,
+            "mode": "id",
+            "name": "ACP"
+        },
+        "http://ns.adobe.com/adobecloud/rel/primary": {
+            "href": "https://design-assets.adobeprojectm.com/content/download/express/public/urn:aaid:sc:VA6C2:cd210180-70f1-5193-aca7-84eeb8a1bdd3/primary?assetType=WEBPAGE_TEMPLATE&etag=23b75d99a3554908ae1f8baf96be58b2",
+            "templated": false,
+            "mode": "id",
+            "name": "ACP"
+        },
+        "http://ns.adobe.com/adobecloud/rel/manifest": {
+            "href": "https://design-assets.adobeprojectm.com/content/download/express/public/urn:aaid:sc:VA6C2:cd210180-70f1-5193-aca7-84eeb8a1bdd3/manifest?assetType=WEBPAGE_TEMPLATE&etag=23b75d99a3554908ae1f8baf96be58b2",
+            "templated": false,
+            "mode": "id",
+            "name": "ACP"
+        },
+        "http://ns.adobe.com/adobecloud/rel/component": {
+            "href": "https://design-assets.adobeprojectm.com/content/download/express/public/urn:aaid:sc:VA6C2:cd210180-70f1-5193-aca7-84eeb8a1bdd3/component?assetType=WEBPAGE_TEMPLATE&etag=23b75d99a3554908ae1f8baf96be58b2{&revision,component_id}",
+            "templated": true,
+            "mode": "id",
+            "name": "ACP"
+        }
+    }
+}

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -36,11 +36,15 @@ function extractComponentLinkHref(template) {
 }
 
 function extractImageThumbnail(page) {
-  return page.rendition.image?.thumbnail;
+  return page?.rendition?.image?.thumbnail;
 }
 
 function getImageThumbnailSrc(renditionLinkHref, componentLinkHref, page) {
   const thumbnail = extractImageThumbnail(page);
+  if (!thumbnail) {
+    // webpages
+    return renditionLinkHref.replace('{&page,size,type,fragment}', '');
+  }
   const {
     mediaType,
     componentId,
@@ -453,6 +457,10 @@ function renderStillWrapper(template, placeholders) {
 
 export default function renderTemplate(template, placeholders) {
   const tmpltEl = createTag('div');
+  if (template.assetType === 'Webpage_Template') {
+    // webpage_template has no pages
+    template.pages = [{}];
+  }
   tmpltEl.append(renderStillWrapper(template, placeholders));
   tmpltEl.append(renderHoverWrapper(template, placeholders));
 

--- a/express/scripts/template-search-api-v3.js
+++ b/express/scripts/template-search-api-v3.js
@@ -363,7 +363,7 @@ function isValidBehaviors(behaviors) {
 export function isValidTemplate(template) {
   return !!(template.status === 'approved'
     && template.customLinks?.branchUrl
-    && template.pages?.[0]?.rendition?.image?.thumbnail?.componentId
+    && (template.assetType === 'Webpage_Template' || template.pages?.[0]?.rendition?.image?.thumbnail?.componentId)
     && template._links?.['http://ns.adobe.com/adobecloud/rel/rendition']?.href?.replace
     && template._links?.['http://ns.adobe.com/adobecloud/rel/component']?.href?.replace
     && isValidBehaviors(template.behaviors));


### PR DESCRIPTION
Extend the current huge block to support a new asset type Webpage_Template. These results will not have pages and things like componentId, and need to be decorated differently.

Resolves: https://jira.corp.adobe.com/browse/MWPW-156610

You should see that templates not getting displayed on stage, due to those templates being considered "invalid." They should be showing up in the branch link.

This is to support new set of pages and should bring no changes to any pages we have right now.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/yge/en/creates/online-journal?martech=off
- After: https://template-webpage--express--adobecom.hlx.page/drafts/yge/en/creates/online-journal?martech=off
