### PR TITLE
[MWPW-158121] Pricing Cards Offer Logic Simplification

### DIFF
--- a/express/scripts/utils/pricing.js
+++ b/express/scripts/utils/pricing.js
@@ -226,17 +226,9 @@ export function shallSuppressOfferEyebrowText(savePer, offerTextContent, isPremi
     return offerIdSuppressMap.get(key);
   }
   let suppressOfferEyeBrowText = false;
-  if (isPremiumCard) {
-    if (isSpecialEyebrowText) {
-      suppressOfferEyeBrowText = !(savePer !== '' && offerTextContent.includes('{{savePercentage}}'));
-    } else if (isPremiumCard === '84EA7C85DEB6D5260ACE527CB41FDF0B' || isPremiumCard === '2D84772E931C704E05CAD34D43BE1746') {
-      suppressOfferEyeBrowText = false;
-    } else {
-      suppressOfferEyeBrowText = true;
-    }
-  } else if (offerTextContent) {
+  if (offerTextContent) {
     suppressOfferEyeBrowText = savePer === '' && offerTextContent.includes('{{savePercentage}}');
-  }
+  }  
   offerIdSuppressMap.set(key, suppressOfferEyeBrowText);
   return suppressOfferEyeBrowText;
 }

--- a/express/scripts/utils/pricing.js
+++ b/express/scripts/utils/pricing.js
@@ -228,7 +228,7 @@ export function shallSuppressOfferEyebrowText(savePer, offerTextContent, isPremi
   let suppressOfferEyeBrowText = false;
   if (offerTextContent) {
     suppressOfferEyeBrowText = savePer === '' && offerTextContent.includes('{{savePercentage}}');
-  }  
+  }
   offerIdSuppressMap.set(key, suppressOfferEyeBrowText);
   return suppressOfferEyeBrowText;
 }


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Issue/Feature 1
- Fixes an issue with the pricing offer not appearing for certain plans.
- The previous logic was extremely convoluted, the new logic is as follows
   1) If the author did specify a savePercentage token in the offer text but it is not present in the pricing offer JSON, then the offer will be suppressed. this makes sense because having a token displayed is undesired behavior.

**Resolves:** https://jira.corp.adobe.com/projects/MWPW/issues/MWPW-158121

**Steps to test the before vs. after and expectations:**
- Steps for feature 1
 Visit the page below and verify that card offers appear for the Teams plan.

<img width="1336" alt="Screenshot 2024-09-12 at 1 02 00 PM" src="https://github.com/user-attachments/assets/3632253e-5ef5-4496-b220-a82eea148865">


**Pages to check for regression and performance:**
-  https://pricing-card-offer-fix--express--adobecom.hlx.page/express/pricing
-  https://pricing-card-offer-fix--express--adobecom.hlx.page/express/pricing?country=gb
-  https://pricing-card-offer-fix--express--adobecom.hlx.page/de/express/pricing?country=de
-  https://pricing-card-offer-fix--express--adobecom.hlx.page/fr/express/pricing?country=fr
-  https://pricing-card-offer-fix--express--adobecom.hlx.page/es/express/pricing?country=es
-  https://pricing-card-offer-fix--express--adobecom.hlx.page/jp/express/pricing?country=jp
-  https://pricing-card-offer-fix--express--adobecom.hlx.page/tw/express/pricing?country=tw
-  https://pricing-card-offer-fix--express--adobecom.hlx.page/nl/express/pricing?country=nl
