### PR TITLE
fix cta-carousel and gen-ai-cards search branch link usp auto poopula…

### DIFF
--- a/express/blocks/cta-carousel/cta-carousel.js
+++ b/express/blocks/cta-carousel/cta-carousel.js
@@ -126,6 +126,7 @@ function buildGenAIUpload(cta, card) {
 async function decorateCards(block, payload) {
   const cards = createTag('div', { class: 'cta-carousel-cards' });
   const placeholders = await fetchPlaceholders();
+  const searchBranchLinks = placeholders['search-branch-links']?.replace(/\s/g, '')?.split(',') || [];
 
   payload.actions.forEach((cta, index) => {
     const card = createTag('div', { class: 'card' });
@@ -169,11 +170,11 @@ async function decorateCards(block, payload) {
         a.textContent = '';
         a.classList.add('clickable-overlay');
       }
-      const searchBranchLinks = placeholders['search-branch-links']?.replace(/\s/g, '')?.split(',');
+
       cta.ctaLinks.forEach((a) => {
-        if (a.href && searchBranchLinks.includes(a.href)) {
+        if (a.href) {
           const btnUrl = new URL(a.href);
-          if (placeholders?.['search-branch-links']?.replace(/\s/g, '').split(',').includes(`${btnUrl.origin}${btnUrl.pathname}`)) {
+          if (searchBranchLinks.includes(`${btnUrl.origin}${btnUrl.pathname}`)) {
             btnUrl.searchParams.set('q', cta.text);
             btnUrl.searchParams.set('category', 'templates');
             a.href = decodeURIComponent(btnUrl.toString());

--- a/express/blocks/gen-ai-cards/gen-ai-cards.js
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.js
@@ -118,6 +118,7 @@ function removeLazyAfterNeighborLoaded(image, lastImage) {
 async function decorateCards(block, { actions }) {
   const cards = createTag('div', { class: 'gen-ai-cards-cards' });
   const placeholders = await fetchPlaceholders();
+  const searchBranchLinks = placeholders['search-branch-links']?.replace(/\s/g, '')?.split(',') || [];
 
   actions.forEach((cta, i) => {
     const {
@@ -151,7 +152,7 @@ async function decorateCards(block, { actions }) {
       } else {
         const a = ctaLinks[0];
         const btnUrl = new URL(a.href);
-        if (placeholders?.['search-branch-links']?.replace(/\s/g, '').split(',').includes(`${btnUrl.origin}${btnUrl.pathname}`)) {
+        if (searchBranchLinks.includes(`${btnUrl.origin}${btnUrl.pathname}`)) {
           btnUrl.searchParams.set('q', cta.text);
           btnUrl.searchParams.set('category', 'templates');
           a.href = decodeURIComponent(btnUrl.toString());


### PR DESCRIPTION
**Resolves:** [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Steps to test the before vs. after and expectations:**
Compare the 2 links below, we can see the q url param missing in the CTA carousel links (when the link is one of the search branch links) on stage and it being present on the feature branch.
![Screenshot 2024-10-01 at 3 43 34 PM](https://github.com/user-attachments/assets/c35f9009-947b-4ad2-bbfd-b9c14596a882)

**Pages to check for regression and performance:**
 - https://search-branch-link-fix--express--adobecom.hlx.page/express/?marthch=off
 - https://stage--express--adobecom.hlx.page/express/?marthch=off
