### PR TITLE
[Marquee Logo Injection] Columns

### DIFF
--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -21,6 +21,12 @@ main .columns-top-container > div {
   max-width: 350px;
 }
 
+main .columns .express-logo.icon {
+  width: unset;
+  height: 30px;
+  padding-bottom: 8px;
+  float: unset;
+}
  
 
 .section.columns-enterprise-container .default-content-wrapper h2 {

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -308,6 +308,11 @@ export default async function decorate(block) {
     && document.querySelector('main .block') === block) {
     addFreePlanWidget(block.querySelector('.button-container') || block.querySelector(':scope .column:not(.hero-animation-overlay,.columns-picture)'));
   }
+  if (document.querySelector('main .block') === block && ['on', 'yes'].includes(getMetadata('marquee-inject-logo')?.toLowerCase())) {
+    const logo = getIconElement('adobe-express-logo');
+    logo.classList.add('express-logo');
+    block.querySelector('.column')?.prepend(logo);
+  }
 
   // add custom background color to columns-highlight-container
   const sectionContainer = block.closest('.section.columns-highlight-container');


### PR DESCRIPTION
Similar to earlier marquee logo injection PRs, this one is for columns. So with a metadata present, the express logo will be prepended to the block if it is the first block on the page (aka when a column is used as a marquee).

No live pages should be affected due to it's behind a metadata guard.

Resolves: https://jira.corp.adobe.com/browse/MWPW-153729?filter=381833

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/drafts/jinglhua/logo?martech=off
- After: https://logo-inject-columns--express--adobecom.hlx.page/drafts/jinglhua/logo?martech=off
