### PR TITLE
Homepage - Align Style Of Carousel Navigation On GenAI and Discover Cards

### DIFF
--- a/express/blocks/discover-cards/discover-cards.css
+++ b/express/blocks/discover-cards/discover-cards.css
@@ -37,7 +37,6 @@ main .section .discover-cards {
     padding-right: 10px;
 }
 .discover-cards .gallery-control {
-    /* padding-top: 4px; */
     padding-top: 11px;
 }
 .discover-cards .gallery-control .status {
@@ -107,9 +106,6 @@ main .section .discover-cards {
     }
     .discover-cards .gallery-control {
         padding-top: 4px;
-    }
-    .discover-cards .gallery-control .status {
-        display: flex;
     }
     .discover-cards .cards-container .card picture img.short { 
         width: 351px;

--- a/express/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.css
@@ -278,6 +278,12 @@ main .gen-ai-cards.homepage .carousel-container .carousel-fader-right {
   margin-left: 20px;
 }
 
+main .gen-ai-cards.homepage .carousel-container .carousel-fader-left.arrow-hidden,
+main .gen-ai-cards.homepage .carousel-container .carousel-fader-right.arrow-hidden {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
 @media (min-width: 900px) {
   .gen-ai-cards.homepage .carousel-container .carousel-element.card:nth-child(2){
     margin-left: 0px;
@@ -292,6 +298,10 @@ main .gen-ai-cards.homepage .carousel-container .carousel-fader-right {
   .gen-ai-cards .carousel-container .carousel-fader-left,
   .gen-ai-cards .carousel-container .carousel-fader-right{
       background: unset;
+  }
+  main .gen-ai-cards.homepage .carousel-container .carousel-fader-left,
+  main .gen-ai-cards.homepage .carousel-container .carousel-fader-right {
+    display: none;
   }
 }
 


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Align Style Of Carousel Navigation On GenAI and Discover Cards

**Resolves:** [MWPW-160541](https://jira.corp.adobe.com/browse/MWPW-160541)

**Steps to test the before vs. after and expectations:**
**Before**
Gallery Control Visible on Discover Cards
<img width="894" alt="gallery-control-visible" src="https://github.com/user-attachments/assets/384751ff-f9fe-4e2b-ada4-c9d00b96e7e0">
GenAI Chevron One Not Visible
<img width="731" alt="GenAI Chevron One Not Visible" src="https://github.com/user-attachments/assets/1f41767e-1c3b-40da-a946-8f88576fda20">


**After**
Gallery Control Hidden on Discover Cards
<img width="903" alt="gallery-control-hidden" src="https://github.com/user-attachments/assets/21b04d81-5c0e-40a5-81db-d0ca45547f3b">
GenAI Chevron Both Visible
<img width="717" alt="GenAI Chevron Both Visible" src="https://github.com/user-attachments/assets/867cfb1e-20df-4e02-99e2-761ab2624044">


**Pages to check for regression and performance:**
- https://homepage-carousel--express--adobecom.hlx.page/drafts/integration/simplified-homepage
