### PR TITLE
remove eg locale from scripts.js

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -17,7 +17,6 @@ const locales = {
   cn: { ietf: 'zh-Hans-CN', tk: 'puu3xkp' },
   de: { ietf: 'de-DE', tk: 'vin7zsi.css' },
   dk: { ietf: 'da-DK', tk: 'aaz7dvd.css' },
-  eg: { ietf: 'en-EG', tk: 'pps7abe.css' },
   es: { ietf: 'es-ES', tk: 'oln4yqj.css' },
   fi: { ietf: 'fi-FI', tk: 'aaz7dvd.css' },
   fr: { ietf: 'fr-FR', tk: 'vrk5vyv.css' },


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- remove eg locale from scripts.js

**Per request from @vhargrave, I have removed the eg locale from scripts.js**

**Steps to test the before vs. after and expectations:**

**Pages to check for regression and performance:**
- https://remove-eg-locale --express--adobecom.hlx.page/express/?martech=off
