### PR TITLE
Remove unnecessary z-index from fullscreen marquee

### DIFF
--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -125,7 +125,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 10;
   opacity: 0;
   cursor: pointer;
   border-radius: 24px;


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- issue: fullscreen marquee CTA overlay covering gnav (z-index sits too high)

**Resolves:** [MWPW-159230](https://jira.corp.adobe.com/browse/MWPW-159230)

**Steps to test the before vs. after and expectations:**
- Go to https://www.adobe.com/express/create/video/instagram/reel and scroll down until the 3d modal of the fullscreen marquee is partially behind Gnav, 
- Try to interact with the Gnav menus.

**Pages to check for regression and performance:**
- https://mwpw-159230--express--adobecom.hlx.page/express/create/video/instagram/reel?martech=off
