### PR TITLE
[Google-YOLO] Align Destination with PEP Logic

### DIFF
--- a/express/scripts/google-yolo.js
+++ b/express/scripts/google-yolo.js
@@ -1,13 +1,15 @@
 import { getMetadata } from './utils.js';
 import BlockMediator from './block-mediator.min.js';
 
+const branchLinkOriginPattern = /^https:\/\/adobesparkpost(-web)?\.app\.link/;
+function isBranchLink(url) {
+  return branchLinkOriginPattern.test(new URL(url).origin);
+}
 function getRedirectUri() {
-  const primaryCtaUrl = BlockMediator.get('primaryCtaUrl')
+  const url = getMetadata('pep-destination')
+    || BlockMediator.get('primaryCtaUrl')
     || document.querySelector('a.button.xlarge.same-fcta, a.primaryCTA')?.href;
-  if (primaryCtaUrl) {
-    return primaryCtaUrl;
-  }
-  return false;
+  return isBranchLink(url) && url;
 }
 
 function onGoogleToken(data) {


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Enable Google-yolo to read pep-destination metadata and only redirect to branch links

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-160446?filter=381833

**Steps to test the before vs. after and expectations:**
- Visit the homepage url using a logged in Chrome
- Follow the prompt on the top right
- On branch link, it should take you inside the product
- On stage https://www.stage.adobe.com/express/, it should take you to the commerce link, which is not desired
- If branch links don't work for you, you can use breakpoint or local override + console log

**Pages to check for regression and performance:**
- https://yolo-redirect--express--adobecom.hlx.live/express/
