### PR TITLE
homepage cards - remaining style issues

### DIFF
--- a/express/blocks/discover-cards/discover-cards.css
+++ b/express/blocks/discover-cards/discover-cards.css
@@ -71,7 +71,16 @@ main .section .discover-cards {
     width: 78px;
 }
 
-@media (min-width: 401px) {  
+.discover-cards .cards-container.gallery {
+    scroll-padding-left: 20px;
+}  
+.discover-cards .cards-container .card:first-child {
+    margin-left: 20px;
+}
+
+
+
+@media (min-width: 400px) {  
     .discover-cards .cards-container .card {
         min-width: 399px;
         height: 478px;
@@ -99,5 +108,23 @@ main .section .discover-cards {
     .discover-cards .cards-container .card picture img.short { 
         width: 351px;
         height: 198px; 
+    }
+}
+
+@media (min-width: 600px) {  
+    .discover-cards .cards-container.gallery {
+        scroll-padding-left: 60px;
+    }  
+    .discover-cards .cards-container .card:first-child {
+        margin-left: 60px;
+    }
+}
+
+@media (min-width: 1200px) {  
+    .discover-cards .cards-container.gallery {
+        scroll-padding-left: 100px;
+    }  
+    .discover-cards .cards-container .card:first-child {
+        margin-left: 100px;
     }
 }

--- a/express/blocks/discover-cards/discover-cards.css
+++ b/express/blocks/discover-cards/discover-cards.css
@@ -78,9 +78,7 @@ main .section .discover-cards {
     margin-left: 20px;
 }
 
-
-
-@media (min-width: 400px) {  
+@media (min-width: 600px) {  
     .discover-cards .cards-container .card {
         min-width: 399px;
         height: 478px;
@@ -109,9 +107,6 @@ main .section .discover-cards {
         width: 351px;
         height: 198px; 
     }
-}
-
-@media (min-width: 600px) {  
     .discover-cards .cards-container.gallery {
         scroll-padding-left: 60px;
     }  

--- a/express/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.css
@@ -267,6 +267,12 @@ main .gen-ai-cards.homepage .carousel-container .carousel-fader-right {
     text-align: center;
     max-width: none;
 }
+.gen-ai-cards.homepage .carousel-container {
+  scroll-padding-left: 20px;
+}  
+.gen-ai-cards.homepage .carousel-container .carousel-element.card:nth-child(2){
+  margin-left: 20px;
+}
 
 @media (min-width: 900px) {
   .gen-ai-cards .gen-ai-cards-heading-section {

--- a/express/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.css
@@ -279,7 +279,7 @@ main .gen-ai-cards.homepage .carousel-container .carousel-fader-right {
     width: 357px;
     height: 396px;
   }
-  .gen-ai-cards .card .text-wrapper {
+  .gen-ai-cards.homepage .card .text-wrapper {
     text-align: left;
     margin: 20px 20px 12px 20px;
   }

--- a/express/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.css
@@ -44,6 +44,12 @@
   align-items: unset;
 }
 
+.gen-ai-cards.homepage .carousel-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
 .gen-ai-cards .card {
   position: relative;
   height: 347px;
@@ -242,22 +248,24 @@ main .gen-ai-cards.homepage .carousel-container .carousel-fader-right {
   top: 45px;
   right: 15px;
 }
+.gen-ai-cards.homepage .gen-ai-cards-heading-section {
+  margin-left: 20px;
+  margin-right: 20px;
+  display: inline-block;
+}
 
-@media (min-width: 400px) {
-  .section .gen-ai-cards-wrapper.homepage {
-    max-width: fit-content;
-  }
-  .gen-ai-cards.homepage .gen-ai-cards-heading {
-    font-size: 36px;
-  }
-  .gen-ai-cards.homepage .gen-ai-cards-heading-section {
-    display: inline-block;
-  }
-  .gen-ai-cards.homepage .gen-ai-cards-heading-section h2, 
-  .gen-ai-cards .gen-ai-cards-heading-section p {
+.gen-ai-cards.homepage .gen-ai-cards-heading {
+  font-size: 36px;
+}
+
+.section .gen-ai-cards-wrapper.homepage {
+  max-width: fit-content;
+}
+
+.gen-ai-cards.homepage .gen-ai-cards-heading-section h2, 
+.gen-ai-cards .gen-ai-cards-heading-section p {
     text-align: center;
     max-width: none;
-  }
 }
 
 @media (min-width: 900px) {

--- a/express/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.css
@@ -9,8 +9,8 @@
 }
 
 .gen-ai-cards.homepage {
-  padding-left: 0px;
-  padding-right: 0px;
+  padding-left: 0;
+  padding-right: 0;
 }
 
 .gen-ai-cards .gen-ai-cards-heading-section {

--- a/express/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.css
@@ -275,6 +275,9 @@ main .gen-ai-cards.homepage .carousel-container .carousel-fader-right {
 }
 
 @media (min-width: 900px) {
+  .gen-ai-cards.homepage .carousel-container .carousel-element.card:nth-child(2){
+    margin-left: 0px;
+  }
   .gen-ai-cards .gen-ai-cards-heading-section {
       flex-direction: row;
       align-items: flex-end;

--- a/express/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.css
@@ -8,6 +8,11 @@
   margin: auto;
 }
 
+.gen-ai-cards.homepage {
+  padding-left: 0px;
+  padding-right: 0px;
+}
+
 .gen-ai-cards .gen-ai-cards-heading-section {
   display: flex;
   flex-direction: column;
@@ -213,6 +218,29 @@
 
 .gen-ai-cards .card .links-wrapper a:not(:hover) {
   background-color: var(--color-white);
+}
+
+main .gen-ai-cards.homepage .carousel-container .carousel-platform.left-fader:not(.right-fader) {
+  -webkit-mask-image: none; 
+  mask-image: none;
+}
+
+main .gen-ai-cards.homepage .carousel-container .carousel-platform.right-fader:not(.left-fade) {
+  -webkit-mask-image: none; 
+  mask-image: none;
+}
+
+main .gen-ai-cards.homepage .carousel-container .carousel-fader-left {
+  align-items: end;
+  top: 45px;
+  right: 42px;
+  left: auto; 
+}
+
+main .gen-ai-cards.homepage .carousel-container .carousel-fader-right {
+  align-items: end;
+  top: 45px;
+  right: 15px;
 }
 
 @media (min-width: 900px) {

--- a/express/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.css
@@ -281,7 +281,7 @@ main .gen-ai-cards.homepage .carousel-container .carousel-fader-right {
   }
   .gen-ai-cards.homepage .card .text-wrapper {
     text-align: left;
-    margin: 20px 20px 12px 20px;
+    margin: 20px 20px 12px;
   }
 }
 

--- a/express/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.css
@@ -60,7 +60,7 @@
 }
 
 .gen-ai-cards.homepage .carousel-element.card {
-  width: 316px;
+  width: 292px;
   height: 396px;
 }
 
@@ -243,6 +243,23 @@ main .gen-ai-cards.homepage .carousel-container .carousel-fader-right {
   right: 15px;
 }
 
+@media (min-width: 400px) {
+  .section .gen-ai-cards-wrapper.homepage {
+    max-width: fit-content;
+  }
+  .gen-ai-cards.homepage .gen-ai-cards-heading {
+    font-size: 36px;
+  }
+  .gen-ai-cards.homepage .gen-ai-cards-heading-section {
+    display: inline-block;
+  }
+  .gen-ai-cards.homepage .gen-ai-cards-heading-section h2, 
+  .gen-ai-cards .gen-ai-cards-heading-section p {
+    text-align: center;
+    max-width: none;
+  }
+}
+
 @media (min-width: 900px) {
   .gen-ai-cards .gen-ai-cards-heading-section {
       flex-direction: row;
@@ -254,26 +271,18 @@ main .gen-ai-cards.homepage .carousel-container .carousel-fader-right {
   }
 }
 
-@media (min-width: 401px) {
-  .section .gen-ai-cards-wrapper.homepage {
-    max-width: fit-content;
-  }
-  .gen-ai-cards.homepage .gen-ai-cards-heading {
-    font-size: 36px;
-  }
-  .gen-ai-cards.homepage .carousel-element.card {
-    width: 353px;
-    height: 396px;
-  }
+@media (min-width: 1200px) {
   .gen-ai-cards.homepage .carousel-element.card .media-wrapper {
     width: 325px;
   }
-  .gen-ai-cards.homepage .gen-ai-cards-heading-section {
-    display: inline-block;
+  .gen-ai-cards.homepage .carousel-element.card {
+    width: 357px;
+    height: 396px;
   }
-  .gen-ai-cards.homepage .gen-ai-cards-heading-section h2, 
-  .gen-ai-cards .gen-ai-cards-heading-section p {
-    text-align: center;
-    max-width: none;
+  .gen-ai-cards .card .text-wrapper {
+    text-align: left;
+    margin: 20px 20px 12px 20px;
   }
 }
+
+


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Fix left spacing on discover cards and gen-ai on smaller screens
- Ensure card navigation moves to bottom right of GenAI and remove linear gradient on left to right navigation
- Ensure responsive gen-ai card sizing

**Resolves:** [MWPW-159393](https://jira.corp.adobe.com/browse/MWPW-159393)

**Pages to check for regression and performance:**
- https://cards-home-page--express--adobecom.hlx.page/drafts/integration/simplified-homepage?martech=off
