### PR TITLE
[SearchBranchLinking] CTA Carousels deduct dimensions from subtext

### DIFF
--- a/express/blocks/cta-carousel/cta-carousel.js
+++ b/express/blocks/cta-carousel/cta-carousel.js
@@ -181,9 +181,11 @@ async function decorateCards(block, payload) {
               const match = /(\d+)x(\d+)(.+)/.exec(cta.subtext);
               if (match) {
                 const [, width, height, unit] = match;
-                if (!btnUrl.searchParams.get('width')) btnUrl.searchParams.set('width', width);
-                if (!btnUrl.searchParams.get('height'))btnUrl.searchParams.set('height', height);
-                if (!btnUrl.searchParams.get('unit'))btnUrl.searchParams.set('unit', unit);
+                if (unit === 'px' || unit === 'in') {
+                  btnUrl.searchParams.get('width') || btnUrl.searchParams.set('width', width);
+                  btnUrl.searchParams.get('height') || btnUrl.searchParams.set('height', height);
+                  btnUrl.searchParams.get('unit') || btnUrl.searchParams.set('unit', unit);
+                }
               }
             }
             a.href = decodeURIComponent(btnUrl.toString());

--- a/express/blocks/cta-carousel/cta-carousel.js
+++ b/express/blocks/cta-carousel/cta-carousel.js
@@ -177,6 +177,15 @@ async function decorateCards(block, payload) {
           if (searchBranchLinks.includes(`${btnUrl.origin}${btnUrl.pathname}`)) {
             btnUrl.searchParams.set('q', cta.text);
             btnUrl.searchParams.set('category', 'templates');
+            if (cta.subtext) {
+              const match = /(\d+)x(\d+)(.+)/.exec(cta.subtext);
+              if (match) {
+                const [, width, height, unit] = match;
+                if (!btnUrl.searchParams.get('width')) btnUrl.searchParams.set('width', width);
+                if (!btnUrl.searchParams.get('height'))btnUrl.searchParams.set('height', height);
+                if (!btnUrl.searchParams.get('unit'))btnUrl.searchParams.set('unit', unit);
+              }
+            }
             a.href = decodeURIComponent(btnUrl.toString());
           }
           a.removeAttribute('title');


### PR DESCRIPTION
**Adds following features:**
- Adds width & height & unit to search branch links of cta-carousel. The only supported units are px and in

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-159045?filter=381833

**Steps to test the before vs. after and expectations:**
- Go to homepage's Recommended Tab
- Inspect the href of the "Instagram square post" create CTA
- You should see width&unit&height being appended

**Pages to check for regression and performance:**
- https://search-branch-dimension--express--adobecom.hlx.page/express/?martech=off
