### PR TITLE
added modal support for susi-teacher

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -139,6 +139,17 @@ const listenAlloy = () => {
   }, 3000);
 };
 
+function registerSUSIModalLinks() {
+  const container = createTag('div', {}, `
+    <div>
+      <a href='https://www.adobe.com/express/fragments/susi-light-teacher#susi-light-1' rel: 'nofollow'></a>
+    </div>`);
+  container.style = 'display:none;position:absolute';
+  const main = document.querySelector('main');
+  const lastDiv = main.querySelector(':scope > div:last-of-type');
+  lastDiv.childElementCount === 0 ? main.insertBefore(container, lastDiv) : main.append(container);
+}
+
 (async function loadPage() {
   if (window.hlx.init || window.isTestEnv) return;
   window.hlx = window.hlx || {};
@@ -161,6 +172,7 @@ const listenAlloy = () => {
   loadExpressMartechSettings();
   loadLana({ clientId: 'express' });
   listenAlloy();
+  registerSUSIModalLinks(); // TODO: remove post bts
   await loadArea();
 
   import('./express-delayed.js').then((mod) => {


### PR DESCRIPTION
Temporarily support any pages with a hash `#susi-light1` to load up the susi-light-teacher modal. This should be able to be removed after all Back to School campaign is over.

Resolves: https://jira.corp.adobe.com/browse/MWPW-155427

Add `#susi-light-1` to any pages and you should see the modal popping up. Landing on a page directly with the hash should also open up the modal. Request reason: visitors will be able to use gnav (purple Sign In button) to append that hash to the end wherever they are on the site.
![SC 2024-08-19 at 5 14 37 PM](https://github.com/user-attachments/assets/de345a39-0e66-4fc0-9f92-bbe400b5819b)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/#susi-light-1?martech=off
- After: https://susi-teacher-everywhere--express--adobecom.hlx.page/express/#susi-light-1?martech=off
