### PR TITLE
[Frictionless-QA] Allow WebP

### DIFF
--- a/express/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -39,16 +39,16 @@ const QA_CONFIGS = {
     ...getBaseImgCfg(JPG, JPEG, WEBP),
   },
   'convert-to-svg': {
-    ...getBaseImgCfg(JPG, JPEG, PNG, WEBP),
+    ...getBaseImgCfg(JPG, JPEG, PNG),
   },
   'crop-image': {
-    ...getBaseImgCfg(JPG, JPEG, PNG, WEBP),
+    ...getBaseImgCfg(JPG, JPEG, PNG),
   },
   'resize-image': {
     ...getBaseImgCfg(JPG, JPEG, PNG, WEBP),
   },
   'remove-background': {
-    ...getBaseImgCfg(JPG, JPEG, PNG, WEBP),
+    ...getBaseImgCfg(JPG, JPEG, PNG),
   },
   'generate-qr-code': {
     ...getBaseImgCfg(JPG, JPEG, PNG),

--- a/express/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -18,6 +18,7 @@ let uploadContainer;
 const JPG = 'jpg';
 const JPEG = 'jpeg';
 const PNG = 'png';
+const WEBP = 'webp';
 export const getBaseImgCfg = (...types) => ({
   group: 'image',
   max_size: 40 * 1024 * 1024,
@@ -32,22 +33,22 @@ export const getBaseVideoCfg = (...types) => ({
 });
 const QA_CONFIGS = {
   'convert-to-jpg': {
-    ...getBaseImgCfg(PNG),
+    ...getBaseImgCfg(PNG, WEBP),
   },
   'convert-to-png': {
-    ...getBaseImgCfg(JPG, JPEG),
+    ...getBaseImgCfg(JPG, JPEG, WEBP),
   },
   'convert-to-svg': {
-    ...getBaseImgCfg(JPG, JPEG, PNG),
+    ...getBaseImgCfg(JPG, JPEG, PNG, WEBP),
   },
   'crop-image': {
-    ...getBaseImgCfg(JPG, JPEG, PNG),
+    ...getBaseImgCfg(JPG, JPEG, PNG, WEBP),
   },
   'resize-image': {
-    ...getBaseImgCfg(JPG, JPEG, PNG),
+    ...getBaseImgCfg(JPG, JPEG, PNG, WEBP),
   },
   'remove-background': {
-    ...getBaseImgCfg(JPG, JPEG, PNG),
+    ...getBaseImgCfg(JPG, JPEG, PNG, WEBP),
   },
   'generate-qr-code': {
     ...getBaseImgCfg(JPG, JPEG, PNG),


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Supports webp format for Convert to JPG, Convert to PNG, and re-size image quick actions.

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-160222

**SDK didn't whitelist our branch environments, so it is more difficult to test before it gets to stage. The only sensible way seems to be the following:**
- Enable local override
- Override frictionless-quick-action.js with content in this PR
- Upload a webp image and the resize toolkit should work

**Pages to check for regression and performance:**
- https://fqa-webp--express--adobecom.hlx.live/express/feature/image/resize?martech=off
