### PR TITLE
[Analytics] Add Block Info to floatingCTA Tagging

### DIFF
--- a/express/blocks/bubble-ui-button/bubble-ui-button.js
+++ b/express/blocks/bubble-ui-button/bubble-ui-button.js
@@ -386,7 +386,7 @@ export async function createMultiFunctionButton($block, data, audience) {
 }
 
 export default async function decorate($block) {
-  if ($block.classList.contains('metadata-powered')) {
+  if ($block.classList.contains('meta-powered')) {
     const audience = $block.querySelector(':scope > div').textContent.trim();
     if (audience === 'mobile') {
       $block.closest('.section').remove();

--- a/express/blocks/floating-button/floating-button.js
+++ b/express/blocks/floating-button/floating-button.js
@@ -9,7 +9,7 @@ import {
 
 export default function decorate(block) {
   addTempWrapper(block, 'floating-button');
-  if (!block.classList.contains('metadata-powered')) {
+  if (!block.classList.contains('meta-powered')) {
     block.parentElement?.remove();
     return;
   }

--- a/express/blocks/multifunction-button/multifunction-button.js
+++ b/express/blocks/multifunction-button/multifunction-button.js
@@ -86,7 +86,7 @@ export function createMultiFunctionButton(block, data, audience) {
 export default async function decorate(block) {
   addTempWrapper(block, 'multifunction-button');
 
-  if (!block.classList.contains('metadata-powered')) return;
+  if (!block.classList.contains('meta-powered')) return;
 
   const audience = block.querySelector(':scope > div').textContent.trim();
   if (audience === 'mobile') {

--- a/express/blocks/shared/floating-cta.js
+++ b/express/blocks/shared/floating-cta.js
@@ -175,6 +175,7 @@ export function createFloatingButton(block, audience, data) {
     class: 'floating-button block',
     'data-block-name': 'floating-button',
     'data-block-status': 'loaded',
+    'data-block': '',
   });
   [...block.classList].filter((c) => c === 'closed').forEach((c) => floatButtonWrapper.classList.add(c));
   const floatButtonInnerWrapper = createTag('div', { class: 'floating-button-inner-wrapper' });

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -663,7 +663,7 @@ export async function decorateBlock(block) {
     // split and add options with a dash
     // (fullscreen-center -> fullscreen-center + fullscreen + center)
     const extra = [];
-    const skipList = ['same-fcta'];
+    const skipList = ['same-fcta', 'meta-powered'];
     block.classList.forEach((className, index) => {
       if (index === 0 || skipList.includes(className)) return; // block name or skip, no split
       const split = className.split('-');
@@ -1927,7 +1927,7 @@ async function buildAutoBlocks(main) {
 
     if (blockName && validButtonVersion.includes(blockName) && lastDiv) {
       const button = buildBlock(blockName, device);
-      button.classList.add('metadata-powered');
+      button.classList.add('meta-powered');
       lastDiv.append(button);
       BlockMediator.set('floatingCtasLoaded', true);
     }

--- a/test/unit/blocks/floating-button/mocks/body.html
+++ b/test/unit/blocks/floating-button/mocks/body.html
@@ -1,6 +1,6 @@
 <main>
   <div class="section">
-    <div class="floating-button metadata-powered block" data-block-name="floating-button"
+    <div class="floating-button meta-powered block" data-block-name="floating-button"
       data-block-status="loading">
       <div>mobile</div>
       <div class="button-container">


### PR DESCRIPTION
**Adds following features:**
- Adds block info to Analytics tracking. Now it should say it's a floating-button or a multi-function button, etc.
- Renamed a class metadata-powered to meta-powered since Milo is doing a string includes className check for the word **metadata**

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-159394

**Steps to test the before vs. after and expectations:**
- Scroll down so that the floatingCTA appears
- Right click and inspect the floatingCTA block
- You should see that it used to not have "daa-lh", but now should have something like `daa-lh="b1|floating-button"`
- Or, you could use https://chromewebstore.google.com/detail/adobe-hawkeye-link-audito/ffiidihjbbghpfelfplkcgbdjkjdcajj?pli=1, and review the link
Before:
![SC 2024-09-30 at 10 15 30 PM](https://github.com/user-attachments/assets/5722ab88-78e7-4ef3-98c9-f2a56dfff47c)

vs.
After:
![SC 2024-09-30 at 10 14 47 PM](https://github.com/user-attachments/assets/2f3c4821-8aa4-477c-ac7f-ffda63d357d3)


**Pages to check for regression: All floatingCTA Desktop/Mobile on those pages should function the same as in PROD, except being tagged differently**
- https://fcta-tracking--express--adobecom.hlx.live/express/create/poster
- https://fcta-tracking--express--adobecom.hlx.live/express/
