### PR TITLE
Retire Default Promo Toggle Change

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -431,10 +431,7 @@ async function decorateCard({
     createPricingSection(placeholders, yPricingRow, yCtaGroup, null),
   ]);
   mPricingSection.classList.add('monthly');
-  yPricingSection.classList.add('annually');
-  // urgent update
-  const defaultHidePlan = BlockMediator.get(groupID) === 'ABM' ? 0 : 1;
-  [mPricingSection, yPricingSection][defaultHidePlan].classList.add('hide');
+  yPricingSection.classList.add('annually', 'hide');
 
   const toggle = createToggle(placeholders, [mPricingSection, yPricingSection], groupID,
     adjustElementPosition);

--- a/express/blocks/pricing-cards/pricing-toggle.js
+++ b/express/blocks/pricing-cards/pricing-toggle.js
@@ -106,8 +106,7 @@ export default function createToggle(placeholders, pricingSections, groupID, adj
       : basePlan;
     const label = placeholders?.[planLabelID];
     const buttonID = `${groupID}:${basePlan}`;
-    // urgent update
-    const isDefault = i === (BlockMediator.get(groupID) === 'ABM' ? 1 : 0);
+    const isDefault = i === 0;
     const button = createTag('button', {
       class: isDefault ? 'checked' : '',
       id: buttonID,


### PR DESCRIPTION
**Retires last month's urgent promo change in this PR:**
- https://github.com/adobecom/express/pull/1121

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-160376?filter=381833

**Steps to test the before vs. after and expectations:**
- Go to the branch link and look at the default option for the big Teams card's toggle
- It should show the first one as default, where as in stage/prod it's using the second one as default

**Page to check for regression and performance:**
- https://revert-promo-toggle--express--adobecom.hlx.live/express/pricing?martech=off
