### PR TITLE
[Hotfix] Remove gnav link update logic

### DIFF
--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -177,17 +177,6 @@ async function loadFEDS() {
       window.feds.components.NavBar.disableRetractability();
     }
 
-    /* attempt to switch link */
-    if (window.location.pathname.includes('/create/')
-      || window.location.pathname.includes('/discover/')
-      || window.location.pathname.includes('/feature/')) {
-      const $aNav = document.querySelector('header a.feds-navLink--primaryCta');
-      const $aHero = document.querySelector('main > div:first-of-type a.button.accent');
-      if ($aNav && $aHero) {
-        $aNav.href = $aHero.href;
-      }
-    }
-
     /* switch all links if lower env */
     const env = getHelixEnv();
     if (env && env.spark) {


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- GNAV's primaryCTA link was overwritten unintentionally by page's primaryCTA link

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-159228

**Steps to test the before vs. after and expectations:**
- Open the Creativity dropdown of GNAV
- FInd the `View plans and pricing cta`
- It should be pointing at the right creative cloud plans and pricing page

**Pages to check for regression and performance:**
- https://hotfix-gnav-primary--express--adobecom.hlx.live/express/?martech=off
