### PR TITLE
[Simplified Homepage] Quote singular bottom spacing to next block

### DIFF
--- a/express/blocks/quotes/quotes.css
+++ b/express/blocks/quotes/quotes.css
@@ -136,7 +136,7 @@ main .quotes.singular .quote {
   background: transparent;
   justify-content: center;
   padding: 70px 0 70px;
-  min-height: 390px;
+  min-height: 370px;
 }
 
 main .quotes.singular .author-photo {
@@ -205,7 +205,7 @@ main .quotes.singular .mobile-container .author-panel .author-photo {
 @media (min-width: 600px) {
   main .quotes.singular .quote {
     width: 80%;
-    min-height: 335px;
+    min-height: 315px;
   }
 }
 

--- a/express/blocks/quotes/quotes.css
+++ b/express/blocks/quotes/quotes.css
@@ -135,7 +135,7 @@ main .quotes.singular .quote {
   flex-flow: row;
   background: transparent;
   justify-content: center;
-  padding: 70px 0 70px;
+  padding: 70px 0;
   min-height: 370px;
 }
 


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- In the Simplified Homepage, the spacing between the singular quote and the pricing cards is a little too big. The gradient was previously moved up a little bit, so the bottom spacing can be made smaller.

**Resolves:** [MWPW-159367](https://jira.corp.adobe.com/browse/MWPW-159367)

**Steps to test the before vs. after and expectations:**
- https://quote-bottom-spacing-before--express--adobecom.hlx.page/drafts/integration/simplified-homepage?martech=off
- https://quote-bottom-spacing-before--express--adobecom.hlx.page/drafts/kennethlum/try-quotes?martech=off

**Pages to check for regression and performance:**
- https://quote-bottom-spacing-after--express--adobecom.hlx.page/drafts/integration/simplified-homepage?martech=off
- https://quote-bottom-spacing-after--express--adobecom.hlx.page/drafts/kennethlum/try-quotes?martech=off
