### PR TITLE
Marquee tokens

### DIFF
--- a/express/blocks/marquee/marquee.js
+++ b/express/blocks/marquee/marquee.js
@@ -39,10 +39,12 @@ const breakpointConfig = [
 ];
 
 const PRICE_TOKEN = '{{pricing}}';
+const SAVE_PERCENTAGE = '{{savePercentage}}';
+const BASE_PRICING_TOKEN = '[[base-pricing-token]]';
 
 // Transforms a {{pricing}} tag into human readable format.
-async function handlePrice(block) {
-  const priceEl = block.querySelector(`[title="${PRICE_TOKEN}"]`);
+async function handlePrice(block, tokenType=PRICE_TOKEN, responseFieldName="formatted") {
+  const priceEl = block.querySelector(`[title="${tokenType}"]`);
   if (!priceEl) return null;
 
   const newContainer = createTag('span');
@@ -51,13 +53,16 @@ async function handlePrice(block) {
   priceEl.remove();
   try {
     const response = await fetchPlanOnePlans(priceEl?.href);
-    newContainer.innerHTML = response.formatted;
+    newContainer.innerHTML = response[responseFieldName];
   } catch (error) {
     window.lana.log('Failed to fetch prices for page plan');
     window.lana.log(error);
   }
   return newContainer;
 }
+
+
+
 
 // FIXME: Not fulfilling requirement. Re-think of a way to allow subtext to contain link.
 function handleSubCTAText(buttonContainer) {
@@ -514,6 +519,8 @@ async function handleOptions(div, typeHint, block) {
 export default async function decorate(block) {
   addTempWrapper(block, 'marquee');
   handlePrice(block);
+  handlePrice(block,SAVE_PERCENTAGE,"savePer");
+  handlePrice(block, BASE_PRICING_TOKEN, "bp");
   const possibleBreakpoints = breakpointConfig.map((bp) => bp.typeHint);
   const possibleOptions = ['shadow', 'background'];
   const animations = {};

--- a/express/blocks/marquee/marquee.js
+++ b/express/blocks/marquee/marquee.js
@@ -39,7 +39,7 @@ const breakpointConfig = [
 ];
 
 const PRICE_TOKEN = '{{pricing}}';
-const SAVE_PERCENTAGE = '{{savePercentage}}';
+const SAVE_PERCENTAGE = '[[savePercentage]]';
 const BASE_PRICING_TOKEN = '[[base-pricing-token]]';
 
 // Transforms a {{pricing}} tag into human readable format.
@@ -520,7 +520,7 @@ export default async function decorate(block) {
   addTempWrapper(block, 'marquee');
   handlePrice(block);
   handlePrice(block,SAVE_PERCENTAGE,"savePer");
-  handlePrice(block, BASE_PRICING_TOKEN, "bp");
+  handlePrice(block, BASE_PRICING_TOKEN, "formattedBP");
   const possibleBreakpoints = breakpointConfig.map((bp) => bp.typeHint);
   const possibleOptions = ['shadow', 'background'];
   const animations = {};

--- a/express/blocks/marquee/marquee.js
+++ b/express/blocks/marquee/marquee.js
@@ -43,7 +43,7 @@ const SAVE_PERCENTAGE = '[[savePercentage]]';
 const BASE_PRICING_TOKEN = '[[base-pricing-token]]';
 
 // Transforms a {{pricing}} tag into human readable format.
-async function handlePrice(block, tokenType=PRICE_TOKEN, responseFieldName="formatted") {
+async function handlePrice(block, tokenType = PRICE_TOKEN, responseFieldName = 'formatted') {
   const priceEl = block.querySelector(`[title="${tokenType}"]`);
   if (!priceEl) return null;
 
@@ -60,9 +60,6 @@ async function handlePrice(block, tokenType=PRICE_TOKEN, responseFieldName="form
   }
   return newContainer;
 }
-
-
-
 
 // FIXME: Not fulfilling requirement. Re-think of a way to allow subtext to contain link.
 function handleSubCTAText(buttonContainer) {
@@ -519,8 +516,8 @@ async function handleOptions(div, typeHint, block) {
 export default async function decorate(block) {
   addTempWrapper(block, 'marquee');
   handlePrice(block);
-  handlePrice(block,SAVE_PERCENTAGE,"savePer");
-  handlePrice(block, BASE_PRICING_TOKEN, "formattedBP");
+  handlePrice(block, SAVE_PERCENTAGE, 'savePer');
+  handlePrice(block, BASE_PRICING_TOKEN, 'formattedBP');
   const possibleBreakpoints = breakpointConfig.map((bp) => bp.typeHint);
   const possibleOptions = ['shadow', 'background'];
   const animations = {};

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -59,35 +59,17 @@ function getPriceElementSuffix(placeholders, placeholderArr, response) {
     .join(' ');
 }
 
-async function handlePrice(block) {
-  const priceEl = block.querySelector(`[title="${BASE_PRICING_TOKEN}"]`);
-  if (!priceEl) return null;
-
-  const newContainer = createTag('span');
-  priceEl.closest('p')?.classList.remove('button-container');
-  priceEl.after(newContainer);
-  priceEl.remove();
-  try {
-    const response = await fetchPlanOnePlans(priceEl?.href);
-    newContainer.innerHTML = response.bp;
-  } catch (error) {
-    window.lana.log('Failed to fetch prices for page plan');
-    window.lana.log(error);
-  }
-  return newContainer;
-}
-
-function handleYear2PricingToken(pricingArea, y2p, priceSuffix) {
+function handlePriceToken(pricingArea, priceToken=YEAR_2_PRICING_TOKEN, newPrice, priceSuffix='') {
   try {
     const elements = pricingArea.querySelectorAll('p');
     const year2PricingToken = Array.from(elements).find(
-      (p) => p.textContent.includes(YEAR_2_PRICING_TOKEN),
+      (p) => p.textContent.includes(priceToken),
     );
     if (!year2PricingToken) return;
-    if (y2p) {
+    if (newPrice) {
       year2PricingToken.innerHTML = year2PricingToken.innerHTML.replace(
-        YEAR_2_PRICING_TOKEN,
-        `${y2p} ${priceSuffix}`,
+        priceToken,
+        `${newPrice} ${priceSuffix}`,
       );
     } else {
       year2PricingToken.textContent = '';
@@ -259,8 +241,8 @@ async function handlePrice(placeholders, pricingArea, specialPromo, groupID, leg
   handleTooltip(pricingArea);
   handleSavePercentage(savePercentElem, isPremiumCard, response);
   handleSpecialPromo(specialPromo, isPremiumCard, response, legacyVersion);
-  handleYear2PricingToken(pricingArea, response.y2p, priceSuffixTextContent);
-
+  handlePriceToken(pricingArea,YEAR_2_PRICING_TOKEN ,response.y2p, priceSuffixTextContent);
+  handlePriceToken(pricingArea,BASE_PRICING_TOKEN ,response.formattedBP);
   priceEl?.parentNode?.remove();
   if (!priceRow) return;
   pricingArea.prepend(priceRow);

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -59,7 +59,7 @@ function getPriceElementSuffix(placeholders, placeholderArr, response) {
     .join(' ');
 }
 
-function handlePriceToken(pricingArea, priceToken=YEAR_2_PRICING_TOKEN, newPrice, priceSuffix='') {
+function handlePriceToken(pricingArea, priceToken = YEAR_2_PRICING_TOKEN, newPrice, priceSuffix = '') {
   try {
     const elements = pricingArea.querySelectorAll('p');
     const year2PricingToken = Array.from(elements).find(
@@ -241,8 +241,8 @@ async function handlePrice(placeholders, pricingArea, specialPromo, groupID, leg
   handleTooltip(pricingArea);
   handleSavePercentage(savePercentElem, isPremiumCard, response);
   handleSpecialPromo(specialPromo, isPremiumCard, response, legacyVersion);
-  handlePriceToken(pricingArea,YEAR_2_PRICING_TOKEN ,response.y2p, priceSuffixTextContent);
-  handlePriceToken(pricingArea,BASE_PRICING_TOKEN ,response.formattedBP);
+  handlePriceToken(pricingArea, YEAR_2_PRICING_TOKEN, response.y2p, priceSuffixTextContent);
+  handlePriceToken(pricingArea, BASE_PRICING_TOKEN, response.formattedBP);
   priceEl?.parentNode?.remove();
   if (!priceRow) return;
   pricingArea.prepend(priceRow);

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -32,6 +32,7 @@ const SAVE_PERCENTAGE = '{{savePercentage}}';
 const SALES_NUMBERS = '{{business-sales-numbers}}';
 const PRICE_TOKEN = '{{pricing}}';
 const YEAR_2_PRICING_TOKEN = '[[year-2-pricing-token]]';
+const BASE_PRICING_TOKEN = '[[base-pricing-token]]';
 
 function suppressOfferEyebrow(specialPromo, legacyVersion) {
   if (specialPromo.parentElement) {
@@ -56,6 +57,24 @@ function getPriceElementSuffix(placeholders, placeholderArr, response) {
         : placeholders?.[key] || '';
     })
     .join(' ');
+}
+
+async function handlePrice(block) {
+  const priceEl = block.querySelector(`[title="${BASE_PRICING_TOKEN}"]`);
+  if (!priceEl) return null;
+
+  const newContainer = createTag('span');
+  priceEl.closest('p')?.classList.remove('button-container');
+  priceEl.after(newContainer);
+  priceEl.remove();
+  try {
+    const response = await fetchPlanOnePlans(priceEl?.href);
+    newContainer.innerHTML = response.bp;
+  } catch (error) {
+    window.lana.log('Failed to fetch prices for page plan');
+    window.lana.log(error);
+  }
+  return newContainer;
 }
 
 function handleYear2PricingToken(pricingArea, y2p, priceSuffix) {


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Issue/Feature 1
 -Implements more pricing tokens for the marquee and pricing cards..

Marquee block: 

[[basePricing]] token that maps to "bp" column in offer sheet
[[savingsPercentage]] token that maps to"savePer" column in offer sheet 
 
Pricing Cards block: 

[[base-pricing-token]] token that maps to "bp" column in offer sheet


**Resolves:** https://jira.corp.adobe.com/projects/MWPW/issues/MWPW-160375

**Steps to test the before vs. after and expectations:**
- Steps for feature 1
- Visit the page below to verify that the pricing cards and marquee block have price information displayed instead of token strings (such as [[base-price]]) 

**Pages to check for regression and performance:**
- https://marquee-tokens--express--adobecom.hlx.page/express/teams-offer
- https://marquee-tokens--express--adobecom.hlx.page/express/pricing

![image](https://github.com/user-attachments/assets/37a9456e-7e8b-4bba-bef6-5889fd9b31c4)

- *Note to Haris* They have already started authoring the new token on stage + main, so you will see some bugged behavior. This change has not been deployed to live yet, so its ok for now. 
- 
https://main--express--adobecom.hlx.page/express/pricing?tab=1

<img width="303" alt="Screenshot 2024-10-16 at 2 19 11 PM" src="https://github.com/user-attachments/assets/67c1cbc0-e776-40ef-aa3c-88deeaaf0820">

