### PR TITLE
[MWPW-159293] Sticky Header For Pricing Table Fix

### DIFF
--- a/express/blocks/pricing-table/pricing-table.js
+++ b/express/blocks/pricing-table/pricing-table.js
@@ -307,10 +307,12 @@ export default async function init(el) {
       const gnavHeight = gnav.offsetHeight;
       const { top } = rows[0].getBoundingClientRect();
       if (top <= gnavHeight && !rows[0].classList.contains('stuck')) {
-        rows[0].classList.add('stuck');
         rows[0].style.top = `${gnavHeight}px`;
       } else if (rows[0].classList.contains('stuck') && top > gnavHeight) {
         rows[0].classList.remove('stuck');
+      }
+      if (top <= gnavHeight - 75 && !rows[0].classList.contains('stuck')) {
+        rows[0].classList.add('stuck');
       }
     };
     window.addEventListener('scroll', debounce(scrollHandler, 30), { passive: true });


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Issue/Feature 1
Using the Tabbed Button feature on this page causes a sticky header to show prematurely. This is visually jarring. 

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-159293

**Steps to test the before vs. after and expectations:**
- Steps for feature 1
- Scroll down to the section in the first image.
- Visit the branch link page and verify that switching between "Teams" and "Individual" tabs does not cause a sticky header to appear prematurely like on the prod page. 

**Pages to check for regression and performance:**
https://compare-page-hover--express--adobecom.hlx.page/express/why-choose-express
https://www.adobe.com/express/why-choose-express

<img width="1141" alt="Screenshot 2024-09-30 at 1 51 54 PM" src="https://github.com/user-attachments/assets/38f813dd-6692-423a-b0d4-97206574936e">
