### PR TITLE
[Pricing] Added top padding for injected headline's logo

### DIFF
--- a/express/blocks/headline/headline.css
+++ b/express/blocks/headline/headline.css
@@ -1,4 +1,5 @@
 .headline .express-logo {
   width: unset;
   height: 30px;
+  padding-top: 30px;
 }


### PR DESCRIPTION
**Fixes following issues:**
- Current headline block if used as the first block, will inject a logo to its top. But since headline block has no self styles, pages could be missing space between gnav and the logo

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-153729?filter=381833

**Steps to test the before vs. after and expectations:**
- Observe the spacing between gnav and the logo vs production

**Pages to check for regression and performance:**
- https://logo-top-padding--express--adobecom.hlx.page/express/pricing?martech=off
