### PR TITLE
remove z-index from how-to-steps.css

### DIFF
--- a/express/blocks/how-to-steps/how-to-steps.css
+++ b/express/blocks/how-to-steps/how-to-steps.css
@@ -155,9 +155,7 @@ main .section .template-x-heading {
   background-color: #ffffff;
   box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 8px;
   border-radius: 15px;
-  z-index: 100;
   position: relative;
-  z-index: 10;
 }
 
 .enlarged-template-img {


### PR DESCRIPTION
Fixes following issues|Adds following features:
https://jira.corp.adobe.com/browse/MWPW-159422
removes z-index from image-wrapper in the how-steps.css
Pages to check for regression and performance:
https://z-index-image-bug--express--adobecom.hlx.page/express/feature/image/editor