### PR TITLE
remove replaceHyphensInText from utils

### DIFF
--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -7,7 +7,6 @@ import {
   getIconElement,
   addHeaderSizing,
   getMetadata,
-  replaceHyphensInText,
 } from '../../scripts/utils.js';
 import { addTempWrapper } from '../../scripts/decorate.js';
 import { addFreePlanWidget } from '../../scripts/utils/free-plan.js';
@@ -24,6 +23,14 @@ import {
   getExpressLandingPageType,
   sendEventToAnalytics,
 } from '../../scripts/instrument.js';
+
+function replaceHyphensInText(area) {
+  [...area.querySelectorAll('h1, h2, h3, h4, h5, h6')]
+    .filter((header) => header.textContent.includes('-'))
+    .forEach((header) => {
+      header.textContent = header.textContent.replace(/-/g, '\u2011');
+    });
+}
 
 function transformToVideoColumn(cell, aTag, block) {
   const parent = cell.parentElement;

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2561,14 +2561,6 @@ function fragmentBlocksToLinks(area) {
   });
 }
 
-export function replaceHyphensInText(area) {
-  [...area.querySelectorAll('h1, h2, h3, h4, h5, h6')]
-    .filter((header) => header.textContent.includes('-'))
-    .forEach((header) => {
-      header.textContent = header.textContent.replace(/-/g, '\u2011');
-    });
-}
-
 export async function loadArea(area = document) {
   const isDoc = area === document;
 


### PR DESCRIPTION
Remove replaceHyphensInText from utils and define it where it is used since it is only used in 1 place.

Test URLs:
- Before: https://main--express--adobecom.hlx.page/express/
- After: https://replace-hyphens-update--express--adobecom.hlx.page/express/
