### PR TITLE
remove padding-left from homepage cards

### DIFF
--- a/express/blocks/discover-cards/discover-cards.css
+++ b/express/blocks/discover-cards/discover-cards.css
@@ -72,9 +72,6 @@ main .section .discover-cards {
 }
 
 @media (min-width: 401px) {  
-    main .section .discover-cards {
-        padding-left: 20px;
-    }
     .discover-cards .cards-container .card {
         min-width: 399px;
         height: 478px;


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- removes padding-left from left edge of discover-cards container on homepage (prevents whitespace when carousel is scrolled)

**Pages to check for regression and performance:**
- https://homepage-cards--express--adobecom.hlx.page/drafts/integration/simplified-homepage
