### PR TITLE
Blue banner and slightly larger text in CTA

### DIFF
--- a/express/blocks/banner/banner.css
+++ b/express/blocks/banner/banner.css
@@ -5,7 +5,7 @@ main .section.banner-compact-container {
 }
 
 main div:has(> .banner.cool) {
-  background: linear-gradient(155.96deg, #bfe4ff -0.25%, #cecef6 104.12%);
+  background: linear-gradient(170.96deg, #bfe4ff -0.25%, #cecef6 104.12%);
 }
 
 main .section.banner-container,

--- a/express/blocks/banner/banner.css
+++ b/express/blocks/banner/banner.css
@@ -171,6 +171,9 @@ main .banner.cool h2 {
   main .banner.cool p.button-container {
     margin-top: 21px;
   }
+  main .banner.cool p.button-container a.button {
+    font-size: 19px;
+  }
 }
 
 @media (min-width: 1200px) {


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- purplish padding up top fix
- beyond 900px width, the CTA text should be slightly larger

**Resolves:** [MWPW-159545](https://jira.corp.adobe.com/browse/MWPW-159545)

**Steps to test the before vs. after and expectations:**
- https://blue-banner-before--express--adobecom.hlx.page/drafts/integration/simplified-homepage?martech=off

**Pages to check for regression and performance:**
- https://blue-banner-after--express--adobecom.hlx.page/drafts/integration/simplified-homepage?martech=off
