### PR TITLE
Treat Template Links as Search Branch Links

### DIFF
--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import { createTag, getIconElement, getMetadata } from '../../scripts/utils.js';
 import { trackSearch, updateImpressionCache } from '../../scripts/template-search-api-v3.js';
+import { getTrackingAppendedURL } from '../../scripts/branchlinks.js';
 import BlockMediator from '../../scripts/block-mediator.min.js';
 
 function containsVideo(pages) {
@@ -100,8 +101,12 @@ async function getVideoUrls(renditionLinkHref, componentLinkHref, page) {
   }
 }
 
-async function share(branchUrl, tooltip, timeoutId) {
-  await navigator.clipboard.writeText(branchUrl);
+async function share(branchUrl, tooltip, timeoutId, placeholders) {
+  const urlWithTracking = getTrackingAppendedURL(branchUrl, placeholders, {
+    placement: 'template-x',
+    isSearchOverride: true,
+  });
+  await navigator.clipboard.writeText(urlWithTracking.toString());
   tooltip.classList.add('display-tooltip');
 
   const rect = tooltip.getBoundingClientRect();
@@ -130,14 +135,14 @@ function renderShareWrapper(branchUrl, placeholders) {
   });
   let timeoutId = null;
   shareIcon.addEventListener('click', () => {
-    timeoutId = share(branchUrl, tooltip, timeoutId);
+    timeoutId = share(branchUrl, tooltip, timeoutId, placeholders);
   });
 
   shareIcon.addEventListener('keypress', (e) => {
     if (e.key !== 'Enter') {
       return;
     }
-    timeoutId = share(branchUrl, tooltip, timeoutId);
+    timeoutId = share(branchUrl, tooltip, timeoutId, placeholders);
   });
   const checkmarkIcon = getIconElement('checkmark-green');
   tooltip.append(checkmarkIcon);

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -106,7 +106,7 @@ async function share(branchUrl, tooltip, timeoutId, placeholders) {
     placement: 'template-x',
     isSearchOverride: true,
   });
-  await navigator.clipboard.writeText(urlWithTracking.toString());
+  await navigator.clipboard.writeText(urlWithTracking);
   tooltip.classList.add('display-tooltip');
 
   const rect = tooltip.getBoundingClientRect();

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -333,6 +333,7 @@ async function decorateNewTemplates(block, props, options = { reDrawMasonry: fal
   const newCells = Array.from(block.querySelectorAll('.template:not(.appear)'));
 
   const templateLinks = block.querySelectorAll('.template:not(.appear) .button-container > a, a.template.placeholder');
+  templateLinks.isSearchOverride = true;
   const linksPopulated = new CustomEvent('linkspopulated', { detail: templateLinks });
   document.dispatchEvent(linksPopulated);
 
@@ -1330,6 +1331,7 @@ async function decorateTemplates(block, props) {
   if (searchId) trackSearch('view-search-result', searchId);
 
   const templateLinks = block.querySelectorAll('.template .button-container > a, a.template.placeholder');
+  templateLinks.isSearchOverride = true;
   const linksPopulated = new CustomEvent('linkspopulated', { detail: templateLinks });
   document.dispatchEvent(linksPopulated);
 }

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -332,6 +332,10 @@ async function decorateNewTemplates(block, props, options = { reDrawMasonry: fal
 
   const newCells = Array.from(block.querySelectorAll('.template:not(.appear)'));
 
+  const templateLinks = block.querySelectorAll('.template:not(.appear) .button-container > a, a.template.placeholder');
+  const linksPopulated = new CustomEvent('linkspopulated', { detail: templateLinks });
+  document.dispatchEvent(linksPopulated);
+
   if (options.reDrawMasonry) {
     props.masonry.cells = [props.masonry.cells[0]].concat(newCells);
   } else {
@@ -1317,9 +1321,6 @@ async function decorateTemplates(block, props) {
 
   await attachFreeInAppPills(block);
 
-  const templateLinks = block.querySelectorAll('.template .button-container > a, a.template.placeholder');
-  const linksPopulated = new CustomEvent('linkspopulated', { detail: templateLinks });
-
   const searchId = new URLSearchParams(window.location.search).get('searchId');
   updateImpressionCache({
     search_keyword: getMetadata('q') || getMetadata('topics-x'),
@@ -1328,6 +1329,8 @@ async function decorateTemplates(block, props) {
   });
   if (searchId) trackSearch('view-search-result', searchId);
 
+  const templateLinks = block.querySelectorAll('.template .button-container > a, a.template.placeholder');
+  const linksPopulated = new CustomEvent('linkspopulated', { detail: templateLinks });
   document.dispatchEvent(linksPopulated);
 }
 

--- a/express/scripts/branchlinks.js
+++ b/express/scripts/branchlinks.js
@@ -48,7 +48,7 @@ const setBasicBranchMetadata = new Set([
 ]);
 
 // return url string with analytics and branch parameters appended
-export function getTrackingAppendedURL(url, placeholders, options) {
+export function getTrackingAppendedURL(url, placeholders, options = {}) {
   const { placement, isSearchOverride } = options;
   const windowParams = new URLSearchParams(window.location.search);
   const [
@@ -107,7 +107,7 @@ export function getTrackingAppendedURL(url, placeholders, options) {
 
   const appending = new URL(url);
   const urlParams = appending.searchParams;
-  const isSearchBranchLink = placeholders['search-branch-links']?.replace(/\s/g, '').split(',').includes(`${url.origin}${url.pathname}`);
+  const isSearchBranchLink = placeholders['search-branch-links']?.replace(/\s/g, '').split(',').includes(`${appending.origin}${appending.pathname}`);
 
   const setParams = (k, v) => {
     if (v) urlParams.set(k, encodeURIComponent(v));

--- a/test/unit/scripts/branchlinks.test.js
+++ b/test/unit/scripts/branchlinks.test.js
@@ -1,0 +1,94 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+import { setConfig, createTag } from '../../../express/scripts/utils.js';
+
+const { default: trackBranchParameters, getTrackingAppendedURL } = await import(
+  '../../../express/scripts/branchlinks.js'
+);
+
+document.body.innerHTML = await readFile({ path: './mocks/branchlinks.html' });
+setConfig({});
+
+function setMeta(name, content) {
+  document.head.append(createTag('meta', { name, content }));
+}
+
+describe('branchlinks getTrackingAppendedURL', () => {
+  let urls;
+  before(() => {
+    window.isTestEnv = true;
+    window.placeholders = {
+      'search-branch-links':
+        'https://adobesparkpost.app.link/c4bWARQhWAb, https://adobesparkpost.app.link/lQEQ4Pi1YHb, https://adobesparkpost.app.link/9tmWXXDAhLb',
+    };
+    window.hlx = { experiment: null };
+    setMeta('branch-asset-collection', 'test');
+    setMeta('branch-newstuff', 'test');
+  });
+  beforeEach(() => {
+    urls = [...document.querySelectorAll('a')].map((a) => a.href);
+  });
+  after(() => {
+    document.querySelector('meta[name="branch-asset-collection"]').remove();
+    document.querySelector('meta[name="branch-newstuff"]').remove();
+  });
+  it('returns a string', () => {
+    urls.forEach((url) => expect(getTrackingAppendedURL(url, window.placeholders)).to.be.string);
+  });
+  it('adds to branch links locale', () => {
+    const appendedUrls = urls.map((url) => getTrackingAppendedURL(url, window.placeholders));
+    appendedUrls.forEach((url) => expect(url.includes('locale')).to.be.true);
+  });
+  it('appends branch tracking parameters to search branch links only', () => {
+    const appendedUrls = urls.map((url) => getTrackingAppendedURL(url, window.placeholders));
+    expect(appendedUrls[0].includes('assetCollection')).to.be.false;
+    expect(appendedUrls[1].includes('assetCollection')).to.be.true;
+    expect(appendedUrls[1].includes('newstuff')).to.be.true;
+    expect(appendedUrls[2].includes('assetCollection')).to.be.false;
+  });
+  it('accepts searchOverride option to allow non search branch links to work like search branch links', () => {
+    expect(
+      getTrackingAppendedURL(urls[2], window.placeholders, { isSearchOverride: true }).includes(
+        'assetCollection',
+      ),
+    ).to.be.true;
+  });
+});
+
+describe('branchlinks trackBranchParameteres', () => {
+  let links;
+  before(async () => {
+    window.isTestEnv = true;
+    window.placeholders = {
+      'search-branch-links':
+        'https://adobesparkpost.app.link/c4bWARQhWAb, https://adobesparkpost.app.link/lQEQ4Pi1YHb, https://adobesparkpost.app.link/9tmWXXDAhLb',
+    };
+    window.hlx = { experiment: null };
+    links = [
+      ...document.querySelectorAll('a'),
+      createTag(
+        'a',
+        {
+          href: 'https://adobesparkpost.app.link/GJrBPFUWBBb?acomx-dno=y',
+        },
+        'normal branch link with no tracking wanted',
+      ),
+    ];
+    await trackBranchParameters(links);
+  });
+  it('adds rel=nofollow to branch links', () => {
+    links.forEach((link) => {
+      expect(link.rel === 'nofollow').to.be.true;
+    });
+  });
+  // <a href="https://adobesparkpost.app.link/GJrBPFUWBBb?acomx-dno=y">normal branch link with no tracking wanted</a>
+  it('skips adding params for links with disable flag', () => {
+    links.forEach((link, index) => {
+      if (index === links.length - 1) {
+        expect(link.href.includes('locale')).to.be.false;
+      } else {
+        expect(link.href.includes('locale')).to.be.true;
+      }
+    });
+  });
+});

--- a/test/unit/scripts/branchlinks.test.js
+++ b/test/unit/scripts/branchlinks.test.js
@@ -81,7 +81,6 @@ describe('branchlinks trackBranchParameteres', () => {
       expect(link.rel === 'nofollow').to.be.true;
     });
   });
-  // <a href="https://adobesparkpost.app.link/GJrBPFUWBBb?acomx-dno=y">normal branch link with no tracking wanted</a>
   it('skips adding params for links with disable flag', () => {
     links.forEach((link, index) => {
       if (index === links.length - 1) {

--- a/test/unit/scripts/mocks/branchlinks.html
+++ b/test/unit/scripts/mocks/branchlinks.html
@@ -1,0 +1,5 @@
+<div class="block">
+  <a href="https://adobesparkpost.app.link/GJrBPFUWBBb">normal branch link</a>
+  <a href="https://adobesparkpost.app.link/c4bWARQhWAb">search branch link</a>
+  <a href="https://adobesparkpost-web.app.link/GJrBPFUWBBb">normal web app branch link</a>
+</div>


### PR DESCRIPTION
Treat template links the same as WAR links, in terms of grabbing page branch metadata and stuffing them into CTAs. Also add those query parameters to the "share" button of templates.

Resolves: https://jira.corp.adobe.com/browse/MWPW-157158

How to test:
1. Open the branch link
2. Hover on any of the little templates and inspect the url of those "Edit this Template" CTA
3. You should see extra query parameters like category=templates. This is not in stage.
4. Clicking the CTA should take you inside the product with the template opened
5. Back to our page and hovering, clicking the little "share" icon on the top right of a template should copy the URL with those query parameters into your clipboard

Pages to test for regression:
- All pages that contain the template-x block. Most representative ones are https://template-branch-links--express--adobecom.hlx.live/express/create/flyer (sixcols variant) and https://template-branch-links--express--adobecom.hlx.live/express/ (tab variant)

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/templates/flyer
- After: https://template-branch-links--express--adobecom.hlx.page/express/templates/flyer
