### PR TITLE
polish homepage cards redesign

### DIFF
--- a/express/blocks/discover-cards/discover-cards.css
+++ b/express/blocks/discover-cards/discover-cards.css
@@ -75,10 +75,11 @@ main .section .discover-cards {
 }
 .discover-cards .cards-container .card.image-bottom picture img.tall {
     width: 294px;
-    height: 289px;
+    height: 274px;
     position: absolute;
     left: 8px;
     bottom: 10px;
+    object-fit: fill;
 }
 .discover-cards .cards-container .card picture img.short {
     height: 147px;
@@ -112,15 +113,13 @@ main .section .discover-cards {
 }
 
 @media (min-width: 401px) {  
-    .discover-cards .cards-container {
-        padding: 16px;
-    }
     .discover-cards .cards-container .card {
         min-width: 399px;
         height: 478px;
     }
     .discover-cards .center-title h3 {
         font-size: 36px;
+        margin-top: 50px;
     }
     .discover-cards .cards-container .card .text-content .header { 
         font-size: 28px; 

--- a/express/blocks/discover-cards/discover-cards.js
+++ b/express/blocks/discover-cards/discover-cards.js
@@ -3,7 +3,6 @@ import buildGallery from '../../features/gallery/gallery.js';
 
 export default async function decorate(block) {
   const isBottomImageVariant = block.classList.contains('bottom-image');
-  block.classList.toggle('no-bg', isBottomImageVariant);
   const firstChild = block.querySelector(':scope > div:first-child');
 
   if (firstChild && firstChild.querySelector('h3')) {
@@ -70,18 +69,18 @@ export default async function decorate(block) {
     });
   });
 
+  const isbgBlock = block && !block.classList.contains('bottom-image');
   block.appendChild(cardsWrapper);
   await buildGallery(cards, cardsWrapper);
 
   function waitForLCP() {
-    if (!isBottomImageVariant) {
-      const parentBlock = document.querySelector('.discover-cards');
+    if (isbgBlock) {
       const imageSize = document.body.dataset.device === 'desktop' ? 'large' : 'small';
-      parentBlock.style.backgroundImage = `
-        linear-gradient(to bottom, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 0) 20%),
-        linear-gradient(to top, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 0) 20%),
-        url(/express/blocks/discover-cards/img/cards-bg-${imageSize}.webp)
-      `;
+      block.style.backgroundImage = `
+          linear-gradient(to bottom, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 0) 20%),
+          linear-gradient(to top, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 0) 20%),
+          url(/express/blocks/discover-cards/img/cards-bg-${imageSize}.webp)
+        `;
     }
   }
   window.addEventListener('express:LCP:loaded', waitForLCP);


### PR DESCRIPTION
I noticed that when both variants are on the same page they are too close to each other vertically:
- added margin-top to header
- removed padding to bring gallery slider closer to bottom of cards
- ensures bg image only appears behind correct variant
- adds CSS to allow images in cards to appear proportional without being squished / distorted


**Pages to check for regression and performance:**
- https://cards-improvements--express--adobecom.hlx.page/express/?martech=off
