### PR TITLE
[Jarvis] Configure ID and Version via Metadata

### DIFF
--- a/express/features/jarvis-chat.js
+++ b/express/features/jarvis-chat.js
@@ -1,5 +1,3 @@
-import { getMetadata } from '../scripts/utils.js';
-
 let chatInitialized = false;
 let loadScript;
 let loadStyle;
@@ -219,8 +217,8 @@ const startInitialization = async (config, event) => {
   }
 
   window.AdobeMessagingExperienceClient.initialize({
-    appid: getMetadata('jarvis-surface-id') || config.jarvis.id,
-    appver: getMetadata('jarvis-surface-version') || config.jarvis.version,
+    appid: config.jarvis.id,
+    appver: config.jarvis.version,
     env: config.env.name !== 'prod' ? 'stage' : 'prod',
     clientId: window.adobeid?.client_id,
     accessToken: window.adobeIMS?.isSignedInUser()

--- a/express/features/jarvis-chat.js
+++ b/express/features/jarvis-chat.js
@@ -1,3 +1,5 @@
+import { getMetadata } from '../scripts/utils.js';
+
 let chatInitialized = false;
 let loadScript;
 let loadStyle;
@@ -217,8 +219,8 @@ const startInitialization = async (config, event) => {
   }
 
   window.AdobeMessagingExperienceClient.initialize({
-    appid: config.jarvis.id,
-    appver: config.jarvis.version,
+    appid: getMetadata('jarvis-surface-id') || config.jarvis.id,
+    appver: getMetadata('jarvis-surface-version') || config.jarvis.version,
     env: config.env.name !== 'prod' ? 'stage' : 'prod',
     clientId: window.adobeid?.client_id,
     accessToken: window.adobeIMS?.isSignedInUser()

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -50,8 +50,8 @@ const config = {
   codeRoot: '/express',
   contentRoot: '/express',
   jarvis: {
-    id: 'Acom_Express',
-    version: '1.0',
+    id: getMetadata('jarvis-surface-id') || 'Acom_Express',
+    version: getMetadata('jarvis-surface-version') || '1.0',
     onDemand: !jarvisImmediatelyVisible,
   },
   links: 'on',


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Allows Jarvis id and version to be configurable per page by metadata

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-160863

**Steps to test the before vs. after and expectations:**
- Visit the url and wait for Jarvis to appear on the bottom right
- On the branch link, you should see no message, since the authored Jarvis id is used
- On stage, you should see "Questions? Get help from our experts."

**Pages to check for regression and performance:**
- https://jarvis-customization--express--adobecom.hlx.page/drafts/jingle/test-jarvis
