### PR TITLE
Sitemap Rebuild Workflow

### DIFF
--- a/.github/workflows/rebuild-sitemap.yml
+++ b/.github/workflows/rebuild-sitemap.yml
@@ -1,0 +1,25 @@
+name: Run JavaScript Script
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'fstab.yaml'
+      - 'helix-query.yaml'
+      - 'helix-sitemap.yaml'
+  push:
+  workflow_dispatch:
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18.x'
+    - name: Install dependencies
+      run: npm ci
+    - name: Run script
+      run: node ./test/helpers/sitemap.js

--- a/.github/workflows/rebuild-sitemap.yml
+++ b/.github/workflows/rebuild-sitemap.yml
@@ -2,7 +2,7 @@ name: Run Sitemap Rebuild
 
 on:
   pull_request:
-    branches: [ main, stage ]
+    branches: [ main ]
     paths:
       - 'fstab.yaml'
       - 'helix-query.yaml'

--- a/.github/workflows/rebuild-sitemap.yml
+++ b/.github/workflows/rebuild-sitemap.yml
@@ -23,6 +23,6 @@ jobs:
       run: npm ci
     - name: Create .env file
       run: |
-        echo "API_KEY=${{ secrets.API_KEY }}" > .env
+        echo "API_KEY=${{ secrets.HELIX_API_KEY }}" > .env
     - name: Run script
       run: node ./test/helpers/sitemap.js

--- a/.github/workflows/rebuild-sitemap.yml
+++ b/.github/workflows/rebuild-sitemap.yml
@@ -20,8 +20,18 @@ jobs:
     - name: Install secondary dependencies
       run: npm install node-fetch@2 dotenv
     - name: Install main dependencies
-      run: npm ci
-    - name: Run script
-      env:
-        HELIX_API_KEY: ${{ secrets.HELIX_API_KEY }}
-      run: node ./test/helpers/sitemap.js
+      run: npm ci 
+    - uses: actions/checkout@v3
+    - name: Import Secrets
+      uses: hashicorp/vault-action@v2
+      with:
+        url: https://vault-amer.adobe.net
+        tlsSkipVerify: false
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        secrets: |
+            cloudtech_wcms/data/express_dev HELIX_API_KEY
+    - name: Run sitemap script
+      run: |
+          node ./test/helpers/sitemap.js

--- a/.github/workflows/rebuild-sitemap.yml
+++ b/.github/workflows/rebuild-sitemap.yml
@@ -21,5 +21,8 @@ jobs:
         node-version: '18.x'
     - name: Install dependencies
       run: npm ci
+    - name: Create .env file
+      run: |
+        echo "API_KEY=${{ secrets.API_KEY }}" > .env
     - name: Run script
       run: node ./test/helpers/sitemap.js

--- a/.github/workflows/rebuild-sitemap.yml
+++ b/.github/workflows/rebuild-sitemap.yml
@@ -9,7 +9,7 @@ on:
       - 'helix-sitemap.yaml'
 
 jobs:
-  run-script:
+  run-sitemap-script:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rebuild-sitemap.yml
+++ b/.github/workflows/rebuild-sitemap.yml
@@ -1,14 +1,12 @@
-name: Run JavaScript Script
+name: Run Sitemap Rebuild
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, stage ]
     paths:
       - 'fstab.yaml'
       - 'helix-query.yaml'
       - 'helix-sitemap.yaml'
-  push:
-  workflow_dispatch:
 
 jobs:
   run-script:

--- a/.github/workflows/rebuild-sitemap.yml
+++ b/.github/workflows/rebuild-sitemap.yml
@@ -17,10 +17,11 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: '18.x'
-    - name: Install dependencies
+    - name: Install secondary dependencies
+      run: npm install node-fetch@2 dotenv
+    - name: Install main dependencies
       run: npm ci
-    - name: Create .env file
-      run: |
-        echo "API_KEY=${{ secrets.HELIX_API_KEY }}" > .env
     - name: Run script
+      env:
+        HELIX_API_KEY: ${{ secrets.HELIX_API_KEY }}
       run: node ./test/helpers/sitemap.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@adobe/express-website",
       "version": "1.0.0",
       "license": "Apache License 2.0",
+      "dependencies": {
+        "node-fetch": "^3.3.2"
+      },
       "devDependencies": {
         "@adobe/eslint-config-helix": "1.1.3",
         "@babel/core": "7.24.7",
@@ -4419,6 +4422,14 @@
         "node": ">=14"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
@@ -5429,6 +5440,28 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -5668,6 +5701,17 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fraction.js": {
@@ -8078,38 +8122,39 @@
         "type-detect": "4.0.8"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": ">=10.5.0"
       }
     },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "dev": true
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-      "dev": true
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dev": true,
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-releases": {
@@ -9360,6 +9405,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/puppeteer/node_modules/node-fetch": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
     "node_modules/puppeteer/node_modules/p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -9415,6 +9472,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/puppeteer/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
+    "node_modules/puppeteer/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/puppeteer/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/puppeteer/node_modules/ws": {
@@ -11290,6 +11369,14 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -14858,6 +14945,11 @@
         "rrweb-cssom": "^0.6.0"
       }
     },
+    "data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
+    },
     "data-urls": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
@@ -15644,6 +15736,15 @@
         "pend": "~1.2.0"
       }
     },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -15830,6 +15931,14 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
+      }
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
       }
     },
     "fraction.js": {
@@ -17656,37 +17765,19 @@
         }
       }
     },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+    },
     "node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
-      "dev": true,
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "requires": {
-        "whatwg-url": "^5.0.0"
-      },
-      "dependencies": {
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-          "dev": true
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-          "dev": true
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-          "dev": true,
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
-        }
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       }
     },
     "node-releases": {
@@ -18509,6 +18600,15 @@
             "p-locate": "^4.1.0"
           }
         },
+        "node-fetch": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+          "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
         "p-limit": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -18546,6 +18646,28 @@
           "dev": true,
           "requires": {
             "find-up": "^4.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
           }
         },
         "ws": {
@@ -19996,6 +20118,11 @@
       "requires": {
         "xml-name-validator": "^4.0.0"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="
     },
     "webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
     "shelljs": "0.8.4",
     "sinon": "^15.1.0",
     "uglify-js": "^3.17.4"
+  },
+  "dependencies": {
+    "node-fetch": "^3.3.2"
   }
 }

--- a/test/helpers/sitemap.js
+++ b/test/helpers/sitemap.js
@@ -1,0 +1,1 @@
+console.log('abc')

--- a/test/helpers/sitemap.js
+++ b/test/helpers/sitemap.js
@@ -1,34 +1,46 @@
-import fs from "fs"
-import fetch from "node-fetch"
-import dotenv from "dotenv"
-dotenv.config() 
+const fetch = require("node-fetch");
+const dotenv = require("dotenv");
 
+dotenv.config();
 const urls = [
     "https://www.adobe.com/express/sitemap.xml"
-]
-const apiKey = process.env.apiKey
- 
+];
+const apiKey = process.env['HELIX_API_KEY'];
+if (! apiKey) {
+    throw new Error("Invalid API Key: " + apiKey)
+}
 async function makeRequests() {
-    const baseURL = "https://admin.hlx.page/sitemap/adobecom/express/stage/"
+    const baseURL = "https://admin.hlx.page/sitemap/adobecom/express/stage/";
+    let failedURLs = []
     for (const url of urls) {
         try { 
-            let parsed_url = url.split("https://www.adobe.com/")[1] 
+            let parsed_url = url.split("https://www.adobe.com/")[1];
             const response = await fetch(baseURL + parsed_url, {
                 method: 'POST', 
                 headers: {
-                    'authorization' : `token ${apiKey}` 
+                    'authorization': `token ${apiKey}`
                 },
             });
-            if (!response.ok) {
-                console.log(response)
+            if (response.status !== 200) {
                 console.error(`Error: ${url}`, response.statusText);
+                failedURLs.push(url)
                 continue;
             }
             const data = await response.text();
             console.log(`Success: ${url}`, data);
         } catch (error) {
-            console.log(error) 
+            console.log(error);
+            failedURLs.push(url)
         }
+    }
+    if (failedURLs.length > 0){
+        console.error('------------')
+        console.error("Failed to build some urls")
+        for (let url of failedURLs){
+            console.error(url)
+        }
+        console.error('------------')
+        throw new Error("Failed to rebuild some urls")
     }
 }
 

--- a/test/helpers/sitemap.js
+++ b/test/helpers/sitemap.js
@@ -1,1 +1,37 @@
-console.log('abc')
+import fs from "fs"
+import fetch from "node-fetch"
+import dotenv from "dotenv"
+dotenv.config() 
+
+const urls = [
+    "https://www.adobe.com/express/sitemap.xml"
+]
+const apiKey = process.env.apiKey
+ 
+async function makeRequests() {
+    const baseURL = "https://admin.hlx.page/sitemap/adobecom/express/stage/"
+    for (const url of urls) {
+        try { 
+            let parsed_url = url.split("https://www.adobe.com/")[1] 
+            const response = await fetch(baseURL + parsed_url, {
+                method: 'POST', 
+                headers: {
+                    'authorization' : `token ${apiKey}` 
+                },
+            });
+
+            if (!response.ok) {
+                console.log(response)
+                console.error(`Error: ${url}`, response.statusText);
+                continue;
+            }
+
+            const data = await response.text();
+            console.log(`Success: ${url}`, data);
+        } catch (error) {
+            console.log(error) 
+        }
+    }
+}
+
+makeRequests();

--- a/test/helpers/sitemap.js
+++ b/test/helpers/sitemap.js
@@ -17,7 +17,7 @@ if (!apiKey) {
 }
 
 async function makeRequests() {
-  const baseURL = 'https://admin.hlx.page/sitemap/adobecom/express/stage/';
+  const baseURL = 'https://admin.hlx.page/sitemap/adobecom/express/main/';
   const failedURLs = [];
   await Promise.all(urls.map(async (url) => {
     try {

--- a/test/helpers/sitemap.js
+++ b/test/helpers/sitemap.js
@@ -19,13 +19,11 @@ async function makeRequests() {
                     'authorization' : `token ${apiKey}` 
                 },
             });
-
             if (!response.ok) {
                 console.log(response)
                 console.error(`Error: ${url}`, response.statusText);
                 continue;
             }
-
             const data = await response.text();
             console.log(`Success: ${url}`, data);
         } catch (error) {

--- a/test/helpers/sitemap.js
+++ b/test/helpers/sitemap.js
@@ -23,10 +23,12 @@ async function makeRequests() {
         },
       });
       if (response.status !== 200) {
+        /* eslint-disable*/
         console.error(`Error: ${url}`, response.statusText);
         failedURLs.push(url);
       } else {
         const data = await response.text();
+        /* eslint-disable*/
         console.log(`Success: ${url}`, data);
       }
     } catch (error) {
@@ -35,11 +37,15 @@ async function makeRequests() {
     }
   }
   if (failedURLs.length > 0) {
+    /* eslint-disable*/
     console.error('------------');
+    /* eslint-disable*/
     console.error('Failed to build some urls');
     for (const url of failedURLs) {
+      /* eslint-disable*/
       console.error(url);
     }
+    /* eslint-disable*/
     console.error('------------');
     throw new Error('Failed to rebuild some urls');
   }

--- a/test/helpers/sitemap.js
+++ b/test/helpers/sitemap.js
@@ -56,5 +56,5 @@ async function makeRequests() {
     throw new Error('Failed to rebuild some urls');
   }
 }
-
+/* eslint-disable*/
 makeRequests().catch((e) => console.error(e))

--- a/test/helpers/sitemap.js
+++ b/test/helpers/sitemap.js
@@ -1,47 +1,48 @@
-const fetch = require("node-fetch");
-const dotenv = require("dotenv");
+const fetch = require('node-fetch');
+/* eslint-disable-next-line import/no-unresolved */
+const dotenv = require('dotenv');
 
 dotenv.config();
 const urls = [
-    "https://www.adobe.com/express/sitemap.xml"
+  'https://www.adobe.com/express/sitemap.xml',
 ];
-const apiKey = process.env['HELIX_API_KEY'];
-if (! apiKey) {
-    throw new Error("Invalid API Key: " + apiKey)
+const apiKey = process.env.HELIX_API_KEY;
+if (!apiKey) {
+  throw new Error(`Invalid API Key: ${apiKey}`);
 }
 async function makeRequests() {
-    const baseURL = "https://admin.hlx.page/sitemap/adobecom/express/stage/";
-    let failedURLs = []
-    for (const url of urls) {
-        try { 
-            let parsed_url = url.split("https://www.adobe.com/")[1];
-            const response = await fetch(baseURL + parsed_url, {
-                method: 'POST', 
-                headers: {
-                    'authorization': `token ${apiKey}`
-                },
-            });
-            if (response.status !== 200) {
-                console.error(`Error: ${url}`, response.statusText);
-                failedURLs.push(url)
-                continue;
-            }
-            const data = await response.text();
-            console.log(`Success: ${url}`, data);
-        } catch (error) {
-            console.log(error);
-            failedURLs.push(url)
-        }
+  const baseURL = 'https://admin.hlx.page/sitemap/adobecom/express/stage/';
+  const failedURLs = [];
+  for await (const url of urls) {
+    try {
+      const parsedURL = url.split('https://www.adobe.com/')[1];
+      const response = await fetch(baseURL + parsedURL, {
+        method: 'POST',
+        headers: {
+          authorization: `token ${apiKey}`,
+        },
+      });
+      if (response.status !== 200) {
+        console.error(`Error: ${url}`, response.statusText);
+        failedURLs.push(url);
+      } else {
+        const data = await response.text();
+        console.log(`Success: ${url}`, data);
+      }
+    } catch (error) {
+      console.log(error);
+      failedURLs.push(url);
     }
-    if (failedURLs.length > 0){
-        console.error('------------')
-        console.error("Failed to build some urls")
-        for (let url of failedURLs){
-            console.error(url)
-        }
-        console.error('------------')
-        throw new Error("Failed to rebuild some urls")
+  }
+  if (failedURLs.length > 0) {
+    console.error('------------');
+    console.error('Failed to build some urls');
+    for (const url of failedURLs) {
+      console.error(url);
     }
+    console.error('------------');
+    throw new Error('Failed to rebuild some urls');
+  }
 }
 
 makeRequests();

--- a/test/helpers/sitemap.js
+++ b/test/helpers/sitemap.js
@@ -5,15 +5,21 @@ const dotenv = require('dotenv');
 dotenv.config();
 const urls = [
   'https://www.adobe.com/express/sitemap.xml',
+  'https://www.adobe.com/express/templates/sitemap.xml',
+  'https://www.adobe.com/express/colors/sitemap.xml',
+  'https://www.adobe.com/express/blog/sitemap.xml',
+
 ];
+
 const apiKey = process.env.HELIX_API_KEY;
 if (!apiKey) {
   throw new Error(`Invalid API Key: ${apiKey}`);
 }
+
 async function makeRequests() {
   const baseURL = 'https://admin.hlx.page/sitemap/adobecom/express/stage/';
   const failedURLs = [];
-  for await (const url of urls) {
+  await Promise.all(urls.map(async (url) => {
     try {
       const parsedURL = url.split('https://www.adobe.com/')[1];
       const response = await fetch(baseURL + parsedURL, {
@@ -35,7 +41,7 @@ async function makeRequests() {
       console.log(error);
       failedURLs.push(url);
     }
-  }
+  }))
   if (failedURLs.length > 0) {
     /* eslint-disable*/
     console.error('------------');
@@ -51,4 +57,4 @@ async function makeRequests() {
   }
 }
 
-makeRequests();
+makeRequests().catch((e) => console.error(e))


### PR DESCRIPTION
Describe your specific features or fixes

Implements a github actions workflow for rebuilding the staging sitemap when a PR is made. This action should help detect issues related to sitemap configs in the future.

Resolves:  https://jira.corp.adobe.com/projects/MWPW/issues/MWPW-157407

Testing Instructions:

To test this locally, 
1) create a .secrets file in the root of the project directory. The secrets file will contain vault role IDs and vault secret IDs, it does NOT contain the API key
2) Ask me for the .secrets content
3) Install `act `locally
4) Run `act -j run-sitemap-script --secret-file .secrets` in your terminal

The terminal should tell you sitemaps were built if it succeeded.

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://sitemap-action--express--adobecom.hlx.page/express/
