### PR TITLE
[Hotfix] Rollback content replace

### DIFF
--- a/express/scripts/content-replace.js
+++ b/express/scripts/content-replace.js
@@ -301,19 +301,12 @@ async function autoUpdatePage(main) {
 
   await Promise.all(Array.from(metaTags).map((meta) => sanitizeMeta(meta)));
 
-  const replacePlaceholdersInTextNodes = (node) => {
-    if (node.nodeType === Node.TEXT_NODE) {
-      node.nodeValue = node.nodeValue.replace(regex, (match, p1) => {
-        if (!wl.includes(match.toLowerCase())) {
-          return getMetadata(p1);
-        }
-        return match;
-      });
-    } else if (node.nodeType === Node.ELEMENT_NODE) {
-      node.childNodes.forEach(replacePlaceholdersInTextNodes);
+  main.innerHTML = main.innerHTML.replaceAll(regex, (match, p1) => {
+    if (!wl.includes(match.toLowerCase())) {
+      return getMetadata(p1);
     }
-  };
-  replacePlaceholdersInTextNodes(main);
+    return match;
+  });
 
   // handle link replacement on sheet-powered pages
   main.querySelectorAll('a[href*="#"]').forEach((a) => {


### PR DESCRIPTION
**Steps to test the before vs. after and expectations:**
- Go to a template page in prod
- Scroll to the bottom
- You should notice that he long-text block contains html tags, but the branch link has fixed that

**Pages to check for regression and performance:**
- https://content-replace-hotfix--express--adobecom.hlx.page/express/templates/flyer?martech=off
