### PR TITLE
[MWPW-160411] Image overflow on the fqa-unity block

### DIFF
--- a/express/blocks/fqa-unity/container.css
+++ b/express/blocks/fqa-unity/container.css
@@ -100,3 +100,7 @@
 .qa-workspace .pb-30px {
   padding-bottom: 30px;
 }
+
+.canvas img {
+  max-height: 100%
+}


### PR DESCRIPTION
### Description:
This PR fixes the image overflow after upload.

### Resolves: 
[MWPW-160411](https://jira.corp.adobe.com/browse/MWPW-160411)

### Screenshots:
**Before:**
![image](https://github.com/user-attachments/assets/2724c567-c1cd-4c28-9103-1ecbdc6e74f2)

**After:**
![image](https://github.com/user-attachments/assets/b46d53ee-ccbf-4536-aea4-79a114095dfd)


### Test URLs:
Before: https://unity-poc--express--adobecom.hlx.page/drafts/rbogos/unity?unitylibs=mwpw-158460-express-mapping
After: https://mwpw-160411-fqa-unity--express--adobecom.hlx.page/drafts/rbogos/unity?unitylibs=mwpw-158460-express-mapping
