### PR TITLE
allow alternative free plan placeholder text via metadata

### DIFF
--- a/express/scripts/utils/free-plan.js
+++ b/express/scripts/utils/free-plan.js
@@ -23,9 +23,15 @@ export async function buildFreePlanWidget(config) {
   const { typeKey, checkmarks } = config;
   const placeholders = await fetchPlaceholders();
   const widget = createTag('div', { class: 'free-plan-widget' });
+  const noSignupRequired = getMetadata('no-signup-required');
 
   typeMap[typeKey].forEach((tagKey) => {
-    const tagText = placeholders[tagKey];
+    let tagText;
+    if (noSignupRequired && tagKey === 'free-plan-check-2') {
+      tagText = placeholders['free-plan-check-3'];
+    } else {
+      tagText = placeholders[tagKey];
+    }
 
     if (tagText) {
       const textDiv = createTag('span', { class: 'plan-widget-tag' });


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Allow authors to specify a metadata key to use an alternative placeholder text in the free plan widget

**Resolves:** [MWPW-157362](https://jira.corp.adobe.com/browse/MWPW-157362)


**Pages to check for regression and performance:**
Before: 
- https://main--express--adobecom.hlx.page/jp/express/feature/image/remove-background/transparent
After:
- https://frictionless-jp--express--adobecom.hlx.page/jp/express/feature/image/remove-background/transparent
