### PR TITLE
Jp blade

### DIFF
--- a/express/blocks/template-x/template-x.js
+++ b/express/blocks/template-x/template-x.js
@@ -159,7 +159,7 @@ function constructProps(block) {
     limit: 70,
     total: 0,
     start: '',
-    collectionId: 'urn:aaid:sc:VA6C2:25a82757-01de-4dd9-b0ee-bde51dd3b418',
+    collectionId: 'urn:aaid:sc:VA6C2:2370e7c8-3200-40c5-be6a-c44b9ed2203f',
     sort: '',
     masonry: undefined,
     headingTitle: null,

--- a/express/scripts/template-search-api-v3.js
+++ b/express/scripts/template-search-api-v3.js
@@ -227,7 +227,6 @@ async function fetchSearchUrl({
   q,
   collectionId,
 }) {
-  // q = '紅葉';
   const base = 'https://www.adobe.com/express-search-api-v3';
   const collectionIdParam = `collectionId=${collectionId}`;
   const queryType = 'search';

--- a/express/scripts/template-search-api-v3.js
+++ b/express/scripts/template-search-api-v3.js
@@ -284,7 +284,6 @@ async function getFallbackMsg(tasks = '') {
 }
 
 async function fetchTemplatesNoToolbar(props) {
-  console.log('props', props);
   const { filters, limit } = props;
   const langs = extractLangs(filters.locales);
   if (langs.length <= 1) {

--- a/express/scripts/template-search-api-v3.js
+++ b/express/scripts/template-search-api-v3.js
@@ -227,6 +227,7 @@ async function fetchSearchUrl({
   q,
   collectionId,
 }) {
+  // q = '紅葉';
   const base = 'https://www.adobe.com/express-search-api-v3';
   const collectionIdParam = `collectionId=${collectionId}`;
   const queryType = 'search';
@@ -283,6 +284,7 @@ async function getFallbackMsg(tasks = '') {
 }
 
 async function fetchTemplatesNoToolbar(props) {
+  console.log('props', props);
   const { filters, limit } = props;
   const langs = extractLangs(filters.locales);
   if (langs.length <= 1) {
@@ -382,6 +384,7 @@ export async function fetchTemplatesCategoryCount(props, tasks) {
 }
 
 export async function fetchTemplates(props) {
+  props.q = props.topic || props.q;
   // api rejects 10000+
   const start = parseInt(props.start, 10);
   if (Number.isInteger(start) && start > 9999) {


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Search term not being sent in request to retrieve template-x templates

**Resolves:** [MWPW-159101](https://jira.corp.adobe.com/browse/MWPW-159101)

**Steps to test the before vs. after and expectations:**

**Pages to check for regression and performance:**
**Before**:
https://main--express--adobecom.hlx.page/drafts/anuj/takedown_blade/jp-fall-seasonal-blade
<img width="1420" alt="before" src="https://github.com/user-attachments/assets/fb59be11-1334-434c-8752-6cb7dd886744">
**q param is missing prior to changes**: 
<img width="486" alt="q-param missing" src="https://github.com/user-attachments/assets/63f72cd7-2d30-46dd-9ceb-72c881e2ee6f">


**After**: 
- https://jp-blade--express--adobecom.hlx.page/drafts/jsandlan/jp-fall-seasonal-blade
<img width="1366" alt="instagram" src="https://github.com/user-attachments/assets/351606e4-eeb1-4069-9867-b915b7e73c99">
<img width="493" alt="express-search after" src="https://github.com/user-attachments/assets/1045c0f5-de89-4ef9-97a7-2ca59643b0e6">

