### PR TITLE
[Post Back to School Clean up] Remove SUSI-Everywhere Fragment

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -138,17 +138,6 @@ const listenAlloy = () => {
   }, 3000);
 };
 
-function registerSUSIModalLinks() {
-  const container = createTag('div', {}, `
-    <div>
-      <a href='https://www.adobe.com/express/fragments/susi-light-teacher#susi-light-1' rel: 'nofollow'></a>
-    </div>`);
-  container.style = 'display:none;position:absolute';
-  const main = document.querySelector('main');
-  const lastDiv = main.querySelector(':scope > div:last-of-type');
-  lastDiv.childElementCount === 0 ? main.insertBefore(container, lastDiv) : main.append(container);
-}
-
 (async function loadPage() {
   if (window.hlx.init || window.isTestEnv) return;
   window.hlx = window.hlx || {};
@@ -171,7 +160,6 @@ function registerSUSIModalLinks() {
   loadExpressMartechSettings();
   loadLana({ clientId: 'express' });
   listenAlloy();
-  registerSUSIModalLinks(); // TODO: remove post bts
   await loadArea();
 
   import('./express-delayed.js').then((mod) => {


### PR DESCRIPTION
**Removes following features:**
- SUSI-Modal that appears everywhere in the site, following a `#susi-light-1` hash change

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-159584

**Steps to test the before vs. after and expectations:**
- Go to any express page with a ending hash `#susi-light-1` like https://stage--express--adobecom.hlx.page/express/?martech=off#susi-light-1
- On prod/stage, a modal should pop up. On this branch, it's no longer showing

**Pages to check for regression and performance:**
- https://rm-susi-everywhere--express--adobecom.hlx.page/express/?martech=off#susi-light-1
