### PR TITLE
[Marquee Logo Injection] Fullscreen Marquee + Columns + Headline

### DIFF
--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -21,6 +21,12 @@ main .columns-top-container > div {
   max-width: 350px;
 }
 
+main .columns .express-logo.icon {
+  width: unset;
+  height: 30px;
+  padding-bottom: 8px;
+  float: unset;
+}
  
 
 .section.columns-enterprise-container .default-content-wrapper h2 {

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -308,6 +308,11 @@ export default async function decorate(block) {
     && document.querySelector('main .block') === block) {
     addFreePlanWidget(block.querySelector('.button-container') || block.querySelector(':scope .column:not(.hero-animation-overlay,.columns-picture)'));
   }
+  if (document.querySelector('main .block') === block && ['on', 'yes'].includes(getMetadata('marquee-inject-logo')?.toLowerCase())) {
+    const logo = getIconElement('adobe-express-logo');
+    logo.classList.add('express-logo');
+    block.querySelector('.column')?.prepend(logo);
+  }
 
   // add custom background color to columns-highlight-container
   const sectionContainer = block.closest('.section.columns-highlight-container');

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -20,6 +20,12 @@
   max-width: none;
 }
 
+.fullscreen-marquee .express-logo {
+  width: unset;
+  height: 30px;
+  padding-bottom: 8px;
+}
+
 .fullscreen-marquee.has-background {
   padding-bottom: 160px;
 }
@@ -264,7 +270,11 @@
 @media (min-width: 900px) {
   .section > .fullscreen-marquee {
     padding-bottom: 40px;
-    padding-top: 80px;
+    padding-top: 40px;
+  }
+
+  .fullscreen-marquee .express-logo {
+    padding-bottom: 18px;
   }
 
   .fullscreen-marquee .fullscreen-marquee-heading {

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.js
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.js
@@ -3,6 +3,8 @@ import {
   createTag,
   fetchPlaceholders,
   transformLinkToAnimation,
+  getIconElement,
+  getMetadata,
 } from '../../scripts/utils.js';
 import { addFreePlanWidget } from '../../scripts/utils/free-plan.js';
 
@@ -166,6 +168,12 @@ export default async function decorate(block) {
 
   if (content) {
     content = buildContent(content);
+  }
+
+  if (['on', 'yes'].includes(getMetadata('marquee-inject-logo')?.toLowerCase())) {
+    const logo = getIconElement('adobe-express-logo');
+    logo.classList.add('express-logo');
+    block.prepend(logo);
   }
 
   if (background) {

--- a/express/blocks/headline/headline.css
+++ b/express/blocks/headline/headline.css
@@ -1,0 +1,4 @@
+.headline .express-logo {
+  width: unset;
+  height: 30px;
+}

--- a/express/blocks/headline/headline.js
+++ b/express/blocks/headline/headline.js
@@ -1,3 +1,5 @@
+import { getMetadata, getIconElement } from '../../scripts/utils.js';
+
 // avoid using this kind of text-block unless necessary
 export default function init(el) {
   const heading = el.querySelector('h1, h2, h3, h4, h5, h6');
@@ -11,6 +13,12 @@ export default function init(el) {
     cfg.remove();
   } catch (e) {
     window.lana?.log(e);
+  }
+
+  if (document.querySelector('main .block') === el && ['on', 'yes'].includes(getMetadata('marquee-inject-logo')?.toLowerCase())) {
+    const logo = getIconElement('adobe-express-logo');
+    logo.classList.add('express-logo');
+    el.prepend(logo);
   }
 
   return el;

--- a/express/blocks/susi-light/susi-light.js
+++ b/express/blocks/susi-light/susi-light.js
@@ -44,7 +44,7 @@ export default async function init(el) {
   const rows = el.querySelectorAll(':scope> div > div');
   const redirectUrl = rows[0]?.textContent?.trim().toLowerCase();
   // eslint-disable-next-line camelcase
-  const client_id = rows[1]?.textContent?.trim() ?? 'AdobeExpressWeb';
+  const client_id = rows[1]?.textContent?.trim() || 'AdobeExpressWeb';
   const title = rows[2]?.textContent?.trim();
   const authParams = {
     dt: false,


### PR DESCRIPTION
Similar to earlier marquee logo injection PRs, this one is for 3 blocks. So with a metadata present, the express logo will be prepended to Columns and Headline if it is the first block on the page. Fullscreen marquee should always be the first block on the page so it doesn't need the first block check.

No live pages should be affected due to it's behind a metadata guard. There is also a minor and trivial update to SUSI-Light coupled together.

Resolves: https://jira.corp.adobe.com/browse/MWPW-153729?filter=381833

Test URLs:
- Columns Before: https://stage--express--adobecom.hlx.page/drafts/jinglhua/logo?martech=off
- Columns After: https://logo-inject-3bl--express--adobecom.hlx.page/drafts/jinglhua/logo?martech=off
- FS Marquee Before: https://stage--express--adobecom.hlx.page/drafts/jinglhua/flyer?martech=off
- FS Marquee After: https://logo-inject-3bl--express--adobecom.hlx.page/drafts/jinglhua/flyer?martech=off
- Headline Before: https://stage--express--adobecom.hlx.page/drafts/jinglhua/pricing?martech=off
- Headline After: https://logo-inject-3bl--express--adobecom.hlx.page/drafts/jinglhua/pricing?martech=off
