### PR TITLE
Changes Delimiter Token For Pricing Cards Credits

### DIFF
--- a/express/blocks/pricing-cards-credits/pricing-cards-credits.js
+++ b/express/blocks/pricing-cards-credits/pricing-cards-credits.js
@@ -38,7 +38,7 @@ function decorateCardBorder(card, source) {
     card.appendChild(newHeader);
     return;
   }
-  const pattern = /\{\{(.*?)\}\}/g;
+  const pattern = /\(\((.*?)\)\)/g;
   const matches = Array.from(source.textContent?.matchAll(pattern));
   if (matches.length > 0) {
     const [, promoType] = matches[0];

--- a/test/unit/blocks/pricing-cards-credits/mocks/body.html
+++ b/test/unit/blocks/pricing-cards-credits/mocks/body.html
@@ -18,7 +18,7 @@
     <div>
       <div></div>
       <div>
-        <h2 id="gradient-promo">{{gradient-promo}}</h2>
+        <h2 id="gradient-promo">((gradient-promo))</h2>
       </div>
     </div>
     <div>


### PR DESCRIPTION
Describe your specific features or fixes:

Changes the delimiter token for gradient borders from {{ }} to (( )) in line with new standards for Express. Usage of {{ }} is problematic for the Milo Migration because of how Milo handles placeholder replacement.

Resolves: https://jira.corp.adobe.com/browse/MWPW-157762

Steps to test the before vs. after and expectations:

Visit the sample page linked below to see how the page handles the new token vs old token

Impacted pages that should be checked for regression:

Not aware of any as of now.

Test URLs:
- Before: https://stage--express--adobecom.hlx.page/express/
- After: https://pricing-cards-credits-braces--express--adobecom.hlx.page/drafts/echen/pricing-cards-credits
