### PR TITLE
Prevent UK Georouter From Showing Redundant Redirect Options

### DIFF
--- a/express/features/georoutingv2/georoutingv2.js
+++ b/express/features/georoutingv2/georoutingv2.js
@@ -296,6 +296,7 @@ export default async function loadGeoRouting(
   let resp;
   for (const url of urls) {
     resp = await fetch(url);
+
     if (resp.ok) {
       if (url.includes('georouting.json')) {
         const json = await resp.json();
@@ -306,8 +307,15 @@ export default async function loadGeoRouting(
       break;
     }
   }
-  const json = await resp.json();
+  let json = await resp.json();
   const { locale } = config;
+  json = {
+    ...json,
+    georouting: {
+      ...json.georouting,
+      data: json.georouting.data.filter((item) => item.prefix !== 'gb'),
+    },
+  };
 
   const urlLocale = locale.prefix.replace('/', '');
   const storedInter = getCookie('international');

--- a/express/scripts/branchlinks.js
+++ b/express/scripts/branchlinks.js
@@ -150,7 +150,7 @@ export function getTrackingAppendedURL(url, placeholders, options = {}) {
   if (placement) setParams('placement', placement);
   const { locale: { ietf, region } } = getConfig();
   setParams('locale', ietf);
-  setParams('contentRegion', region === 'uk' ? 'gb' : region);
+  setParams('contentRegion', region);
 
   if (sKwcId) {
     const sKwcIdParameters = sKwcId.split('!');

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -20,7 +20,6 @@ const locales = {
   es: { ietf: 'es-ES', tk: 'oln4yqj.css' },
   fi: { ietf: 'fi-FI', tk: 'aaz7dvd.css' },
   fr: { ietf: 'fr-FR', tk: 'vrk5vyv.css' },
-  gb: { ietf: 'en-GB', tk: 'pps7abe.css' },
   id_id: { ietf: 'id-ID', tk: 'cya6bri.css' },
   in: { ietf: 'en-IN', tk: 'pps7abe.css' },
   it: { ietf: 'it-IT', tk: 'bbf5pok.css' },

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2442,7 +2442,8 @@ async function loadPostLCP(config) {
     loadMartech();
   }
   const georouting = getMetadata('georouting') || config.geoRouting;
-  if (georouting === 'on') {
+  const isHomepage = window.location.pathname.endsWith('/express/');
+  if (georouting === 'on' && isHomepage) {
     const { default: loadGeoRouting } = await import('../features/georoutingv2/georoutingv2.js');
     await loadGeoRouting(config, createTag, getMetadata, loadBlock, loadStyle);
   }

--- a/express/scripts/utils/pricing.js
+++ b/express/scripts/utils/pricing.js
@@ -184,7 +184,7 @@ function getCurrencyDisplay(currency) {
 }
 
 export function normCountry(country) {
-  return (country.toLowerCase() === 'uk' ? 'gb' : country.toLowerCase()).split('_')[0];
+  return (country.toLowerCase()).split('_')[0];
 }
 
 // urlparam > cookie > sessionStorage > feds > api > config


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- In the UK, the georouter presents to options for redirect - one for GB and one for UK. 
- Only one locale is needed so to resolve the issue the GB locale should not be utilized.

**Resolves:** [MWPW-160876](https://jira.corp.adobe.com/browse/MWPW-160876)

**Steps to test the before vs. after and expectations:**
- Steps for feature 1

**Pages to check for regression and performance:**
**Before**
- Set VPN to London
- https://georouter-homepage-only--express--adobecom.hlx.page/express/print?martech=off will show this:
<img width="1222" alt="before - homepage" src="https://github.com/user-attachments/assets/2faad38f-c93c-4188-a50e-b815a6737171">
- https://georouter-homepage-only--express--adobecom.hlx.page/express/print?martech=off will show the georouter on a non-homepage page: 
<img width="1549" alt="before - print" src="https://github.com/user-attachments/assets/13b81dbb-42b6-4ed8-b578-7232f3233025">

**After**
- Set VPN to London
- https://georouter-homepage-only--express--adobecom.hlx.page/express/?martech=off should show the georouter with one option: 
<img width="1612" alt="after - homepage" src="https://github.com/user-attachments/assets/e5c619b9-abd4-4ff1-9d6d-c134ae7420af">

- https://georouter-homepage-only--express--adobecom.hlx.page/express/print?martech=off should not show the georouter:
<img width="1387" alt="after - print" src="https://github.com/user-attachments/assets/d00fb27c-2d0e-4c11-a7c5-8e5d964955a7">


