### PR TITLE
[Simplified Homepage] Quote singular - gradient fades out better

### DIFF
--- a/express/blocks/quotes/quotes.css
+++ b/express/blocks/quotes/quotes.css
@@ -205,7 +205,7 @@ main .quotes.singular .mobile-container .author-panel .author-photo {
 @media (min-width: 600px) {
   main .quotes.singular .quote {
     width: 80%;
-    min-height: 330px;
+    min-height: 335px;
   }
 }
 

--- a/express/blocks/quotes/quotes.css
+++ b/express/blocks/quotes/quotes.css
@@ -130,20 +130,13 @@ main .quotes.singular .quote-container .mobile-container .background {
   z-index: -1;
 }
 
-main .quotes.singular .new-block {
-  width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
-  padding: 100px 0;
-}
-
 main .quotes.singular .quote {
   display: flex;
   flex-flow: row;
   background: transparent;
   justify-content: center;
-  padding: 100px 0 70px;
-  min-height: 320px;
+  padding: 70px 0 70px;
+  min-height: 390px;
 }
 
 main .quotes.singular .author-photo {
@@ -212,6 +205,7 @@ main .quotes.singular .mobile-container .author-panel .author-photo {
 @media (min-width: 600px) {
   main .quotes.singular .quote {
     width: 80%;
+    min-height: 330px;
   }
 }
 

--- a/express/blocks/quotes/quotes.js
+++ b/express/blocks/quotes/quotes.js
@@ -31,7 +31,7 @@ export default function decorate($block) {
       const backgroundDesktopCSS = `no-repeat calc(-400px + 25%) -20px / 640px url("${backgroundUrl}"), no-repeat calc(450px + 75%) -20px / 640px url("${backgroundUrl}")`;
       $desktopContainerBackground.style.background = backgroundDesktopCSS;
 
-      const backgroundMobileCSS = `no-repeat -20px -20px url("${backgroundUrl}")`;
+      const backgroundMobileCSS = `no-repeat -20px -20px / 750px url("${backgroundUrl}")`;
       $mobileContainerBackground.style.background = backgroundMobileCSS;
 
       $rows.shift();

--- a/express/blocks/quotes/quotes.js
+++ b/express/blocks/quotes/quotes.js
@@ -28,10 +28,10 @@ export default function decorate($block) {
       const $img = $rows[0].children[0].querySelector('img');
       const backgroundUrl = $img.src;
 
-      const backgroundDesktopCSS = `no-repeat calc(-400px + 25%) 10px / 640px url("${backgroundUrl}"), no-repeat calc(450px + 75%) 10px / 640px url("${backgroundUrl}")`;
+      const backgroundDesktopCSS = `no-repeat calc(-400px + 25%) -20px / 640px url("${backgroundUrl}"), no-repeat calc(450px + 75%) -20px / 640px url("${backgroundUrl}")`;
       $desktopContainerBackground.style.background = backgroundDesktopCSS;
 
-      const backgroundMobileCSS = `no-repeat -20px 10px url("${backgroundUrl}")`;
+      const backgroundMobileCSS = `no-repeat -20px -20px url("${backgroundUrl}")`;
       $mobileContainerBackground.style.background = backgroundMobileCSS;
 
       $rows.shift();

--- a/express/blocks/quotes/quotes.js
+++ b/express/blocks/quotes/quotes.js
@@ -31,7 +31,7 @@ export default function decorate($block) {
       const backgroundDesktopCSS = `no-repeat calc(-400px + 25%) -20px / 640px url("${backgroundUrl}"), no-repeat calc(450px + 75%) -20px / 640px url("${backgroundUrl}")`;
       $desktopContainerBackground.style.background = backgroundDesktopCSS;
 
-      const backgroundMobileCSS = `no-repeat -20px -20px / 750px url("${backgroundUrl}")`;
+      const backgroundMobileCSS = ` no-repeat -20px -20px / 750px url("${backgroundUrl}")`;
       $mobileContainerBackground.style.background = backgroundMobileCSS;
 
       $rows.shift();

--- a/express/blocks/quotes/quotes.js
+++ b/express/blocks/quotes/quotes.js
@@ -31,7 +31,7 @@ export default function decorate($block) {
       const backgroundDesktopCSS = `no-repeat calc(-400px + 25%) -20px / 640px url("${backgroundUrl}"), no-repeat calc(450px + 75%) -20px / 640px url("${backgroundUrl}")`;
       $desktopContainerBackground.style.background = backgroundDesktopCSS;
 
-      const backgroundMobileCSS = ` no-repeat -20px -20px / 750px url("${backgroundUrl}")`;
+      const backgroundMobileCSS = `no-repeat -20px -20px / 750px url("${backgroundUrl}")`;
       $mobileContainerBackground.style.background = backgroundMobileCSS;
 
       $rows.shift();

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2670,7 +2670,7 @@ export function titleCase(str) {
   return splitStr.join(' ');
 }
 
-export function pickRandomFromArray(arr) {
+export function pickRandomFromArray(arr) { // trigger rebuild
   return arr[Math.floor(arr.length * Math.random())];
 }
 

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2670,7 +2670,7 @@ export function titleCase(str) {
   return splitStr.join(' ');
 }
 
-export function pickRandomFromArray(arr) { // trigger rebuild
+export function pickRandomFromArray(arr) {
   return arr[Math.floor(arr.length * Math.random())];
 }
 


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Made the gradient fade out better for Desktop
- The Mobile requires a min-height in the event that the quote is quite short

**Resolves:** [MWPW-158236](https://jira.corp.adobe.com/browse/MWPW-158236)

**Steps to test the before vs. after and expectations:**
- https://quote-gradient-adjust-before--express--adobecom.hlx.page/drafts/kennethlum/try-quotes?martech=off
- https://quote-gradient-adjust-before--express--adobecom.hlx.page/drafts/integration/simplified-homepage?martech=off
- 
**Pages to check for regression and performance:**
- https://quote-gradient-adjust-after--express--adobecom.hlx.page/drafts/kennethlum/try-quotes?martech=off
- https://quote-gradient-adjust-after--express--adobecom.hlx.page/drafts/integration/simplified-homepage?martech=off

**Additional regression checks for the default block and variants for existing pages: (from the .xls file as of July 2024)**
(there was only the default block in the past)
- https://quote-singular-after--express--adobecom.hlx.page/express/business/teams
- https://quote-singular-after--express--adobecom.hlx.page/express/discover/quotes/nature
- https://quote-singular-after--express--adobecom.hlx.page/express/create/flyer
