### PR TITLE
JP Express Long Form

### DIFF
--- a/express/blocks/banner/banner.css
+++ b/express/blocks/banner/banner.css
@@ -99,7 +99,7 @@ main .banner .standout-container em {
   font-weight: 900;
 }
 
-main .banner.block.narrow-desktop-width {
+main .banner.narrow-desktop-width {
   max-width: 850px;
   margin: 0 auto; 
   padding: 10px; 

--- a/express/blocks/banner/banner.css
+++ b/express/blocks/banner/banner.css
@@ -1,12 +1,10 @@
 main .section.banner-container,
-main .section.banner-narrow-container,
 main .section.banner-standout-container,
 main .section.banner-compact-container {
   background-color: var(--color-info-accent);
 }
 
 main .section.banner-container,
-main .section.banner-narrow-container,
 main .section.banner-light-container {
   padding: 80px 15px;
 }

--- a/express/blocks/banner/banner.css
+++ b/express/blocks/banner/banner.css
@@ -102,7 +102,7 @@ main .banner .standout-container em {
 }
 
 main .grid-width-6-desktop.banner-narrow-container .banner { 
-  max-width: 850px !important;
+  max-width: 850px;
   margin: 0 auto; 
 }
 

--- a/express/blocks/banner/banner.css
+++ b/express/blocks/banner/banner.css
@@ -99,7 +99,7 @@ main .banner .standout-container em {
   font-weight: 900;
 }
 
-main .grid-width-6-desktop.narrow.banner-container  .banner{
+main .grid-width-6-desktop.narrow.banner-container .banner{
   max-width: 850px;
   margin: 0 auto; 
 }

--- a/express/blocks/banner/banner.css
+++ b/express/blocks/banner/banner.css
@@ -99,6 +99,12 @@ main .banner .standout-container em {
   font-weight: 900;
 }
 
+main .banner.block.narrow-desktop-width {
+  max-width: 850px;
+  margin: 0 auto; 
+  padding: 10px; 
+}
+
 @media (min-width: 900px) {
   main .section.banner-container {
     padding-left: 56px;

--- a/express/blocks/banner/banner.css
+++ b/express/blocks/banner/banner.css
@@ -1,10 +1,12 @@
 main .section.banner-container,
+main .section.banner-narrow-container,
 main .section.banner-standout-container,
 main .section.banner-compact-container {
   background-color: var(--color-info-accent);
 }
 
 main .section.banner-container,
+main .section.banner-narrow-container,
 main .section.banner-light-container {
   padding: 80px 15px;
 }
@@ -99,8 +101,8 @@ main .banner .standout-container em {
   font-weight: 900;
 }
 
-main .grid-width-6-desktop.narrow.banner-container .banner{
-  max-width: 850px;
+main .grid-width-6-desktop.banner-narrow-container .banner { 
+  max-width: 850px !important;
   margin: 0 auto; 
 }
 

--- a/express/blocks/banner/banner.css
+++ b/express/blocks/banner/banner.css
@@ -99,7 +99,7 @@ main .banner .standout-container em {
   font-weight: 900;
 }
 
-main .banner.narrow-desktop-width {
+main .banner.narrow-width {
   max-width: 850px;
   margin: 0 auto; 
 }

--- a/express/blocks/banner/banner.css
+++ b/express/blocks/banner/banner.css
@@ -101,8 +101,13 @@ main .banner .standout-container em {
   font-weight: 900;
 }
 
-main .grid-width-6-desktop.banner-narrow-container .banner { 
+main .grid-width-6-desktop .banner.narrow.desktop { 
   max-width: 850px;
+  margin: 0 auto; 
+}
+
+main .banner.narrow.mobile { 
+  max-width: 375px;
   margin: 0 auto; 
 }
 

--- a/express/blocks/banner/banner.css
+++ b/express/blocks/banner/banner.css
@@ -99,7 +99,7 @@ main .banner .standout-container em {
   font-weight: 900;
 }
 
-main .banner.narrow-width {
+main .grid-width-6-desktop.narrow.banner-container  .banner{
   max-width: 850px;
   margin: 0 auto; 
 }

--- a/express/blocks/banner/banner.css
+++ b/express/blocks/banner/banner.css
@@ -102,7 +102,6 @@ main .banner .standout-container em {
 main .banner.narrow-desktop-width {
   max-width: 850px;
   margin: 0 auto; 
-  padding: 10px; 
 }
 
 @media (min-width: 900px) {

--- a/express/blocks/banner/banner.js
+++ b/express/blocks/banner/banner.js
@@ -1,8 +1,14 @@
-import { normalizeHeadings, createTag } from '../../scripts/utils.js';
+import { normalizeHeadings, createTag, getMetadata } from '../../scripts/utils.js';
 
 export default async function decorate(block) {
   const isBannerLightVariant = block.classList.contains('light');
   const isBannerStandoutVariant = block.classList.contains('standout');
+
+  const narrowWidth = getMetadata('narrow-width') === 'on';
+  const container = document.querySelector('div.banner.block');
+  if (narrowWidth && container) {
+    container.classList.add('narrow-desktop-width');
+  }
 
   if (isBannerStandoutVariant) {
     const standoutContainer = createTag('div', {

--- a/express/blocks/banner/banner.js
+++ b/express/blocks/banner/banner.js
@@ -1,14 +1,8 @@
-import { normalizeHeadings, createTag, getMetadata } from '../../scripts/utils.js';
+import { normalizeHeadings, createTag } from '../../scripts/utils.js';
 
 export default async function decorate(block) {
   const isBannerLightVariant = block.classList.contains('light');
   const isBannerStandoutVariant = block.classList.contains('standout');
-
-  const narrowWidth = getMetadata('narrow-width') === 'on';
-  const container = document.querySelector('div.banner.block');
-  if (narrowWidth && container) {
-    container.classList.add('narrow-width');
-  }
 
   if (isBannerStandoutVariant) {
     const standoutContainer = createTag('div', {

--- a/express/blocks/banner/banner.js
+++ b/express/blocks/banner/banner.js
@@ -17,6 +17,11 @@ export default async function decorate(block) {
     block.replaceChildren(standoutContainer);
   }
 
+  if (isBannerNarrowVariant) {
+    block.parentElement.style.backgroundColor = 'var(--color-info-accent)';
+    block.parentElement.style.padding = '80px 15px';
+  }
+
   if (isBannerNarrowVariant && document.body.dataset.device === 'desktop') {
     block.classList.add('desktop');
     block.classList.remove('mobile');

--- a/express/blocks/banner/banner.js
+++ b/express/blocks/banner/banner.js
@@ -7,7 +7,7 @@ export default async function decorate(block) {
   const narrowWidth = getMetadata('narrow-width') === 'on';
   const container = document.querySelector('div.banner.block');
   if (narrowWidth && container) {
-    container.classList.add('narrow-desktop-width');
+    container.classList.add('narrow-width');
   }
 
   if (isBannerStandoutVariant) {

--- a/express/blocks/banner/banner.js
+++ b/express/blocks/banner/banner.js
@@ -1,7 +1,6 @@
 import { normalizeHeadings, createTag } from '../../scripts/utils.js';
 
 export default async function decorate(block) {
-  console.log('are we here', block);
   const isBannerLightVariant = block.classList.contains('light');
   const isBannerStandoutVariant = block.classList.contains('standout');
   const isBannerNarrowVariant = block.classList.contains('narrow');

--- a/express/blocks/banner/banner.js
+++ b/express/blocks/banner/banner.js
@@ -1,8 +1,10 @@
 import { normalizeHeadings, createTag } from '../../scripts/utils.js';
 
 export default async function decorate(block) {
+  console.log('are we here', block);
   const isBannerLightVariant = block.classList.contains('light');
   const isBannerStandoutVariant = block.classList.contains('standout');
+  const isBannerNarrowVariant = block.classList.contains('narrow');
 
   if (isBannerStandoutVariant) {
     const standoutContainer = createTag('div', {
@@ -14,6 +16,14 @@ export default async function decorate(block) {
     }
 
     block.replaceChildren(standoutContainer);
+  }
+
+  if (isBannerNarrowVariant && document.body.dataset.device === 'desktop') {
+    block.classList.add('desktop');
+    block.classList.remove('mobile');
+  } else {
+    block.classList.add('mobile');
+    block.classList.remove('desktop');
   }
 
   normalizeHeadings(block, ['h2', 'h3']);

--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -207,6 +207,12 @@ main .section.columns-container.steps-container div .steps.block div.step-descri
   line-height: 1.28;
 }
 
+main .columns-wrapper .columns.block.narrow-desktop-width {
+  max-width: 850px;
+  margin: 0 auto; 
+  padding: 10px; 
+}
+
 main .columns > div span.num {
   position: relative;
   font-weight: 900;

--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -207,7 +207,7 @@ main .section.columns-container.steps-container div .steps.block div.step-descri
   line-height: 1.28;
 }
 
-main .columns-wrapper .columns.block.narrow-desktop-width {
+main .columns-wrapper .columns.narrow-desktop-width {
   max-width: 850px;
   margin: 0 auto; 
   padding: 10px; 

--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -210,7 +210,6 @@ main .section.columns-container.steps-container div .steps.block div.step-descri
 main .columns-wrapper .columns.narrow-desktop-width {
   max-width: 850px;
   margin: 0 auto; 
-  padding: 10px; 
 }
 
 main .columns > div span.num {

--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -207,7 +207,7 @@ main .section.columns-container.steps-container div .steps.block div.step-descri
   line-height: 1.28;
 }
 
-main .columns-wrapper .columns.narrow-desktop-width {
+main .columns-wrapper .columns.narrow-width {
   max-width: 850px;
   margin: 0 auto; 
 }

--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -207,7 +207,7 @@ main .section.columns-container.steps-container div .steps.block div.step-descri
   line-height: 1.28;
 }
 
-main .columns-wrapper .columns.narrow-width {
+main .columns-wrapper .columns.narrow {
   max-width: 850px;
   margin: 0 auto; 
 }

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -180,11 +180,27 @@ export default async function decorate(block) {
 
   const narrowWidth = getMetadata('narrow-width') === 'on';
   const container = document.querySelector('div.columns.block');
+  const rows = Array.from(block.children);
+
   if (narrowWidth && container) {
     container.classList.add('narrow-width');
+    let count = 1;
+    rows.forEach((ele) => {
+      if (ele.innerHTML.includes('h2')) {
+        const headers = ele.querySelectorAll('h2');
+        headers.forEach((header) => {
+          const span = document.createElement('span');
+          span.style.background = 'linear-gradient(to top, rgb(201, 101, 214), rgb(239, 133, 120))';
+          span.style.webkitBackgroundClip = 'text';
+          span.style.backgroundClip = 'text';
+          span.style.color = 'transparent';
+          span.textContent = `${count}. `;
+          header.prepend(span);
+          count += 1;
+        });
+      }
+    });
   }
-
-  const rows = Array.from(block.children);
 
   let numCols = 0;
   if (rows[0]) numCols = rows[0].children.length;

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -178,6 +178,12 @@ export default async function decorate(block) {
   const colorProperties = extractProperties(block);
   addTempWrapper(block, 'columns');
 
+  const narrowWidth = getMetadata('narrow-width') === 'on';
+  const container = document.querySelector('div.columns.block');
+  if (narrowWidth && container) {
+    container.classList.add('narrow-desktop-width');
+  }
+
   const rows = Array.from(block.children);
 
   let numCols = 0;

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -184,8 +184,8 @@ export default async function decorate(block) {
   if (container?.classList.contains('narrow')) {
     let count = 1;
     rows.forEach((ele) => {
-      if (ele.innerHTML.includes('h2')) {
-        const headers = ele.querySelectorAll('h2');
+      const headers = ele.querySelectorAll('h2');
+      if (headers.length > 0) {
         headers.forEach((header) => {
           const span = document.createElement('span');
           span.style.background = 'linear-gradient(to top, rgb(201, 101, 214), rgb(239, 133, 120))';

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -178,12 +178,10 @@ export default async function decorate(block) {
   const colorProperties = extractProperties(block);
   addTempWrapper(block, 'columns');
 
-  const narrowWidth = getMetadata('narrow-width') === 'on';
   const container = document.querySelector('div.columns.block');
   const rows = Array.from(block.children);
 
-  if (narrowWidth && container) {
-    container.classList.add('narrow-width');
+  if (container?.classList.contains('narrow')) {
     let count = 1;
     rows.forEach((ele) => {
       if (ele.innerHTML.includes('h2')) {

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -181,7 +181,7 @@ export default async function decorate(block) {
   const narrowWidth = getMetadata('narrow-width') === 'on';
   const container = document.querySelector('div.columns.block');
   if (narrowWidth && container) {
-    container.classList.add('narrow-desktop-width');
+    container.classList.add('narrow-width');
   }
 
   const rows = Array.from(block.children);

--- a/express/blocks/faq/faq.css
+++ b/express/blocks/faq/faq.css
@@ -65,7 +65,7 @@ main .faq .faq-answer p {
     margin-top: 0;
 }
 
-main .faq.narrow-desktop-width {
+main .faq.narrow-width {
     max-width: 850px;
     margin: 0 auto; 
 }

--- a/express/blocks/faq/faq.css
+++ b/express/blocks/faq/faq.css
@@ -65,7 +65,7 @@ main .faq .faq-answer p {
     margin-top: 0;
 }
 
-main .faq.block.narrow-desktop-width {
+main .faq.narrow-desktop-width {
     max-width: 850px;
     margin: 0 auto; 
     padding: 10px; 

--- a/express/blocks/faq/faq.css
+++ b/express/blocks/faq/faq.css
@@ -68,7 +68,6 @@ main .faq .faq-answer p {
 main .faq.narrow-desktop-width {
     max-width: 850px;
     margin: 0 auto; 
-    padding: 10px; 
 }
 
 @media (min-width: 900px) {

--- a/express/blocks/faq/faq.css
+++ b/express/blocks/faq/faq.css
@@ -65,12 +65,7 @@ main .faq .faq-answer p {
     margin-top: 0;
 }
 
-main .grid-width-6-desktop.narrow.faq-container .faq {
-    max-width: 850px;
-    margin: 0 auto; 
-}
-
-main .grid-width-6-desktop.narrow.faq-container .default-content-wrapper {
+main .faq-narrow-container {
     max-width: 850px;
     margin: 0 auto; 
 }

--- a/express/blocks/faq/faq.css
+++ b/express/blocks/faq/faq.css
@@ -65,7 +65,12 @@ main .faq .faq-answer p {
     margin-top: 0;
 }
 
-main .faq.narrow-width {
+main .grid-width-6-desktop.narrow.faq-container .faq {
+    max-width: 850px;
+    margin: 0 auto; 
+}
+
+main .grid-width-6-desktop.narrow.faq-container .default-content-wrapper {
     max-width: 850px;
     margin: 0 auto; 
 }

--- a/express/blocks/faq/faq.css
+++ b/express/blocks/faq/faq.css
@@ -65,7 +65,7 @@ main .faq .faq-answer p {
     margin-top: 0;
 }
 
-main .faq-narrow-container {
+main .faq.narrow {
     max-width: 850px;
     margin: 0 auto; 
 }

--- a/express/blocks/faq/faq.css
+++ b/express/blocks/faq/faq.css
@@ -65,6 +65,12 @@ main .faq .faq-answer p {
     margin-top: 0;
 }
 
+main .faq.block.narrow-desktop-width {
+    max-width: 850px;
+    margin: 0 auto; 
+    padding: 10px; 
+}
+
 @media (min-width: 900px) {
     main .section.faq-container > div {
         padding: 0 56px;

--- a/express/blocks/faq/faq.js
+++ b/express/blocks/faq/faq.js
@@ -62,6 +62,12 @@ function decorateFAQBlocks(block) {
 export default async function decorate(block) {
   decorateFAQBlocks(block);
 
+  const narrowWidth = getMetadata('narrow-width') === 'on';
+  const container = document.querySelector('div.faq.block');
+  if (narrowWidth && container) {
+    container.classList.add('narrow-desktop-width');
+  }
+
   const phoneNumberTags = block.querySelectorAll('a[title="{{business-sales-numbers}}"]');
   if (phoneNumberTags.length > 0) {
     const { formatSalesPhoneNumber } = await import('../../scripts/utils/pricing.js');

--- a/express/blocks/faq/faq.js
+++ b/express/blocks/faq/faq.js
@@ -65,7 +65,7 @@ export default async function decorate(block) {
   const narrowWidth = getMetadata('narrow-width') === 'on';
   const container = document.querySelector('div.faq.block');
   if (narrowWidth && container) {
-    container.classList.add('narrow-desktop-width');
+    container.classList.add('narrow-width');
   }
 
   const phoneNumberTags = block.querySelectorAll('a[title="{{business-sales-numbers}}"]');

--- a/express/blocks/faq/faq.js
+++ b/express/blocks/faq/faq.js
@@ -61,13 +61,6 @@ function decorateFAQBlocks(block) {
 
 export default async function decorate(block) {
   decorateFAQBlocks(block);
-
-  const narrowWidth = getMetadata('narrow-width') === 'on';
-  const container = document.querySelector('div.faq.block');
-  if (narrowWidth && container) {
-    container.classList.add('narrow-width');
-  }
-
   const phoneNumberTags = block.querySelectorAll('a[title="{{business-sales-numbers}}"]');
   if (phoneNumberTags.length > 0) {
     const { formatSalesPhoneNumber } = await import('../../scripts/utils/pricing.js');

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -258,7 +258,10 @@
   text-decoration: underline;
   padding-left: 10px;
   padding-right: 10px;
+}
 
+main .fullscreen-marquee-heading h1.narrow-desktop-width {
+  font-size: 45px;
 }
 
 @media (min-width: 900px) {

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -260,7 +260,7 @@
   padding-right: 10px;
 }
 
-main .fullscreen-marquee-heading h1.narrow-desktop-width {
+main .fullscreen-marquee-heading h1.narrow-width {
   font-size: 45px;
 }
 

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -260,7 +260,7 @@
   padding-right: 10px;
 }
 
-main .fullscreen-marquee-heading h1.narrow-width {
+.grid-width-6-desktop.small-header .fullscreen-marquee h1 {
   font-size: 45px;
 }
 

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.js
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.js
@@ -181,8 +181,11 @@ export default async function decorate(block) {
 
   const narrowWidth = getMetadata('narrow-width') === 'on';
   const container = document.querySelector('.fullscreen-marquee-heading > h1');
-  if (narrowWidth && container) {
+  const desktop = document.body.dataset.device === 'desktop';
+  if (narrowWidth && container && desktop) {
     container.classList.add('narrow-desktop-width');
+  } else {
+    container.classList.remove('narrow-desktop-width');
   }
 
   if (content && document.body.dataset.device === 'desktop') {

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.js
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.js
@@ -179,13 +179,10 @@ export default async function decorate(block) {
     block.append(heading);
   }
 
-  const narrowWidth = getMetadata('narrow-width') === 'on';
-  const container = document.querySelector('.fullscreen-marquee-heading > h1');
+  const smallHeaderApplied = block.parentElement.classList.contains('small-header');
   const desktop = document.body.dataset.device === 'desktop';
-  if (narrowWidth && container && desktop) {
-    container.classList.add('narrow-width');
-  } else {
-    container.classList.remove('narrow-width');
+  if (!desktop && smallHeaderApplied) {
+    block.parentElement.classList.remove('small-header');
   }
 
   if (content && document.body.dataset.device === 'desktop') {

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.js
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.js
@@ -3,7 +3,6 @@ import {
   createTag,
   fetchPlaceholders,
   transformLinkToAnimation,
-  getMetadata,
 } from '../../scripts/utils.js';
 import { addFreePlanWidget } from '../../scripts/utils/free-plan.js';
 

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.js
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.js
@@ -183,9 +183,9 @@ export default async function decorate(block) {
   const container = document.querySelector('.fullscreen-marquee-heading > h1');
   const desktop = document.body.dataset.device === 'desktop';
   if (narrowWidth && container && desktop) {
-    container.classList.add('narrow-desktop-width');
+    container.classList.add('narrow-width');
   } else {
-    container.classList.remove('narrow-desktop-width');
+    container.classList.remove('narrow-width');
   }
 
   if (content && document.body.dataset.device === 'desktop') {

--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.js
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.js
@@ -3,6 +3,7 @@ import {
   createTag,
   fetchPlaceholders,
   transformLinkToAnimation,
+  getMetadata,
 } from '../../scripts/utils.js';
 import { addFreePlanWidget } from '../../scripts/utils/free-plan.js';
 
@@ -176,6 +177,12 @@ export default async function decorate(block) {
   if (heading) {
     heading.classList.add('fullscreen-marquee-heading');
     block.append(heading);
+  }
+
+  const narrowWidth = getMetadata('narrow-width') === 'on';
+  const container = document.querySelector('.fullscreen-marquee-heading > h1');
+  if (narrowWidth && container) {
+    container.classList.add('narrow-desktop-width');
   }
 
   if (content && document.body.dataset.device === 'desktop') {

--- a/express/blocks/how-to-steps/how-to-steps.css
+++ b/express/blocks/how-to-steps/how-to-steps.css
@@ -79,16 +79,16 @@ main .how-to-steps .tip-number span {
   transform: translate(-50%, -50%);
 }
 
-main .how-to-steps-inline-tip-narrow-container .how-to-steps.narrow {
+main .how-to-steps.narrow {
   max-width: 850px;
   margin: 0 auto; 
 }
 
-main .how-to-steps-inline-tip-narrow-container .how-to-steps.narrow-mobile-width {
+main .how-to-steps.narrow-mobile-width {
   max-width: none;
 }
 
-main .how-to-steps-inline-tip-narrow-container .how-to-steps.narrow h3 {
+main .how-to-steps.narrow h3 {
   font-size: 28px;
 }
 
@@ -102,8 +102,54 @@ main .how-to-steps.inline-tip.narrow-mobile-width .tip .tip-number {
 }
 
 main .how-to-steps .narrow {
-    max-width: 850px;
-    margin: 0 auto; 
+  max-width: 850px;
+  margin: 0 auto; 
+}
+
+.template-x-container {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+main .section .template-x-heading {
+  font-weight: normal;
+  margin-top: 10px;
+  margin-bottom: 20px;
+  text-align: left;
+}
+
+.template-x-thumbnail picture img {
+  width: 200px; 
+  height: auto;  
+}
+
+.image-wrapper {
+  padding: 10px;
+  background-color: #ffffff;
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 8px;
+  border-radius: 15px;
+  z-index: 100;
+}
+
+/* Ensure the CTA button is hidden initially */
+.image-wrapper .edit-template-button {
+  display: none;
+}
+
+/* Show the CTA button when the .button-container is hovered */
+.button-container:hover .edit-template-button {
+  display: block;
+  position: absolute;
+  top: 50%; /* Adjust to desired position */
+  left: 50%;
+  transform: translate(-50%, -50%); /* Center the button */
+  z-index: 10; /* Ensure the button appears above the image */
+  background-color: var(--color-info-accent-light);
+  border: none;
+  padding: 10px 20px;
+  color: white;
+  cursor: pointer;
 }
 
 @media (min-width: 600px) {

--- a/express/blocks/how-to-steps/how-to-steps.css
+++ b/express/blocks/how-to-steps/how-to-steps.css
@@ -119,6 +119,9 @@ main .section .template-x-heading {
   text-align: left;
 }
 
+.hover-container {
+}
+
 .template-x-thumbnail picture img {
   width: 200px; 
   height: auto;  
@@ -130,6 +133,13 @@ main .section .template-x-heading {
   box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 8px;
   border-radius: 15px;
   z-index: 100;
+  position: relative;
+  z-index: 10;
+}
+
+.enlarged-template-img {
+  border-radius: 10px;
+  object-fit: cover;
 }
 
 /* Ensure the CTA button is hidden initially */

--- a/express/blocks/how-to-steps/how-to-steps.css
+++ b/express/blocks/how-to-steps/how-to-steps.css
@@ -79,7 +79,7 @@ main .how-to-steps .tip-number span {
   transform: translate(-50%, -50%);
 }
 
-main .how-to-steps-inline-tip-container .how-to-steps.narrow-desktop-width {
+main .how-to-steps-inline-tip-container .how-to-steps.narrow-width {
   max-width: 850px;
   margin: 0 auto; 
 }
@@ -88,11 +88,11 @@ main .how-to-steps-inline-tip-container .how-to-steps.narrow-mobile-width {
   max-width: 'none';
 }
 
-main .how-to-steps-inline-tip-container .how-to-steps.narrow-desktop-width h3 {
+main .how-to-steps-inline-tip-container .how-to-steps.narrow-width h3 {
   font-size: 28px;
 }
 
-main .how-to-steps.inline-tip.narrow-desktop-width .tip .tip-number {
+main .how-to-steps.inline-tip.narrow-width .tip .tip-number {
   width: 40px;
   min-width: 40px;
   height: 40px;
@@ -108,7 +108,7 @@ main .how-to-steps.inline-tip.narrow-mobile-width .tip .tip-number {
   font-size: 22px;
 }
 
-main .how-to-steps .narrow-desktop-width {
+main .how-to-steps .narrow-width {
     max-width: 850px;
     margin: 0 auto; 
 }

--- a/express/blocks/how-to-steps/how-to-steps.css
+++ b/express/blocks/how-to-steps/how-to-steps.css
@@ -119,12 +119,14 @@ main .section .template-x-heading {
   text-align: left;
 }
 
-.hover-container {
-}
-
 .template-x-thumbnail picture img {
   width: 200px; 
   height: auto;  
+}
+
+.template-x-thumbnail picture img.icon-share-arrow {
+  width: 14px;
+  height: auto;
 }
 
 .image-wrapper {
@@ -140,6 +142,29 @@ main .section .template-x-heading {
 .enlarged-template-img {
   border-radius: 10px;
   object-fit: cover;
+}
+
+.share-icon-wrapper {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 20; /* Ensure it is above other elements */
+  width: 24px; /* Adjust size as needed */
+  height: 24px;
+  background-color: white; /* White background for the circle */
+  border-radius: 50%; /* Makes the background a circle */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 8px;
+  margin-top: 4px;
+  cursor: pointer;
+}
+
+.share-icon-wrapper svg {
+  width: 16px;  /* Adjust size to make it smaller */
+  height: 16px;
+  cursor: pointer;
 }
 
 /* Ensure the CTA button is hidden initially */

--- a/express/blocks/how-to-steps/how-to-steps.css
+++ b/express/blocks/how-to-steps/how-to-steps.css
@@ -85,21 +85,14 @@ main .how-to-steps-inline-tip-narrow-container .how-to-steps.narrow {
 }
 
 main .how-to-steps-inline-tip-narrow-container .how-to-steps.narrow-mobile-width {
-  max-width: 'none';
+  max-width: none;
 }
 
 main .how-to-steps-inline-tip-narrow-container .how-to-steps.narrow h3 {
   font-size: 28px;
 }
 
-main .how-to-steps.inline-tip.narrow .tip .tip-number {
-  width: 40px;
-  min-width: 40px;
-  height: 40px;
-  min-height: 40px;
-  font-size: 22px;
-}
-
+main .how-to-steps.inline-tip.narrow .tip .tip-number,
 main .how-to-steps.inline-tip.narrow-mobile-width .tip .tip-number {
   width: 40px;
   min-width: 40px;

--- a/express/blocks/how-to-steps/how-to-steps.css
+++ b/express/blocks/how-to-steps/how-to-steps.css
@@ -84,6 +84,30 @@ main .how-to-steps-inline-tip-container .how-to-steps.narrow-desktop-width {
   margin: 0 auto; 
 }
 
+main .how-to-steps-inline-tip-container .how-to-steps.narrow-mobile-width {
+  max-width: 'none';
+}
+
+main .how-to-steps-inline-tip-container .how-to-steps.narrow-desktop-width h3 {
+  font-size: 28px;
+}
+
+main .how-to-steps.inline-tip.narrow-desktop-width .tip .tip-number {
+  width: 40px;
+  margin-left: 28px;
+  min-width: 40px;
+  height: 40px;
+  min-height: 40px;
+  font-size: 22px;
+}
+
+main .how-to-steps.inline-tip.narrow-mobile-width .tip .tip-number {
+  width: 40px;
+  min-width: 40px;
+  height: 40px;
+  min-height: 40px;
+  font-size: 22px;
+}
 
 main .how-to-steps .narrow-desktop-width {
     max-width: 850px;

--- a/express/blocks/how-to-steps/how-to-steps.css
+++ b/express/blocks/how-to-steps/how-to-steps.css
@@ -79,20 +79,20 @@ main .how-to-steps .tip-number span {
   transform: translate(-50%, -50%);
 }
 
-main .how-to-steps-inline-tip-container .how-to-steps.narrow-width {
+main .how-to-steps-inline-tip-narrow-container .how-to-steps.narrow {
   max-width: 850px;
   margin: 0 auto; 
 }
 
-main .how-to-steps-inline-tip-container .how-to-steps.narrow-mobile-width {
+main .how-to-steps-inline-tip-narrow-container .how-to-steps.narrow-mobile-width {
   max-width: 'none';
 }
 
-main .how-to-steps-inline-tip-container .how-to-steps.narrow-width h3 {
+main .how-to-steps-inline-tip-narrow-container .how-to-steps.narrow h3 {
   font-size: 28px;
 }
 
-main .how-to-steps.inline-tip.narrow-width .tip .tip-number {
+main .how-to-steps.inline-tip.narrow .tip .tip-number {
   width: 40px;
   min-width: 40px;
   height: 40px;
@@ -108,7 +108,7 @@ main .how-to-steps.inline-tip.narrow-mobile-width .tip .tip-number {
   font-size: 22px;
 }
 
-main .how-to-steps .narrow-width {
+main .how-to-steps .narrow {
     max-width: 850px;
     margin: 0 auto; 
 }

--- a/express/blocks/how-to-steps/how-to-steps.css
+++ b/express/blocks/how-to-steps/how-to-steps.css
@@ -79,14 +79,14 @@ main .how-to-steps .tip-number span {
   transform: translate(-50%, -50%);
 }
 
-main .how-to-steps-inline-tip-container .how-to-steps.block.narrow-desktop-width {
+main .how-to-steps-inline-tip-container .how-to-steps.narrow-desktop-width {
   max-width: 850px;
   margin: 0 auto; 
   padding: 10px; 
 }
 
 
-main .how-to-steps .block .narrow-desktop-width {
+main .how-to-steps .narrow-desktop-width {
     max-width: 850px;
     margin: 0 auto; 
     padding: 10px;  

--- a/express/blocks/how-to-steps/how-to-steps.css
+++ b/express/blocks/how-to-steps/how-to-steps.css
@@ -85,7 +85,7 @@ main .how-to-steps.narrow {
 }
 
 main .how-to-steps.narrow-mobile-width {
-  max-width: none;
+  max-width: 375px;
 }
 
 main .how-to-steps.narrow h3 {
@@ -114,12 +114,22 @@ main .section .template-x-container .template-x-heading {
   text-align: center;
 }
 
-main .section .template-x-container.desktop, 
+main .section .template-x-container.desktop {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  text-align: left;
+  margin-left: 60px;
+  margin-right: 60px;
+}
+
 main .section .template-x-container.desktop .template-x-heading {
   display: flex;
   flex-direction: column;
   gap: 10px;
   text-align: left;
+  margin-left: 0px;
+  margin-right: 0px;
 }
 
 main .section .template-x-heading {

--- a/express/blocks/how-to-steps/how-to-steps.css
+++ b/express/blocks/how-to-steps/how-to-steps.css
@@ -106,10 +106,20 @@ main .how-to-steps .narrow {
   margin: 0 auto; 
 }
 
-.template-x-container {
+main .section .template-x-container, 
+main .section .template-x-container .template-x-heading {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  text-align: center;
+}
+
+main .section .template-x-container.desktop, 
+main .section .template-x-container.desktop .template-x-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  text-align: left;
 }
 
 main .section .template-x-heading {
@@ -172,8 +182,16 @@ main .section .template-x-heading {
   display: none;
 }
 
-.button-container {
+.button-container.template-x {
   display: none;
+}
+
+.button-container.template-x.visible {
+  position: relative;
+  margin-top: 5px;
+  display: flex;
+  justify-content: center;
+  width: 100%;
 }
 
 .button-container:hover .edit-template-button {

--- a/express/blocks/how-to-steps/how-to-steps.css
+++ b/express/blocks/how-to-steps/how-to-steps.css
@@ -79,6 +79,19 @@ main .how-to-steps .tip-number span {
   transform: translate(-50%, -50%);
 }
 
+main .how-to-steps-inline-tip-container .how-to-steps.block.narrow-desktop-width {
+  max-width: 850px;
+  margin: 0 auto; 
+  padding: 10px; 
+}
+
+
+main .how-to-steps .block .narrow-desktop-width {
+    max-width: 850px;
+    margin: 0 auto; 
+    padding: 10px;  
+}
+
 @media (min-width: 600px) {
   main .how-to-steps .tip-number {
     width: 70px;

--- a/express/blocks/how-to-steps/how-to-steps.css
+++ b/express/blocks/how-to-steps/how-to-steps.css
@@ -82,14 +82,12 @@ main .how-to-steps .tip-number span {
 main .how-to-steps-inline-tip-container .how-to-steps.narrow-desktop-width {
   max-width: 850px;
   margin: 0 auto; 
-  padding: 10px; 
 }
 
 
 main .how-to-steps .narrow-desktop-width {
     max-width: 850px;
     margin: 0 auto; 
-    padding: 10px;  
 }
 
 @media (min-width: 600px) {

--- a/express/blocks/how-to-steps/how-to-steps.css
+++ b/express/blocks/how-to-steps/how-to-steps.css
@@ -172,6 +172,10 @@ main .section .template-x-heading {
   display: none;
 }
 
+.button-container {
+  display: none;
+}
+
 /* Show the CTA button when the .button-container is hovered */
 .button-container:hover .edit-template-button {
   display: block;

--- a/express/blocks/how-to-steps/how-to-steps.css
+++ b/express/blocks/how-to-steps/how-to-steps.css
@@ -114,6 +114,7 @@ main .how-to-steps .narrow {
 
 main .section .template-x-heading {
   font-weight: normal;
+  font-size: var(--body-font-size-xl);
   margin-top: 10px;
   margin-bottom: 20px;
   text-align: left;
@@ -148,11 +149,11 @@ main .section .template-x-heading {
   position: absolute;
   top: 10px;
   right: 10px;
-  z-index: 20; /* Ensure it is above other elements */
-  width: 24px; /* Adjust size as needed */
+  z-index: 20;
+  width: 24px;
   height: 24px;
-  background-color: white; /* White background for the circle */
-  border-radius: 50%; /* Makes the background a circle */
+  background-color: white;
+  border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -162,12 +163,11 @@ main .section .template-x-heading {
 }
 
 .share-icon-wrapper svg {
-  width: 16px;  /* Adjust size to make it smaller */
+  width: 16px; 
   height: 16px;
   cursor: pointer;
 }
 
-/* Ensure the CTA button is hidden initially */
 .image-wrapper .edit-template-button {
   display: none;
 }
@@ -176,14 +176,13 @@ main .section .template-x-heading {
   display: none;
 }
 
-/* Show the CTA button when the .button-container is hovered */
 .button-container:hover .edit-template-button {
   display: block;
   position: absolute;
-  top: 50%; /* Adjust to desired position */
+  top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%); /* Center the button */
-  z-index: 10; /* Ensure the button appears above the image */
+  transform: translate(-50%, -50%);
+  z-index: 10;
   background-color: var(--color-info-accent-light);
   border: none;
   padding: 10px 20px;

--- a/express/blocks/how-to-steps/how-to-steps.css
+++ b/express/blocks/how-to-steps/how-to-steps.css
@@ -94,7 +94,6 @@ main .how-to-steps-inline-tip-container .how-to-steps.narrow-desktop-width h3 {
 
 main .how-to-steps.inline-tip.narrow-desktop-width .tip .tip-number {
   width: 40px;
-  margin-left: 28px;
   min-width: 40px;
   height: 40px;
   min-height: 40px;

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -2,6 +2,7 @@
 
 import {
   createTag,
+  getIconElement,
 // eslint-disable-next-line import/no-unresolved
 } from '../../scripts/utils.js';
 
@@ -49,6 +50,25 @@ export default function decorate(block, name, doc) {
         // Ensure the parent row is relatively positioned
         row.style.position = 'relative';
 
+        // Create and append the share icon to the hover container
+        const wrapper = createTag('div', { class: 'share-icon-wrapper' });
+        const shareIcon = getIconElement('share-arrow');
+        wrapper.appendChild(shareIcon);
+        hoverContainer.appendChild(wrapper);
+
+        // Add click event listener to the share icon
+        shareIcon.addEventListener('click', () => {
+          console.log('clicked');
+          const href = document.querySelector('.button-container > a')?.href;
+          if (href) {
+            navigator.clipboard.writeText(href).then(() => {
+              console.log('href copied to clipboard');
+            }).catch((err) => {
+              console.error('Failed to copy href: ', err);
+            });
+          }
+        });
+
         const imageWrapper = createTag('div', { class: 'image-wrapper' });
 
         // Clone the original image to create an enlarged version
@@ -88,7 +108,7 @@ export default function decorate(block, name, doc) {
             console.log('Mouse left hover container:', hoverContainer);
 
             // Remove the hover container when the mouse leaves
-            hoverContainer.remove();
+            // hoverContainer.remove();
             hoverContainer = null; // Reset the hover container reference
           }
         });
@@ -103,6 +123,7 @@ export default function decorate(block, name, doc) {
     if (templateXVariant && row.querySelector('picture')) {
       row.classList.add('template-x-thumbnail');
       const imgElement = row.querySelector('picture img');
+      imgElement.style.borderRadius = '10px';
       const buttonContainer = row.querySelector('.button-container'); // Assume each row has a button-container
 
       // Call the function to handle hover effect

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -22,6 +22,7 @@ export default function decorate(block, name, doc) {
   const desktop = document.body.dataset.device === 'desktop';
   if (desktop && narrowVariant && container) {
     container.classList.add('narrow');
+    container.classList.remove('narrow-mobile-width');
   } else if (narrowVariant && container) {
     container.classList.remove('narrow');
     container.classList.add('narrow-mobile-width');

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -66,7 +66,11 @@ export default function decorate($block, name, doc) {
     $cells[0].remove();
     $cells[1].innerHTML = '';
     $cells[1].classList.add('tip');
-    $cells[1].style.maxWidth = '600px';
+    if (narrowWidth && desktop) {
+      $cells[1].style.maxWidth = '750px';
+    } else {
+      $cells[1].style.maxWidth = '600px';
+    }
     $cells[1].style.margin = '0 auto';
     $cells[1].append($text);
   });

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -13,8 +13,12 @@ export default function decorate($block, name, doc) {
 
   const narrowWidth = getMetadata('narrow-width') === 'on';
   const container = document.querySelector('div.how-to-steps.block');
-  if (narrowWidth && container) {
+  const desktop = document.body.dataset.device === 'desktop';
+  if (desktop && narrowWidth && container) {
     container.classList.add('narrow-desktop-width');
+  } else if (narrowWidth && container) {
+    container.classList.remove('narrow-desktop-width');
+    container.classList.add('narrow-mobile-width');
   }
 
   const includeSchema = !$block.classList.contains('noschema');

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -36,7 +36,7 @@ export default function decorate(block, name, doc) {
     step: [],
   };
 
-  function createHoverContainer(imgElement, row, buttonContainer) {
+  function renderHoverContainer(imgElement, row, buttonContainer) {
     let hoverContainer;
 
     imgElement.addEventListener('mouseenter', () => {
@@ -49,6 +49,8 @@ export default function decorate(block, name, doc) {
         const shareIcon = getIconElement('share-arrow');
         wrapper.appendChild(shareIcon);
         hoverContainer.appendChild(wrapper);
+
+        buttonContainer.classList.add('visible');
 
         shareIcon.addEventListener('click', () => {
           if (templateHref) {
@@ -70,12 +72,6 @@ export default function decorate(block, name, doc) {
         hoverContainer.style.top = `${imgElement.offsetTop - (imgElement.offsetHeight * 0.1) - 10}px`;
         hoverContainer.style.left = `${imgElement.offsetLeft - (imgElement.offsetWidth * 0.1) - 10}px`;
 
-        buttonContainer.style.position = 'relative';
-        buttonContainer.style.marginTop = '10px';
-        buttonContainer.style.display = 'flex';
-        buttonContainer.style.justifyContent = 'center';
-        buttonContainer.style.width = '100%';
-
         imageWrapper.appendChild(enlargedImg);
         imageWrapper.appendChild(buttonContainer);
         hoverContainer.appendChild(imageWrapper);
@@ -83,6 +79,7 @@ export default function decorate(block, name, doc) {
 
         hoverContainer.addEventListener('mouseleave', () => {
           if (hoverContainer) {
+            buttonContainer.classList.remove('visible');
             hoverContainer.remove();
             hoverContainer = null;
           }
@@ -93,14 +90,21 @@ export default function decorate(block, name, doc) {
 
   const templateXVariant = block?.classList.contains('template-x');
   const templateXContainer = templateXVariant && createTag('div', { class: 'template-x-container' });
+  if (document.body.dataset.device === 'desktop') {
+    templateXContainer.classList.add('desktop');
+  } else {
+    templateXContainer.classList.remove('desktop');
+  }
 
   rows.forEach((row, i) => {
     if (templateXVariant && row.querySelector('picture')) {
       row.classList.add('template-x-thumbnail');
+
       const imgElement = row.querySelector('picture img');
       imgElement.style.borderRadius = '10px';
       const buttonContainer = row.querySelector('.button-container');
-      createHoverContainer(imgElement, row, buttonContainer);
+      buttonContainer.classList.add('template-x');
+      renderHoverContainer(imgElement, row, buttonContainer);
       const templateXText = row.lastElementChild;
       const text = templateXText?.textContent.trim();
       const templateXHeading = createTag('h4', { class: 'template-x-heading' }, text);

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -44,30 +44,21 @@ export default function decorate(block, name, doc) {
         console.log('Mouse entered image:', imgElement);
 
         // Create a new div element for the hover container
-        hoverContainer = document.createElement('div');
-
-        // Add a class to identify this container
-        // hoverContainer.classList.add('jackson');
+        hoverContainer = document.createElement('div', { class: 'hover-container' });
 
         // Ensure the parent row is relatively positioned
         row.style.position = 'relative';
 
         const imageWrapper = createTag('div', { class: 'image-wrapper' });
-        imageWrapper.style.position = 'relative';
-        imageWrapper.style.zIndex = '10'; // Ensure the background is on top
 
         // Clone the original image to create an enlarged version
         const enlargedImg = imgElement.cloneNode(true);
-
-        // Set the styles to make the enlarged image visible and positioned correctly
-        enlargedImg.style.width = `${imgElement.offsetWidth * 1.2}px`; // 20% larger than the original image width
-        enlargedImg.style.height = `${imgElement.offsetHeight * 1.2}px`; //
-        enlargedImg.style.objectFit = 'cover';
-        // Round the corners of the enlarged image
-        enlargedImg.style.borderRadius = '10px'; // Adjust the value as needed
+        enlargedImg.classList.add('enlarged-template-img');
+        enlargedImg.style.width = `${imgElement.offsetWidth * 1.2}px`;
+        enlargedImg.style.height = `${imgElement.offsetHeight * 1.2}px`;
 
         // Prevent the hover container from blocking mouse events
-        hoverContainer.style.pointerEvents = 'none';
+        hoverContainer.style.pointerEvents = 'auto'; // Allow mouse events on the hover container
         hoverContainer.style.position = 'absolute';
         hoverContainer.style.top = `${imgElement.offsetTop - (imgElement.offsetHeight * 0.1) - 10}px`; // Adjust for padding
         hoverContainer.style.left = `${imgElement.offsetLeft - (imgElement.offsetWidth * 0.1) - 10}px`;
@@ -91,17 +82,16 @@ export default function decorate(block, name, doc) {
         // Append the hover container to the row, over the image
         imgElement.parentElement.appendChild(hoverContainer);
 
-        console.log('Hover container with enlarged image and button added:', hoverContainer);
-      }
-    });
+        // Add the mouseleave event listener to the hoverContainer
+        hoverContainer.addEventListener('mouseleave', () => {
+          if (hoverContainer) { // Ensure the container exists before trying to remove it
+            console.log('Mouse left hover container:', hoverContainer);
 
-    imgElement.addEventListener('mouseleave', () => {
-      if (hoverContainer) { // Ensure the container exists before trying to remove it
-        console.log('Mouse left image:', imgElement);
-
-        // Remove the hover container when the mouse leaves
-        hoverContainer.remove();
-        hoverContainer = null; // Reset the hover container reference
+            // Remove the hover container when the mouse leaves
+            hoverContainer.remove();
+            hoverContainer = null; // Reset the hover container reference
+          }
+        });
       }
     });
   }
@@ -111,7 +101,6 @@ export default function decorate(block, name, doc) {
 
   rows.forEach((row, i) => {
     if (templateXVariant && row.querySelector('picture')) {
-      console.log('row', row);
       row.classList.add('template-x-thumbnail');
       const imgElement = row.querySelector('picture img');
       const buttonContainer = row.querySelector('.button-container'); // Assume each row has a button-container

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -11,6 +11,13 @@ export default function decorate($block, name, doc) {
   const $heading = $howto.closest('.section').querySelector('h2, h3, h4');
   const $rows = Array.from($howto.children);
 
+  let numberStepStart = 1;
+  if ($rows.length > 0) {
+    const firstRow = $rows[0];
+    numberStepStart = +firstRow.querySelectorAll('div')[1].innerText.trim();
+    $rows[0].remove();
+  }
+
   const narrowWidth = getMetadata('narrow-width') === 'on';
   const container = document.querySelector('div.how-to-steps.block');
   const desktop = document.body.dataset.device === 'desktop';
@@ -41,37 +48,19 @@ export default function decorate($block, name, doc) {
         text: $cells[1].textContent.trim(),
       },
     });
-
     const $h3 = createTag('h3');
     $h3.innerHTML = $cells[0].textContent.trim();
-    $h3.style.flex = '1';
-
     const $p = createTag('p');
     $p.innerHTML = $cells[1].innerHTML;
-
-    const $headerWrapper = createTag('div', { class: 'header-wrapper' });
-    $headerWrapper.style.display = 'flex';
-    $headerWrapper.style.alignItems = 'center';
-    $headerWrapper.style.gap = '8px';
-
-    const $number = createTag('div', { class: 'tip-number' });
-    $number.innerHTML = `<span>${i + 1}</span>`;
-    $number.style.flex = 'none';
-
-    $headerWrapper.append($number);
-    $headerWrapper.append($h3);
     const $text = createTag('div', { class: 'tip-text' });
-    $text.append($headerWrapper);
+    $text.append($h3);
     $text.append($p);
+    const $number = createTag('div', { class: 'tip-number' });
+    $number.innerHTML = `<span>${i + numberStepStart - 1}</span>`;
     $cells[0].remove();
     $cells[1].innerHTML = '';
     $cells[1].classList.add('tip');
-    if (narrowWidth && desktop) {
-      $cells[1].style.maxWidth = '750px';
-    } else {
-      $cells[1].style.maxWidth = '600px';
-    }
-    $cells[1].style.margin = '0 auto';
+    $cells[1].append($number);
     $cells[1].append($text);
   });
 

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -60,6 +60,7 @@ export default function decorate(block, name, doc) {
         shareIcon.addEventListener('click', () => {
           console.log('clicked');
           const href = document.querySelector('.button-container > a')?.href;
+          console.log('href', href);
           if (href) {
             navigator.clipboard.writeText(href).then(() => {
               console.log('href copied to clipboard');
@@ -108,7 +109,7 @@ export default function decorate(block, name, doc) {
             console.log('Mouse left hover container:', hoverContainer);
 
             // Remove the hover container when the mouse leaves
-            // hoverContainer.remove();
+            hoverContainer.remove();
             hoverContainer = null; // Reset the hover container reference
           }
         });

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -2,7 +2,6 @@
 
 import {
   createTag,
-  getMetadata,
 // eslint-disable-next-line import/no-unresolved
 } from '../../scripts/utils.js';
 
@@ -18,13 +17,13 @@ export default function decorate($block, name, doc) {
     $rows[0].remove();
   }
 
-  const narrowWidth = getMetadata('narrow-width') === 'on';
+  const narrowVariant = $block?.classList.contains('narrow');
   const container = document.querySelector('div.how-to-steps.block');
   const desktop = document.body.dataset.device === 'desktop';
-  if (desktop && narrowWidth && container) {
-    container.classList.add('narrow-width');
-  } else if (narrowWidth && container) {
-    container.classList.remove('narrow-width');
+  if (desktop && narrowVariant && container) {
+    container.classList.add('narrow');
+  } else if (narrowVariant && container) {
+    container.classList.remove('narrow');
     container.classList.add('narrow-mobile-width');
   }
 

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -5,19 +5,19 @@ import {
 // eslint-disable-next-line import/no-unresolved
 } from '../../scripts/utils.js';
 
-export default function decorate($block, name, doc) {
-  const $howto = $block;
-  const $heading = $howto.closest('.section').querySelector('h2, h3, h4');
-  const $rows = Array.from($howto.children);
+export default function decorate(block, name, doc) {
+  const howto = block;
+  const heading = howto.closest('.section').querySelector('h2, h3, h4');
+  const rows = Array.from(howto.children);
 
   let numberStepStart = 1;
-  const isStepNumberDefined = $rows[0].innerHTML.includes('number-step-start');
+  const isStepNumberDefined = rows[0].innerHTML.includes('number-step-start');
   if (isStepNumberDefined) {
-    numberStepStart = +$rows[0].querySelectorAll('div')[1].innerText.trim();
-    $rows[0].remove();
+    numberStepStart = +rows[0].querySelectorAll('div')[1].innerText.trim();
+    rows[0].remove();
   }
 
-  const narrowVariant = $block?.classList.contains('narrow');
+  const narrowVariant = block?.classList.contains('narrow');
   const container = document.querySelector('div.how-to-steps.block');
   const desktop = document.body.dataset.device === 'desktop';
   if (desktop && narrowVariant && container) {
@@ -27,45 +27,140 @@ export default function decorate($block, name, doc) {
     container.classList.add('narrow-mobile-width');
   }
 
-  const includeSchema = !$block.classList.contains('noschema');
+  const includeSchema = !block.classList.contains('noschema');
 
   const schema = {
     '@context': 'http://schema.org',
     '@type': 'HowTo',
-    name: ($heading && $heading.textContent.trim()) || document.title,
+    name: (heading && heading.textContent.trim()) || document.title,
     step: [],
   };
 
-  $rows.forEach(($row, i) => {
-    const $cells = Array.from($row.children);
-    schema.step.push({
-      '@type': 'HowToStep',
-      position: i + 1,
-      name: $cells[0].textContent.trim(),
-      itemListElement: {
-        '@type': 'HowToDirection',
-        text: $cells[1].textContent.trim(),
-      },
+  function createHoverContainer(imgElement, row, buttonContainer) {
+    let hoverContainer;
+
+    imgElement.addEventListener('mouseenter', () => {
+      if (!hoverContainer) { // Ensure the container is not already created
+        console.log('Mouse entered image:', imgElement);
+
+        // Create a new div element for the hover container
+        hoverContainer = document.createElement('div');
+
+        // Add a class to identify this container
+        // hoverContainer.classList.add('jackson');
+
+        // Ensure the parent row is relatively positioned
+        row.style.position = 'relative';
+
+        const imageWrapper = createTag('div', { class: 'image-wrapper' });
+        imageWrapper.style.position = 'relative';
+        imageWrapper.style.zIndex = '10'; // Ensure the background is on top
+
+        // Clone the original image to create an enlarged version
+        const enlargedImg = imgElement.cloneNode(true);
+
+        // Set the styles to make the enlarged image visible and positioned correctly
+        enlargedImg.style.width = `${imgElement.offsetWidth * 1.2}px`; // 20% larger than the original image width
+        enlargedImg.style.height = `${imgElement.offsetHeight * 1.2}px`; //
+        enlargedImg.style.objectFit = 'cover';
+        // Round the corners of the enlarged image
+        enlargedImg.style.borderRadius = '10px'; // Adjust the value as needed
+
+        // Prevent the hover container from blocking mouse events
+        hoverContainer.style.pointerEvents = 'none';
+        hoverContainer.style.position = 'absolute';
+        hoverContainer.style.top = `${imgElement.offsetTop - (imgElement.offsetHeight * 0.1) - 10}px`; // Adjust for padding
+        hoverContainer.style.left = `${imgElement.offsetLeft - (imgElement.offsetWidth * 0.1) - 10}px`;
+
+        // Ensure the button container is positioned below the enlarged image within the wrapper
+        buttonContainer.style.position = 'relative';
+        buttonContainer.style.marginTop = '10px'; // Add some space between the image and the button
+        buttonContainer.style.display = 'flex';
+        buttonContainer.style.justifyContent = 'center'; // Center the button horizontally
+        buttonContainer.style.width = '100%';
+
+        // Append the enlarged image to the image wrapper
+        imageWrapper.appendChild(enlargedImg);
+
+        // Append the button container to the image wrapper
+        imageWrapper.appendChild(buttonContainer);
+
+        // Append the image wrapper to the hover container
+        hoverContainer.appendChild(imageWrapper);
+
+        // Append the hover container to the row, over the image
+        imgElement.parentElement.appendChild(hoverContainer);
+
+        console.log('Hover container with enlarged image and button added:', hoverContainer);
+      }
     });
-    const $h3 = createTag('h3');
-    $h3.innerHTML = $cells[0].textContent.trim();
-    const $p = createTag('p');
-    $p.innerHTML = $cells[1].innerHTML;
-    const $text = createTag('div', { class: 'tip-text' });
-    $text.append($h3);
-    $text.append($p);
-    const $number = createTag('div', { class: 'tip-number' }, `<span>${i + numberStepStart - 1}</span>`);
-    $cells[0].remove();
-    $cells[1].innerHTML = '';
-    $cells[1].classList.add('tip');
-    $cells[1].append($number);
-    $cells[1].append($text);
+
+    imgElement.addEventListener('mouseleave', () => {
+      if (hoverContainer) { // Ensure the container exists before trying to remove it
+        console.log('Mouse left image:', imgElement);
+
+        // Remove the hover container when the mouse leaves
+        hoverContainer.remove();
+        hoverContainer = null; // Reset the hover container reference
+      }
+    });
+  }
+
+  const templateXVariant = block?.classList.contains('template-x');
+  const templateXContainer = templateXVariant && createTag('div', { class: 'template-x-container' });
+
+  rows.forEach((row, i) => {
+    if (templateXVariant && row.querySelector('picture')) {
+      console.log('row', row);
+      row.classList.add('template-x-thumbnail');
+      const imgElement = row.querySelector('picture img');
+      const buttonContainer = row.querySelector('.button-container'); // Assume each row has a button-container
+
+      // Call the function to handle hover effect
+      createHoverContainer(imgElement, row, buttonContainer);
+
+      const templateXText = row.lastElementChild;
+      const text = templateXText?.textContent.trim();
+      const templateXHeading = createTag('h4', { class: 'template-x-heading' }, text);
+      row.insertBefore(templateXHeading, row.firstChild);
+      if (templateXText) {
+        templateXText.remove();
+      }
+
+      templateXContainer.appendChild(row);
+    } else {
+      const cells = Array.from(row.children);
+      schema.step.push({
+        '@type': 'HowToStep',
+        position: i + 1,
+        name: cells[0].textContent.trim(),
+        itemListElement: {
+          '@type': 'HowToDirection',
+          text: cells[1].textContent.trim(),
+        },
+      });
+      const h3 = createTag('h3');
+      h3.innerHTML = cells[0].textContent.trim();
+      const p = createTag('p');
+      p.innerHTML = cells[1].innerHTML;
+      const text = createTag('div', { class: 'tip-text' });
+      text.append(h3);
+      text.append(p);
+      const number = createTag('div', { class: 'tip-number' }, `<span>${i + numberStepStart - 1}</span>`);
+      cells[0].remove();
+      cells[1].innerHTML = '';
+      cells[1].classList.add('tip');
+      cells[1].append(number);
+      cells[1].append(text);
+    }
   });
 
+  templateXVariant && block.appendChild(templateXContainer);
+
   if (includeSchema) {
-    const $schema = createTag('script', { type: 'application/ld+json' });
-    $schema.innerHTML = JSON.stringify(schema);
-    const $head = doc.head;
-    $head.append($schema);
+    const schemaTag = createTag('script', { type: 'application/ld+json' });
+    schemaTag.innerHTML = JSON.stringify(schema);
+    const docHead = doc.head;
+    docHead.append(schemaTag);
   }
 }

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -41,31 +41,22 @@ export default function decorate(block, name, doc) {
     let hoverContainer;
 
     imgElement.addEventListener('mouseenter', () => {
-      if (!hoverContainer) { // Ensure the container is not already created
-        console.log('Mouse entered image:', imgElement);
-
-        // Create a new div element for the hover container
+      if (!hoverContainer) {
+        const templateHref = buttonContainer.querySelector('a').href;
         hoverContainer = document.createElement('div', { class: 'hover-container' });
-
-        // Ensure the parent row is relatively positioned
         row.style.position = 'relative';
 
-        // Create and append the share icon to the hover container
         const wrapper = createTag('div', { class: 'share-icon-wrapper' });
         const shareIcon = getIconElement('share-arrow');
         wrapper.appendChild(shareIcon);
         hoverContainer.appendChild(wrapper);
 
-        // Add click event listener to the share icon
         shareIcon.addEventListener('click', () => {
-          console.log('clicked');
-          const href = document.querySelector('.button-container > a')?.href;
-          console.log('href', href);
-          if (href) {
-            navigator.clipboard.writeText(href).then(() => {
-              console.log('href copied to clipboard');
+          if (templateHref) {
+            navigator.clipboard.writeText(templateHref).then(() => {
+              console.log('template-x link copied');
             }).catch((err) => {
-              console.error('Failed to copy href: ', err);
+              console.error('Failed to copy template-x link: ', err);
             });
           }
         });
@@ -106,7 +97,7 @@ export default function decorate(block, name, doc) {
         // Add the mouseleave event listener to the hoverContainer
         hoverContainer.addEventListener('mouseleave', () => {
           if (hoverContainer) { // Ensure the container exists before trying to remove it
-            console.log('Mouse left hover container:', hoverContainer);
+            // console.log('Mouse left hover container:', hoverContainer);
 
             // Remove the hover container when the mouse leaves
             hoverContainer.remove();

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -41,19 +41,33 @@ export default function decorate($block, name, doc) {
         text: $cells[1].textContent.trim(),
       },
     });
+
     const $h3 = createTag('h3');
     $h3.innerHTML = $cells[0].textContent.trim();
+    $h3.style.flex = '1';
+
     const $p = createTag('p');
     $p.innerHTML = $cells[1].innerHTML;
-    const $text = createTag('div', { class: 'tip-text' });
-    $text.append($h3);
-    $text.append($p);
+
+    const $headerWrapper = createTag('div', { class: 'header-wrapper' });
+    $headerWrapper.style.display = 'flex';
+    $headerWrapper.style.alignItems = 'center';
+    $headerWrapper.style.gap = '8px';
+
     const $number = createTag('div', { class: 'tip-number' });
     $number.innerHTML = `<span>${i + 1}</span>`;
+    $number.style.flex = 'none';
+
+    $headerWrapper.append($number);
+    $headerWrapper.append($h3);
+    const $text = createTag('div', { class: 'tip-text' });
+    $text.append($headerWrapper);
+    $text.append($p);
     $cells[0].remove();
     $cells[1].innerHTML = '';
     $cells[1].classList.add('tip');
-    $cells[1].append($number);
+    $cells[1].style.maxWidth = '600px';
+    $cells[1].style.margin = '0 auto';
     $cells[1].append($text);
   });
 

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -2,6 +2,7 @@
 
 import {
   createTag,
+  getMetadata,
 // eslint-disable-next-line import/no-unresolved
 } from '../../scripts/utils.js';
 
@@ -9,6 +10,12 @@ export default function decorate($block, name, doc) {
   const $howto = $block;
   const $heading = $howto.closest('.section').querySelector('h2, h3, h4');
   const $rows = Array.from($howto.children);
+
+  const narrowWidth = getMetadata('narrow-width') === 'on';
+  const container = document.querySelector('div.how-to-steps.block');
+  if (narrowWidth && container) {
+    container.classList.add('narrow-desktop-width');
+  }
 
   const includeSchema = !$block.classList.contains('noschema');
 

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -15,9 +15,9 @@ export default function decorate($block, name, doc) {
   const container = document.querySelector('div.how-to-steps.block');
   const desktop = document.body.dataset.device === 'desktop';
   if (desktop && narrowWidth && container) {
-    container.classList.add('narrow-desktop-width');
+    container.classList.add('narrow-width');
   } else if (narrowWidth && container) {
-    container.classList.remove('narrow-desktop-width');
+    container.classList.remove('narrow-width');
     container.classList.add('narrow-mobile-width');
   }
 

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -1,5 +1,4 @@
 /* eslint-disable import/named, import/extensions */
-
 import {
   createTag,
   getIconElement,
@@ -63,45 +62,31 @@ export default function decorate(block, name, doc) {
 
         const imageWrapper = createTag('div', { class: 'image-wrapper' });
 
-        // Clone the original image to create an enlarged version
         const enlargedImg = imgElement.cloneNode(true);
         enlargedImg.classList.add('enlarged-template-img');
         enlargedImg.style.width = `${imgElement.offsetWidth * 1.2}px`;
         enlargedImg.style.height = `${imgElement.offsetHeight * 1.2}px`;
 
-        // Prevent the hover container from blocking mouse events
-        hoverContainer.style.pointerEvents = 'auto'; // Allow mouse events on the hover container
+        hoverContainer.style.pointerEvents = 'auto';
         hoverContainer.style.position = 'absolute';
-        hoverContainer.style.top = `${imgElement.offsetTop - (imgElement.offsetHeight * 0.1) - 10}px`; // Adjust for padding
+        hoverContainer.style.top = `${imgElement.offsetTop - (imgElement.offsetHeight * 0.1) - 10}px`;
         hoverContainer.style.left = `${imgElement.offsetLeft - (imgElement.offsetWidth * 0.1) - 10}px`;
 
-        // Ensure the button container is positioned below the enlarged image within the wrapper
         buttonContainer.style.position = 'relative';
-        buttonContainer.style.marginTop = '10px'; // Add some space between the image and the button
+        buttonContainer.style.marginTop = '10px';
         buttonContainer.style.display = 'flex';
-        buttonContainer.style.justifyContent = 'center'; // Center the button horizontally
+        buttonContainer.style.justifyContent = 'center';
         buttonContainer.style.width = '100%';
 
-        // Append the enlarged image to the image wrapper
         imageWrapper.appendChild(enlargedImg);
-
-        // Append the button container to the image wrapper
         imageWrapper.appendChild(buttonContainer);
-
-        // Append the image wrapper to the hover container
         hoverContainer.appendChild(imageWrapper);
-
-        // Append the hover container to the row, over the image
         imgElement.parentElement.appendChild(hoverContainer);
 
-        // Add the mouseleave event listener to the hoverContainer
         hoverContainer.addEventListener('mouseleave', () => {
-          if (hoverContainer) { // Ensure the container exists before trying to remove it
-            // console.log('Mouse left hover container:', hoverContainer);
-
-            // Remove the hover container when the mouse leaves
+          if (hoverContainer) {
             hoverContainer.remove();
-            hoverContainer = null; // Reset the hover container reference
+            hoverContainer = null;
           }
         });
       }
@@ -116,11 +101,8 @@ export default function decorate(block, name, doc) {
       row.classList.add('template-x-thumbnail');
       const imgElement = row.querySelector('picture img');
       imgElement.style.borderRadius = '10px';
-      const buttonContainer = row.querySelector('.button-container'); // Assume each row has a button-container
-
-      // Call the function to handle hover effect
+      const buttonContainer = row.querySelector('.button-container');
       createHoverContainer(imgElement, row, buttonContainer);
-
       const templateXText = row.lastElementChild;
       const text = templateXText?.textContent.trim();
       const templateXHeading = createTag('h4', { class: 'template-x-heading' }, text);

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -54,8 +54,7 @@ export default function decorate($block, name, doc) {
     const $text = createTag('div', { class: 'tip-text' });
     $text.append($h3);
     $text.append($p);
-    const $number = createTag('div', { class: 'tip-number' });
-    $number.innerHTML = `<span>${i + numberStepStart - 1}</span>`;
+    const $number = createTag('div', { class: 'tip-number' }, `<span>${i + numberStepStart - 1}</span>`);
     $cells[0].remove();
     $cells[1].innerHTML = '';
     $cells[1].classList.add('tip');

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -52,9 +52,7 @@ export default function decorate(block, name, doc) {
 
         shareIcon.addEventListener('click', () => {
           if (templateHref) {
-            navigator.clipboard.writeText(templateHref).then(() => {
-              console.log('template-x link copied');
-            }).catch((err) => {
+            navigator.clipboard.writeText(templateHref).catch((err) => {
               console.error('Failed to copy template-x link: ', err);
             });
           }

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -12,9 +12,9 @@ export default function decorate($block, name, doc) {
   const $rows = Array.from($howto.children);
 
   let numberStepStart = 1;
-  if ($rows.length > 0) {
-    const firstRow = $rows[0];
-    numberStepStart = +firstRow.querySelectorAll('div')[1].innerText.trim();
+  const isStepNumberDefined = $rows[0].innerHTML.includes('number-step-start');
+  if (isStepNumberDefined) {
+    numberStepStart = +$rows[0].querySelectorAll('div')[1].innerText.trim();
     $rows[0].remove();
   }
 

--- a/express/blocks/link-list/link-list.css
+++ b/express/blocks/link-list/link-list.css
@@ -8,6 +8,12 @@ main .link-list-centered-container > div {
   max-width: 1200px;
 }
 
+main .section.link-list-container .link-list.block.narrow-desktop-width {
+  max-width: 850px;
+  margin: 0 auto; 
+  padding: 10px; 
+}
+
 main .link-list {
   display: block;
   overflow: hidden;

--- a/express/blocks/link-list/link-list.css
+++ b/express/blocks/link-list/link-list.css
@@ -11,7 +11,6 @@ main .link-list-centered-container > div {
 main .section.link-list-container .link-list.narrow-desktop-width {
   max-width: 850px;
   margin: 0 auto; 
-  padding: 10px; 
 }
 
 main .link-list {

--- a/express/blocks/link-list/link-list.css
+++ b/express/blocks/link-list/link-list.css
@@ -8,7 +8,7 @@ main .link-list-centered-container > div {
   max-width: 1200px;
 }
 
-main .grid-width-6-desktop.link-list-narrow-container {
+main .link-list-wrapper .link-list.narrow {
   max-width: 850px;
   margin: 0 auto; 
 }

--- a/express/blocks/link-list/link-list.css
+++ b/express/blocks/link-list/link-list.css
@@ -8,7 +8,7 @@ main .link-list-centered-container > div {
   max-width: 1200px;
 }
 
-main .grid-width-6-desktop.narrow.section.link-list-container .link-list {
+main .grid-width-6-desktop.link-list-container.narrow {
   max-width: 850px;
   margin: 0 auto; 
 }

--- a/express/blocks/link-list/link-list.css
+++ b/express/blocks/link-list/link-list.css
@@ -8,7 +8,7 @@ main .link-list-centered-container > div {
   max-width: 1200px;
 }
 
-main .section.link-list-container .link-list.block.narrow-desktop-width {
+main .section.link-list-container .link-list.narrow-desktop-width {
   max-width: 850px;
   margin: 0 auto; 
   padding: 10px; 

--- a/express/blocks/link-list/link-list.css
+++ b/express/blocks/link-list/link-list.css
@@ -8,7 +8,7 @@ main .link-list-centered-container > div {
   max-width: 1200px;
 }
 
-main .grid-width-6-desktop.link-list-container.narrow {
+main .grid-width-6-desktop.link-list-narrow-container {
   max-width: 850px;
   margin: 0 auto; 
 }

--- a/express/blocks/link-list/link-list.css
+++ b/express/blocks/link-list/link-list.css
@@ -8,7 +8,7 @@ main .link-list-centered-container > div {
   max-width: 1200px;
 }
 
-main .section.link-list-container .link-list.narrow-desktop-width {
+main .section.link-list-container .link-list.narrow-width {
   max-width: 850px;
   margin: 0 auto; 
 }

--- a/express/blocks/link-list/link-list.css
+++ b/express/blocks/link-list/link-list.css
@@ -8,7 +8,7 @@ main .link-list-centered-container > div {
   max-width: 1200px;
 }
 
-main .section.link-list-container .link-list.narrow-width {
+main .grid-width-6-desktop.narrow.section.link-list-container .link-list {
   max-width: 850px;
   margin: 0 auto; 
 }

--- a/express/blocks/link-list/link-list.js
+++ b/express/blocks/link-list/link-list.js
@@ -2,7 +2,6 @@ import {
   fetchPlaceholders,
   fetchRelevantRows,
   normalizeHeadings,
-  getMetadata,
 } from '../../scripts/utils.js';
 import { addTempWrapper } from '../../scripts/decorate.js';
 
@@ -66,12 +65,6 @@ export default async function decorate(block) {
     variant = SMART_VARIANT;
   }
   addTempWrapper(block, 'link-list');
-
-  const narrowWidth = getMetadata('narrow-width') === 'on';
-  const container = document.querySelector('div.link-list.block');
-  if (narrowWidth && container) {
-    container.classList.add('narrow-width');
-  }
 
   const placeholders = await fetchPlaceholders();
   const options = {};

--- a/express/blocks/link-list/link-list.js
+++ b/express/blocks/link-list/link-list.js
@@ -70,7 +70,7 @@ export default async function decorate(block) {
   const narrowWidth = getMetadata('narrow-width') === 'on';
   const container = document.querySelector('div.link-list.block');
   if (narrowWidth && container) {
-    container.classList.add('narrow-desktop-width');
+    container.classList.add('narrow-width');
   }
 
   const placeholders = await fetchPlaceholders();

--- a/express/blocks/link-list/link-list.js
+++ b/express/blocks/link-list/link-list.js
@@ -2,6 +2,7 @@ import {
   fetchPlaceholders,
   fetchRelevantRows,
   normalizeHeadings,
+  getMetadata,
 } from '../../scripts/utils.js';
 import { addTempWrapper } from '../../scripts/decorate.js';
 
@@ -65,6 +66,13 @@ export default async function decorate(block) {
     variant = SMART_VARIANT;
   }
   addTempWrapper(block, 'link-list');
+
+  const narrowWidth = getMetadata('narrow-width') === 'on';
+  const container = document.querySelector('div.link-list.block');
+  if (narrowWidth && container) {
+    container.classList.add('narrow-desktop-width');
+  }
+
   const placeholders = await fetchPlaceholders();
   const options = {};
 

--- a/express/blocks/promotion/promotion.css
+++ b/express/blocks/promotion/promotion.css
@@ -48,7 +48,7 @@ main .section .promotion h2 {
   margin-top: 0;
 }
 
-main .promotion-narrow-container .promotion {
+main .promotion.narrow {
   max-width: 850px;
   margin: 0 auto; 
 }

--- a/express/blocks/promotion/promotion.css
+++ b/express/blocks/promotion/promotion.css
@@ -48,6 +48,12 @@ main .section .promotion h2 {
   margin-top: 0;
 }
 
+main .promotion.narrow-desktop-width {
+  max-width: 850px;
+  margin: 0 auto; 
+  padding: 10px; 
+}
+
 @media (min-width: 900px) {
   main .section.promotion-container > div {
     max-width: 800px;

--- a/express/blocks/promotion/promotion.css
+++ b/express/blocks/promotion/promotion.css
@@ -51,7 +51,6 @@ main .section .promotion h2 {
 main .promotion.narrow-desktop-width {
   max-width: 850px;
   margin: 0 auto; 
-  padding: 10px; 
 }
 
 @media (min-width: 900px) {

--- a/express/blocks/promotion/promotion.css
+++ b/express/blocks/promotion/promotion.css
@@ -48,7 +48,7 @@ main .section .promotion h2 {
   margin-top: 0;
 }
 
-main .promotion-container.narrow {
+main .promotion.narrow {
   max-width: 850px;
   margin: 0 auto; 
 }

--- a/express/blocks/promotion/promotion.css
+++ b/express/blocks/promotion/promotion.css
@@ -48,7 +48,7 @@ main .section .promotion h2 {
   margin-top: 0;
 }
 
-main .promotion.narrow-desktop-width {
+main .promotion.narrow-width {
   max-width: 850px;
   margin: 0 auto; 
 }

--- a/express/blocks/promotion/promotion.css
+++ b/express/blocks/promotion/promotion.css
@@ -48,7 +48,7 @@ main .section .promotion h2 {
   margin-top: 0;
 }
 
-main .promotion.narrow {
+main .promotion-narrow-container .promotion {
   max-width: 850px;
   margin: 0 auto; 
 }

--- a/express/blocks/promotion/promotion.css
+++ b/express/blocks/promotion/promotion.css
@@ -48,7 +48,7 @@ main .section .promotion h2 {
   margin-top: 0;
 }
 
-main .promotion.narrow {
+main .promotion-container.narrow {
   max-width: 850px;
   margin: 0 auto; 
 }

--- a/express/blocks/promotion/promotion.css
+++ b/express/blocks/promotion/promotion.css
@@ -48,7 +48,7 @@ main .section .promotion h2 {
   margin-top: 0;
 }
 
-main .promotion.narrow-width {
+main .promotion.narrow {
   max-width: 850px;
   margin: 0 auto; 
 }

--- a/express/blocks/promotion/promotion.js
+++ b/express/blocks/promotion/promotion.js
@@ -4,7 +4,9 @@ import {
   decorateButtons,
   fixIcons,
   toClassName,
-  createOptimizedPicture, getConfig,
+  createOptimizedPicture,
+  getConfig,
+  getMetadata,
 } from '../../scripts/utils.js';
 import { addTempWrapper } from '../../scripts/decorate.js';
 
@@ -23,6 +25,12 @@ async function fetchPromotion(name) {
 
 export default async function decorate($block) {
   addTempWrapper($block, 'promotion');
+
+  const narrowWidth = getMetadata('narrow-width') === 'on';
+  const container = document.querySelector('div.promotion.block');
+  if (narrowWidth && container) {
+    container.classList.add('narrow-desktop-width');
+  }
 
   const name = $block.textContent.trim();
   if (!name) return;

--- a/express/blocks/promotion/promotion.js
+++ b/express/blocks/promotion/promotion.js
@@ -29,7 +29,7 @@ export default async function decorate($block) {
   const narrowWidth = getMetadata('narrow-width') === 'on';
   const container = document.querySelector('div.promotion.block');
   if (narrowWidth && container) {
-    container.classList.add('narrow-desktop-width');
+    container.classList.add('narrow-width');
   }
 
   const name = $block.textContent.trim();

--- a/express/blocks/promotion/promotion.js
+++ b/express/blocks/promotion/promotion.js
@@ -6,7 +6,6 @@ import {
   toClassName,
   createOptimizedPicture,
   getConfig,
-  getMetadata,
 } from '../../scripts/utils.js';
 import { addTempWrapper } from '../../scripts/decorate.js';
 
@@ -26,10 +25,10 @@ async function fetchPromotion(name) {
 export default async function decorate($block) {
   addTempWrapper($block, 'promotion');
 
-  const narrowWidth = getMetadata('narrow-width') === 'on';
   const container = document.querySelector('div.promotion.block');
-  if (narrowWidth && container) {
-    container.classList.add('narrow-width');
+  const narrowVariant = container?.classList.contains('narrow');
+  if (narrowVariant && container) {
+    container.classList.add('narrow');
   }
 
   const name = $block.textContent.trim();

--- a/express/blocks/promotion/promotion.js
+++ b/express/blocks/promotion/promotion.js
@@ -25,12 +25,6 @@ async function fetchPromotion(name) {
 export default async function decorate($block) {
   addTempWrapper($block, 'promotion');
 
-  const container = document.querySelector('div.promotion.block');
-  const narrowVariant = container?.classList.contains('narrow');
-  if (narrowVariant && container) {
-    container.classList.add('narrow');
-  }
-
   const name = $block.textContent.trim();
   if (!name) return;
 

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -2172,6 +2172,12 @@ main .template-x-wrapper.horizontal > .template-x.horizontal.tabbed > .template-
     padding: 0 28px;
 }
 
+.template-x-narrow-container {
+    max-width: 850px;
+    margin: 0 auto; 
+    padding: 10px;  
+}
+
 nav ol.templates-breadcrumbs {
     list-style: none;
     margin: 0 0 0 16px;

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -2175,7 +2175,10 @@ main .template-x-wrapper.horizontal > .template-x.horizontal.tabbed > .template-
 .template-x-narrow-container {
     max-width: 850px;
     margin: 0 auto; 
-    padding: 10px;  
+}
+
+.template-x-narrow-container h2 {
+    font-size: 22px;
 }
 
 nav ol.templates-breadcrumbs {

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -2172,12 +2172,12 @@ main .template-x-wrapper.horizontal > .template-x.horizontal.tabbed > .template-
     padding: 0 28px;
 }
 
-.template-x-narrow-container {
+.template-x.narrow {
     max-width: 850px;
     margin: 0 auto; 
 }
 
-.template-x-narrow-container h2 {
+.template-x.narrow h2 {
     font-size: 22px;
 }
 

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -926,6 +926,15 @@ function decorateContent(el) {
   block.className = 'default-content-wrapper';
   block.append(...children);
   block.dataset.block = '';
+
+  const narrowWidth = getMetadata('narrow-width') === 'on';
+  const containers = document.querySelectorAll('div.default-content-wrapper');
+  containers.forEach((container) => {
+    if (narrowWidth && container) {
+      container.classList.add('narrow-desktop-width');
+    }
+  });
+
   return block;
 }
 

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -927,14 +927,14 @@ function decorateContent(el) {
   block.append(...children);
   block.dataset.block = '';
 
-  const narrowWidth = getMetadata('narrow-width') === 'on';
+  const narrowVariant = document.querySelector('.long-form[data-narrow="on"]');
   const containers = document.querySelectorAll('div.default-content-wrapper');
   const desktop = document.body.dataset.device === 'desktop';
   containers.forEach((container) => {
-    if (narrowWidth && container) {
-      container.classList.add('narrow-width');
+    if (narrowVariant && container) {
+      container.classList.add('narrow');
       if (!desktop) {
-        const headers = container.querySelectorAll('h1'); // Select all header elements
+        const headers = container.querySelectorAll('h1');
         headers.forEach((header) => {
           header.style.fontSize = '36px';
         });

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -929,9 +929,16 @@ function decorateContent(el) {
 
   const narrowWidth = getMetadata('narrow-width') === 'on';
   const containers = document.querySelectorAll('div.default-content-wrapper');
+  const desktop = document.body.dataset.device === 'desktop';
   containers.forEach((container) => {
     if (narrowWidth && container) {
       container.classList.add('narrow-desktop-width');
+      if (!desktop) {
+        const headers = container.querySelectorAll('h1'); // Select all header elements
+        headers.forEach((header) => {
+          header.style.fontSize = '36px';
+        });
+      }
     }
   });
 

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -926,7 +926,6 @@ function decorateContent(el) {
   block.className = 'default-content-wrapper';
   block.append(...children);
   block.dataset.block = '';
-
   return block;
 }
 

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -932,7 +932,7 @@ function decorateContent(el) {
   const desktop = document.body.dataset.device === 'desktop';
   containers.forEach((container) => {
     if (narrowWidth && container) {
-      container.classList.add('narrow-desktop-width');
+      container.classList.add('narrow-width');
       if (!desktop) {
         const headers = container.querySelectorAll('h1'); // Select all header elements
         headers.forEach((header) => {

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -927,21 +927,6 @@ function decorateContent(el) {
   block.append(...children);
   block.dataset.block = '';
 
-  const narrowVariant = document.querySelector('.long-form[data-narrow="on"]');
-  const containers = document.querySelectorAll('div.default-content-wrapper');
-  const desktop = document.body.dataset.device === 'desktop';
-  containers.forEach((container) => {
-    if (narrowVariant && container) {
-      container.classList.add('narrow');
-      if (!desktop) {
-        const headers = container.querySelectorAll('h1');
-        headers.forEach((header) => {
-          header.style.fontSize = '36px';
-        });
-      }
-    }
-  });
-
   return block;
 }
 

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -1022,7 +1022,7 @@ main > div:not(.banner-container) .block:not(.pricing-summary, .pricing-cards, .
   display: none;
 }
 
-main .long-form.grid-width-6-desktop .default-content-wrapper.narrow {
+main .long-form.grid-width-6-desktop.narrow .default-content-wrapper {
   max-width: 850px;
   margin: 0 auto; 
 } 

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -1025,7 +1025,6 @@ main > div:not(.banner-container) .block:not(.pricing-summary, .pricing-cards, .
 main .long-form.grid-width-6-desktop .default-content-wrapper.narrow-desktop-width {
   max-width: 850px;
   margin: 0 auto; 
-  padding: 10px; 
 } 
 
 

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -1022,6 +1022,12 @@ main > div:not(.banner-container) .block:not(.pricing-summary, .pricing-cards, .
   display: none;
 }
 
+main .long-form.grid-width-6-desktop .default-content-wrapper.narrow-desktop-width {
+  max-width: 850px;
+  margin: 0 auto; 
+  padding: 10px; 
+} 
+
 
 @media (min-width: 900px) {
   main .block .button-container.free-plan-container {

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -1027,6 +1027,13 @@ main .long-form.grid-width-6-desktop.narrow .default-content-wrapper {
   margin: 0 auto; 
 } 
 
+@media (max-width: 600px) {
+  .long-form.narrow.section.section-wrapper {
+    max-width: 375px;
+    margin: 0 auto;
+  }
+}
+
 
 @media (min-width: 900px) {
   main .block .button-container.free-plan-container {

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -1022,7 +1022,7 @@ main > div:not(.banner-container) .block:not(.pricing-summary, .pricing-cards, .
   display: none;
 }
 
-main .long-form.grid-width-6-desktop .default-content-wrapper.narrow-desktop-width {
+main .long-form.grid-width-6-desktop .default-content-wrapper.narrow-width {
   max-width: 850px;
   margin: 0 auto; 
 } 

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -1022,7 +1022,7 @@ main > div:not(.banner-container) .block:not(.pricing-summary, .pricing-cards, .
   display: none;
 }
 
-main .long-form.grid-width-6-desktop .default-content-wrapper.narrow-width {
+main .long-form.grid-width-6-desktop .default-content-wrapper.narrow {
   max-width: 850px;
   margin: 0 auto; 
 } 


### PR DESCRIPTION
This PR ensures all content below the marquee has a max width of 850px on the JP Long Form page.


**Resolves** [MWPW-153062](https://jira.corp.adobe.com/browse/MWPW-153062)
Full Screen Marquee Header Text Size set to 45px 

Full Screen Marquee Header Sub Copy Can Be Simply Omitted From Authoring Doc 

========

Content Width Below Marquee set to 850px 

========

Long Form Headers on Desktop / Mobile set to 36px 

========

How To Steps Push Numbers In To Align With Sub Copy 

How To Steps Headers on Desktop / Mobile set to 28px 

How To Step Number Text Size on Desktop / Mobile set to 22px 

How To Step Number Size on Desktop / Mobile Circle Radius reduced to 40px from 48px 

========

Template X Width Set To 850px 

Template X Reduce Headline Font Size to 22px 


**Pages to check for regression and performance:**
- Before: https://fix-scroll-bug-toc--express--adobecom.hlx.page/drafts/jsandlan/long-form-flyer
- After: https://jp-express-long-form--express--adobecom.hlx.page/drafts/jsandlan/long-form-flyer