### PR TITLE
Fix Template-X Toolbar Sticky behavior

### DIFF
--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -5,7 +5,7 @@ import {
   getIconElement,
   getMetadata,
 } from '../../scripts/utils.js';
-import { trackSearch, updateImpressionCache } from '../../scripts/template-search-api-v3.js';
+import { trackSearch, updateImpressionCache, generateSearchId } from '../../scripts/template-search-api-v3.js';
 import BlockMediator from '../../scripts/block-mediator.min.js';
 
 function handlelize(str) {
@@ -324,7 +324,14 @@ function buildSearchDropdown(block, searchBarWrapper, placeholders) {
     const trendsWrapper = createTag('ul', { class: 'trends-wrapper' });
     for (const [key, value] of Object.entries(trends)) {
       const trendLinkWrapper = createTag('li');
-      const trendLink = createTag('a', { class: 'trend-link', href: value });
+      const trendLink = createTag('a', { class: 'trend-link', href: `${value}?searchId=${generateSearchId()}` });
+      trendLink.addEventListener('click', () => {
+        updateImpressionCache({
+          keyword_filter: key,
+          content_category: 'templates',
+        });
+        trackSearch('search-inspire', new URLSearchParams(new URL(trendLink.href).search).get('searchId'));
+      });
       trendLink.textContent = key;
       trendLinkWrapper.append(trendLink);
       trendsWrapper.append(trendLinkWrapper);

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -795,7 +795,7 @@ main.with-holiday-templates-banner {
     background: var(--color-gray-100);
     position: sticky;
     z-index: 1;
-    top: var(--header-height);
+    top: 64px;
 }
 
 .template-x .api-templates-toolbar {

--- a/express/blocks/template-x/template-x.css
+++ b/express/blocks/template-x/template-x.css
@@ -795,7 +795,7 @@ main.with-holiday-templates-banner {
     background: var(--color-gray-100);
     position: sticky;
     z-index: 1;
-    top: 0;
+    top: var(--header-height);
 }
 
 .template-x .api-templates-toolbar {


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Fix Sticky Toolbar covered by Nav
- Minor update for search tracking for search-marquee block

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-158373

**Steps to test the before vs. after and expectations:**
- Go to https://template-sticky-fix--express--adobecom.hlx.live/express/templates/flyer?martech=off
- Wait a bit for Nav to load
- Scroll down on a template page
![SC 2024-09-12 at 3 45 36 PM](https://github.com/user-attachments/assets/e12fdc5c-54a9-474c-9067-9d02e89e6a3d)
- In the branch link, it should be sticky and reserve space for the Nav. In stage or prod, either the toolbar or the NAV will be covered by the other and no longer visible.

**Pages to check for regression:**
- https://template-sticky-fix--express--adobecom.hlx.live/express/templates/flyer?martech=off
