### PR TITLE
[Template Search Tracking] Fixes for Unknown Values

### DIFF
--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -160,7 +160,7 @@ function initSearchFunction(block) {
   };
 
   const onSearchSubmit = async () => {
-    searchBar.disabled = true;
+    // searchBar.disabled = true;
     await redirectSearch();
   };
 

--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -160,6 +160,7 @@ function initSearchFunction(block) {
   };
 
   const onSearchSubmit = async () => {
+    searchBar.disabled = true;
     await redirectSearch();
   };
 

--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -175,7 +175,7 @@ function initSearchFunction(block) {
       type_filter: 'all',
       collection: 'all-templates',
       keyword_rank: index + 1,
-      search_keyword: searchBar.value,
+      search_keyword: searchBar.value || 'empty search',
       search_type: 'autocomplete',
     });
 
@@ -188,7 +188,7 @@ function initSearchFunction(block) {
       status_filter: 'free',
       type_filter: 'all',
       collection: 'all-templates',
-      search_keyword: searchBar.value,
+      search_keyword: searchBar.value || 'empty search',
       search_type: 'direct',
     });
     await onSearchSubmit();

--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -160,7 +160,6 @@ function initSearchFunction(block) {
   };
 
   const onSearchSubmit = async () => {
-    // searchBar.disabled = true;
     await redirectSearch();
   };
 

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -385,7 +385,7 @@ function renderHoverWrapper(template, placeholders) {
       content_id: template.id,
       status: template.licensingCategory,
       task: getMetadata('tasksx') || getMetadata('tasks') || '',
-      search_keyword: getMetadata('q') || getMetadata('topics') || '',
+      search_keyword: getMetadata('q') || getMetadata('topics-x') || getMetadata('topics') || '',
       collection: getMetadata('tasksx') || getMetadata('tasks') || '',
       collection_path: window.location.pathname,
     });

--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -1322,7 +1322,7 @@ async function decorateTemplates(block, props) {
 
   const searchId = new URLSearchParams(window.location.search).get('searchId');
   updateImpressionCache({
-    search_keyword: getMetadata('q') || getMetadata('topics-x'),
+    search_keyword: getMetadata('q') || getMetadata('topics-x') || getMetadata('topics'),
     result_count: props.total,
     content_category: 'templates',
   });
@@ -1464,7 +1464,7 @@ function importSearchBar(block, blockMediator) {
             type_filter: 'all',
             collection: 'all-templates',
             keyword_rank: index + 1,
-            search_keyword: searchBar.value,
+            search_keyword: searchBar.value || 'empty search',
             search_type: 'autocomplete',
           });
           await onSearchSubmit();
@@ -1478,7 +1478,7 @@ function importSearchBar(block, blockMediator) {
             type_filter: 'all',
             collection: 'all-templates',
             search_type: 'direct',
-            search_keyword: searchBar.value,
+            search_keyword: searchBar.value || 'empty search',
           });
           await onSearchSubmit();
         });

--- a/express/scripts/template-ckg.js
+++ b/express/scripts/template-ckg.js
@@ -138,8 +138,10 @@ async function updateLinkList(container, linkPill, list) {
         const innerLink = clone.querySelector('a');
         if (innerLink) {
           const url = new URL(innerLink.href);
-          url.searchParams.set('searchId', generateSearchId());
-          innerLink.href = url.toString();
+          if (!url.searchParams.get('searchId')) {
+            url.searchParams.set('searchId', generateSearchId());
+            innerLink.href = url.toString();
+          }
         }
 
         if (clone) pageLinks.push(clone);

--- a/express/scripts/template-ckg.js
+++ b/express/scripts/template-ckg.js
@@ -132,8 +132,16 @@ async function updateLinkList(container, linkPill, list) {
         };
 
         clone = replaceLinkPill(linkPill, pageData);
-        clone.innerHTML = clone.innerHTML.replaceAll('Default', d.displayValue);
-        clone.innerHTML = clone.innerHTML.replace('/express/templates/default', `${d.pathname}?searchId=${generateSearchId()}`);
+        clone.innerHTML = clone.innerHTML
+          .replaceAll('Default', d.displayValue)
+          .replace('/express/templates/default', d.pathname);
+        const innerLink = clone.querySelector('a');
+        if (innerLink) {
+          const url = new URL(innerLink.href);
+          url.searchParams.set('searchId', generateSearchId());
+          innerLink.href = url.toString();
+        }
+
         if (clone) pageLinks.push(clone);
       } else {
         // fixme: we need single page search UX

--- a/express/scripts/template-redirect.js
+++ b/express/scripts/template-redirect.js
@@ -20,12 +20,19 @@ export function constructTargetPath(topics, tasks, tasksx) {
 
 export default async function redirectToExistingPage() {
   // TODO: check if the search query points to an existing page. If so, redirect.
-  const { topics, tasks, tasksx } = new Proxy(new URLSearchParams(window.location.search), {
-    get: (searchParams, prop) => searchParams.get(prop),
-  });
+  const {
+    topics,
+    tasks,
+    tasksx,
+    searchId,
+  } = new Proxy(
+    new URLSearchParams(window.location.search), {
+      get: (searchParams, prop) => searchParams.get(prop),
+    },
+  );
   const pathToMatch = constructTargetPath(topics, tasks, tasksx);
   if (await existsTemplatePage(pathToMatch)) {
-    window.location.assign(`${window.location.origin}${pathToMatch}`);
+    window.location.assign(`${window.location.origin}${pathToMatch}${searchId ? `?searchId=${searchId}` : ''}`);
     document.body.style.display = 'none'; // hide the page until the redirect happens
   }
 }


### PR DESCRIPTION
**Fixes:** Address 2 issues currently live with Template Search Tracking:
- Unknown `search-inspire` values. Solution: explicitly fire with "empty search".
- `searchId` getting dropped from search page to real SEO page. Solution: handled 2 places where it could be dropped, 1 in CKG pills and 1 in template-redirect.

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-157759

**Steps to test the before vs. after and expectations:**
- You should see the first few CKG Pills linking to static template pages to start having `searchId` query parameter. This was missing in stage
- Search for `birthday card`, and in the address bar of the landing page, you should see `searchId` query parameter. This was missing when searching in stage

**Impacted pages that should be checked for regression:**
- https://search-tracking-updates--express--adobecom.hlx.page/express/templates/card?martech=off
- https://search-tracking-updates--express--adobecom.hlx.page/express/templates/?martech=off
- https://search-tracking-updates--express--adobecom.hlx.page/express/templates/search?tasks=&tasksx=&phformat=5:7&topics=happy%20dog&q=happy%20dog&searchId=205583&martech=off


**Performance Test URLs:**
- Before: https://stage--express--adobecom.hlx.page/express/templates/card?martech=off
- After: https://search-tracking-updates--express--adobecom.hlx.page/express/templates/card?martech=off
