### PR TITLE
[Marquee Logo Injection] Fullscreen Marquee

### DIFF
--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -23,7 +23,7 @@
 .fullscreen-marquee .express-logo {
   width: unset;
   height: 30px;
-  padding-bottom: 18px;
+  padding-bottom: 8px;
 }
 
 .fullscreen-marquee.has-background {
@@ -271,6 +271,10 @@
   .section > .fullscreen-marquee {
     padding-bottom: 40px;
     padding-top: 40px;
+  }
+
+  .fullscreen-marquee .express-logo {
+    padding-bottom: 18px;
   }
 
   .fullscreen-marquee .fullscreen-marquee-heading {

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -20,6 +20,12 @@
   max-width: none;
 }
 
+.fullscreen-marquee .express-logo {
+  width: unset;
+  height: 30px;
+  padding-bottom: 18px;
+}
+
 .fullscreen-marquee.has-background {
   padding-bottom: 160px;
 }
@@ -264,7 +270,7 @@
 @media (min-width: 900px) {
   .section > .fullscreen-marquee {
     padding-bottom: 40px;
-    padding-top: 80px;
+    padding-top: 40px;
   }
 
   .fullscreen-marquee .fullscreen-marquee-heading {

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.js
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.js
@@ -3,6 +3,8 @@ import {
   createTag,
   fetchPlaceholders,
   transformLinkToAnimation,
+  getIconElement,
+  getMetadata,
 } from '../../scripts/utils.js';
 import { addFreePlanWidget } from '../../scripts/utils/free-plan.js';
 
@@ -166,6 +168,12 @@ export default async function decorate(block) {
 
   if (content) {
     content = buildContent(content);
+  }
+
+  if (['on', 'yes'].includes(getMetadata('marquee-inject-logo')?.toLowerCase())) {
+    const logo = getIconElement('adobe-express-logo');
+    logo.classList.add('express-logo');
+    block.prepend(logo);
   }
 
   if (background) {

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.js
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.js
@@ -171,13 +171,10 @@ export default async function decorate(block) {
   }
 
   if (['on', 'yes'].includes(getMetadata('marquee-inject-logo')?.toLowerCase())) {
-    // const logo = getIconElement('adobe-express-logo');
-    // logo.classList.add('express-logo');
-    // block.prepend(logo);
+    const logo = getIconElement('adobe-express-logo');
+    logo.classList.add('express-logo');
+    block.prepend(logo);
   }
-  const logo = getIconElement('adobe-express-logo');
-  logo.classList.add('express-logo');
-  block.prepend(logo);
 
   if (background) {
     block.classList.add('has-background');

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.js
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.js
@@ -171,10 +171,13 @@ export default async function decorate(block) {
   }
 
   if (['on', 'yes'].includes(getMetadata('marquee-inject-logo')?.toLowerCase())) {
-    const logo = getIconElement('adobe-express-logo');
-    logo.classList.add('express-logo');
-    block.prepend(logo);
+    // const logo = getIconElement('adobe-express-logo');
+    // logo.classList.add('express-logo');
+    // block.prepend(logo);
   }
+  const logo = getIconElement('adobe-express-logo');
+  logo.classList.add('express-logo');
+  block.prepend(logo);
 
   if (background) {
     block.classList.add('has-background');

--- a/express/blocks/susi-light/susi-light.js
+++ b/express/blocks/susi-light/susi-light.js
@@ -44,7 +44,7 @@ export default async function init(el) {
   const rows = el.querySelectorAll(':scope> div > div');
   const redirectUrl = rows[0]?.textContent?.trim().toLowerCase();
   // eslint-disable-next-line camelcase
-  const client_id = rows[1]?.textContent?.trim() ?? 'AdobeExpressWeb';
+  const client_id = rows[1]?.textContent?.trim() || 'AdobeExpressWeb';
   const title = rows[2]?.textContent?.trim();
   const authParams = {
     dt: false,


### PR DESCRIPTION
Similar to earlier marquee logo injection PRs, this one is for fullscreen-marquee. So with a metadata present, the express logo will be prepended to the block. There is also a minor and trivial update to SUSI-Light coupled together.

No live pages should be affected due to it's behind a metadata guard.

Resolves: https://jira.corp.adobe.com/browse/MWPW-153729?filter=381833

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/jinglhua/flyer?martech=off
- After: https://logo-inject-fs-marquee--express--adobecom.hlx.page/drafts/jinglhua/flyer?martech=off
