### PR TITLE
Templates enhancement, for Desktop and not for mobile

### DIFF
--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -406,7 +406,6 @@ function renderHoverWrapper(template, placeholders) {
     }
   };
 
-  // cta.addEventListener('click', ctaClickHandler, { passive: true });
   cta.addEventListener('click', ctaClickHandler, { passive: true });
   ctaLink.addEventListener('click', ctaClickHandler, { passive: true });
   ctaLink.addEventListener('click', ctaClickHandlerTouchDevice);

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -165,6 +165,15 @@ function renderCTA(placeholders, branchUrl) {
   return btnEl;
 }
 
+function renderCTALink(branchUrl) {
+  const linkEl = createTag('a', {
+    href: branchUrl,
+    class: 'cta-link',
+    tabindex: '-1',
+  });
+  return linkEl;
+}
+
 function getPageIterator(pages) {
   return {
     i: 0,
@@ -182,6 +191,7 @@ function getPageIterator(pages) {
     },
   };
 }
+
 async function renderRotatingMedias(wrapper,
   pages,
   { templateTitle, renditionLinkHref, componentLinkHref }) {
@@ -363,13 +373,22 @@ function renderHoverWrapper(template, placeholders) {
     mediaWrapper, enterHandler, leaveHandler, focusHandler,
   } = renderMediaWrapper(template, placeholders);
 
-  btnContainer.append(mediaWrapper);
+  console.log("=== btnContainer", btnContainer)
+  // btnContainer.append(mediaWrapper);
+
+  const cta = renderCTA(placeholders, template.customLinks.branchUrl);
+  const ctaLink = renderCTALink(template.customLinks.branchUrl);
+
+  ctaLink.append(mediaWrapper);
+
+  btnContainer.append(cta);
+  btnContainer.append(ctaLink);
 
   btnContainer.addEventListener('mouseenter', enterHandler);
   btnContainer.addEventListener('mouseleave', leaveHandler);
 
-  const cta = renderCTA(placeholders, template.customLinks.branchUrl);
-  btnContainer.prepend(cta);
+  // const cta = renderCTA(placeholders, template.customLinks.branchUrl);
+  // btnContainer.prepend(cta);
   cta.addEventListener('focusin', focusHandler);
 
   const ctaClickHandler = () => {
@@ -384,10 +403,23 @@ function renderHoverWrapper(template, placeholders) {
     trackSearch('select-template', BlockMediator.get('templateSearchSpecs')?.search_id);
   };
 
+  const ctaClickHandlerTouchDevice = (ev) => {
+    // If it is a mobile device with a touch screen, do not jump over to the Edit page,
+    // but allow the user to preview the template instead
+    if (window.matchMedia('(pointer: coarse)').matches) {
+      ev.preventDefault();
+    }
+  };
+
+  // cta.addEventListener('click', ctaClickHandler, { passive: true });
   cta.addEventListener('click', ctaClickHandler, { passive: true });
+  ctaLink.addEventListener('click', ctaClickHandler, { passive: true });
+  ctaLink.addEventListener('click', ctaClickHandlerTouchDevice);
 
   return btnContainer;
 }
+
+
 
 function getStillWrapperIcons(template, placeholders) {
   let planIcon = null;

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -373,9 +373,6 @@ function renderHoverWrapper(template, placeholders) {
     mediaWrapper, enterHandler, leaveHandler, focusHandler,
   } = renderMediaWrapper(template, placeholders);
 
-  console.log("=== btnContainer", btnContainer)
-  // btnContainer.append(mediaWrapper);
-
   const cta = renderCTA(placeholders, template.customLinks.branchUrl);
   const ctaLink = renderCTALink(template.customLinks.branchUrl);
 
@@ -387,8 +384,6 @@ function renderHoverWrapper(template, placeholders) {
   btnContainer.addEventListener('mouseenter', enterHandler);
   btnContainer.addEventListener('mouseleave', leaveHandler);
 
-  // const cta = renderCTA(placeholders, template.customLinks.branchUrl);
-  // btnContainer.prepend(cta);
   cta.addEventListener('focusin', focusHandler);
 
   const ctaClickHandler = () => {
@@ -418,8 +413,6 @@ function renderHoverWrapper(template, placeholders) {
 
   return btnContainer;
 }
-
-
 
 function getStillWrapperIcons(template, placeholders) {
   let planIcon = null;

--- a/express/blocks/template-x/template-rendering.js
+++ b/express/blocks/template-x/template-rendering.js
@@ -134,7 +134,9 @@ function renderShareWrapper(branchUrl, placeholders) {
     tabindex: '-1',
   });
   let timeoutId = null;
-  shareIcon.addEventListener('click', () => {
+  shareIcon.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    ev.stopPropagation();
     timeoutId = share(branchUrl, tooltip, timeoutId, placeholders);
   });
 

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -2070,6 +2070,7 @@ main .template-x-wrapper.horizontal > .template-x.horizontal.tabbed > .template-
 }
 
 .template-x .template .button-container a.cta-link {
+    display: block;
     width: 100%;
     height: calc(100% - 34px);
     white-space: nowrap;

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -2051,7 +2051,7 @@ main .template-x-wrapper.horizontal > .template-x.horizontal.tabbed > .template-
 
 .template-x .template .button-container .media-wrapper {
     position: relative;
-    height: calc(100% - 34px);
+    height: 100%;
     width: 100%;
 }
 
@@ -2059,7 +2059,7 @@ main .template-x-wrapper.horizontal > .template-x.horizontal.tabbed > .template-
     flex-basis: 100%;
 }
 
-.template-x .template .button-container a {
+.template-x .template .button-container a.button {
     max-width: 100%;
     margin: 6px 6px 0;
     box-sizing: border-box;
@@ -2069,11 +2069,18 @@ main .template-x-wrapper.horizontal > .template-x.horizontal.tabbed > .template-
     text-overflow: ellipsis;
 }
 
-.template-x.horizontal .template .button-container a {
+.template-x .template .button-container a.cta-link {
+    width: 100%;
+    height: calc(100% - 34px);
+    white-space: nowrap;
+    font-weight: var(--body-font-weight);
+}
+
+.template-x.horizontal .template .button-container a.button {
     min-height: 16px;
 }
 
-.template-x.horizontal.mini .template .button-container a {
+.template-x.horizontal.mini .template .button-container a.button {
     font-size: var(--body-font-size-xs);
     padding: 2px 6px 4px;
 }


### PR DESCRIPTION
Make the templates on https://www.adobe.com/express/templates/ to be able to "click to edit" for the images, group images, and video.
If it is a mobile device, don't let it happen, because the user doesn't have a chance to hover the mouse over the template to preview the larger image / group images / video.

**Resolves:** [MWPW-158218](https://jira.corp.adobe.com/browse/MWPW-158218)

Before:
- https://templates-enhance-before--express--adobecom.hlx.page/express/templates/?martech=off&lighthouse=on
- https://templates-enhance-before--express--adobecom.hlx.page/express/?martech=off&lighthouse=on

**Pages to check for regression and performance:**
- https://templates-enhance-after--express--adobecom.hlx.page/express/templates/?martech=off&lighthouse=on
- https://templates-enhance-after--express--adobecom.hlx.page/express/?martech=off&lighthouse=on
- https://templates-enhance-after--express--adobecom.hlx.page/express/colors/green?martech=off&lighthouse=on
- https://templates-enhance-after--express--adobecom.hlx.page/express/create/poster?martech=off&lighthouse=on
