### PR TITLE
Header on Gen-AI Cards Too Large On Mobile

### DIFF
--- a/express/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.css
@@ -254,8 +254,12 @@ main .gen-ai-cards.homepage .carousel-container .carousel-fader-right {
   display: inline-block;
 }
 
+.gen-ai-cards.homepage .gen-ai-cards-heading-section p {
+  font-size: 16px;
+}
+
 .gen-ai-cards.homepage .gen-ai-cards-heading {
-  font-size: 36px;
+  font-size: 22px;
 }
 
 .section .gen-ai-cards-wrapper.homepage {
@@ -281,6 +285,9 @@ main .gen-ai-cards.homepage .carousel-container .carousel-fader-right {
   .gen-ai-cards .gen-ai-cards-heading-section {
       flex-direction: row;
       align-items: flex-end;
+  }
+  .gen-ai-cards.homepage .gen-ai-cards-heading {
+    font-size: 36px;
   }
   .gen-ai-cards .carousel-container .carousel-fader-left,
   .gen-ai-cards .carousel-container .carousel-fader-right{


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Header on Gen-AI Cards Too Large On Mobile

**Resolves:** [MWPW-158234](https://jira.corp.adobe.com/browse/MWPW-158234)

**Steps to test the before vs. after and expectations:**


**Pages to check for regression and performance:**
- https://homepage-cards-updates--express--adobecom.hlx.page/express/?martech=off
