### PR TITLE
[Template Search Tracking] Add Potentially Missing Location Param

### DIFF
--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -145,7 +145,7 @@ function initSearchFunction(block, searchBarWrapper) {
     if (allTemplatesMetadata.some(pathMatchX) && document.body.dataset.device !== 'mobile') {
       targetLocation = `${window.location.origin}${targetPathX}?searchId=${searchId || ''}`;
     } else if (allTemplatesMetadata.some(pathMatch) && document.body.dataset.device !== 'desktop') {
-      targetLocation = `${window.location.origin}${targetPath}`;
+      targetLocation = `${window.location.origin}${targetPath}?searchId=${searchId || ''}`;
     } else {
       const searchUrlTemplate = `/express/templates/search?tasks=${currentTasks.xCore}&tasksx=${currentTasks.content}&phformat=${format}&topics=${searchInput || "''"}&q=${searchBar.value || "''"}&searchId=${searchId || ''}`;
       targetLocation = `${window.location.origin}${prefix}${searchUrlTemplate}`;

--- a/express/scripts/template-search-api-v3.js
+++ b/express/scripts/template-search-api-v3.js
@@ -187,6 +187,8 @@ export function trackSearch(eventName, searchID = generateSearchId()) {
 
   // eslint-disable-next-line no-undef
   const impression = cleanPayload(structuredClone(BlockMediator.get('templateSearchSpecs')), eventName);
+  // catch location missing scenarios
+  if (!impression.custom_ui_location) impression.custom_ui_location = 'seo';
   function fireEvent() {
     _satellite.track('event', {
       xdm: {},


### PR DESCRIPTION
**Adds following features:**
- We were unable to reproduce a scenario where the custom_ui_location field becomes null in Amplitude. This is an experimental fix with the hope that post deploying, we see the number of null reducing or unchanged, thus providing us more insights.

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-157759

**Steps to test the before vs. after and expectations:**
- We were not able to reproduce scenarios where custom_ui_location is false. So it will have to be verified by our analysts. The PR itself should be trivial.

**Pages to check for regression and performance:**
- https://search-track-location-catch--express--adobecom.hlx.page/express/templates/flyer?martech=off
