### PR TITLE
[MWPW-159048] Light Colored Primary CTA For Marquee

### DIFF
--- a/express/blocks/marquee/marquee.css
+++ b/express/blocks/marquee/marquee.css
@@ -20,8 +20,6 @@ body.no-desktop-brand-header header {
   margin: auto;
   width: 100%;
   box-sizing: border-box;
-  --color-white: #FFF;
-  --color-black: #000;
 }
 
 .marquee.light-primary-cta a.button.primaryCTA {

--- a/express/blocks/marquee/marquee.css
+++ b/express/blocks/marquee/marquee.css
@@ -29,6 +29,7 @@ body.no-desktop-brand-header header {
   color: var(--color-black);
   border-color:transparent;
 }
+
 .marquee.light-primary-cta a.button.primaryCTA:hover{
   border-color: transparent;
   background-color: #FDFDFD;

--- a/express/blocks/marquee/marquee.css
+++ b/express/blocks/marquee/marquee.css
@@ -20,6 +20,17 @@ body.no-desktop-brand-header header {
   margin: auto;
   width: 100%;
   box-sizing: border-box;
+  --color-white: #FFF;
+  --color-black: #000;
+}
+
+.marquee.light-primary-cta a.button.primaryCTA {
+  background: var(--color-white);
+  color: var(--color-black);
+  border-color:transparent;
+}
+.marquee.light-primary-cta a.button.primaryCTA:hover{
+  border-color: transparent;
 }
 
 .marquee.appear {

--- a/express/blocks/marquee/marquee.css
+++ b/express/blocks/marquee/marquee.css
@@ -32,7 +32,7 @@ body.no-desktop-brand-header header {
 
 .marquee.light-primary-cta a.button.primaryCTA:hover{
   border-color: transparent;
-  background-color: #FDFDFD;
+  background-color: #E6E6E6;
 }
 
 .marquee.appear {

--- a/express/blocks/marquee/marquee.css
+++ b/express/blocks/marquee/marquee.css
@@ -31,6 +31,7 @@ body.no-desktop-brand-header header {
 }
 .marquee.light-primary-cta a.button.primaryCTA:hover{
   border-color: transparent;
+  background-color: #FDFDFD;
 }
 
 .marquee.appear {


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Issue/Feature 1
- Adds light colored primary CTA to the marquee block for visual accessibility request.

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-159048

**Steps to test the before vs. after and expectations:**
- Steps for feature 1
   View the preview page and verify that the desktop version of the page has no visible graphical errors. 

For QA
  Visit the authoring document linked below and verify that removing the light-primary-cta makes the page look the same as www.adobe.com/express , the current home page.
  Verify that adding it back in makes the primary CTA button look white on mobile and desktop. Keep in mind that both marquee blocks in the document should be edited. 

<img width="818" alt="Screenshot 2024-09-26 at 11 06 53 AM" src="https://github.com/user-attachments/assets/858328e2-7643-4221-8162-c0777c7a9651">


<img width="1299" alt="Screenshot 2024-09-26 at 11 00 12 AM" src="https://github.com/user-attachments/assets/53babbf0-4222-49a8-8cd5-5edb58039417">


**Pages to check for regression and performance:**
https://marquee-light-buttons--express--adobecom.hlx.page/drafts/echen/index-copy-1 

(Control, **do not edit**)

https://marquee-light-buttons--express--adobecom.hlx.page/express/?mep=%2Fexpress%2Fpersonalization%2Fentitled.json--express-entitled+%26+desktop
