### PR TITLE
[Simplified Homepage] Banner adjustment - mobile

### DIFF
--- a/express/blocks/banner/banner.css
+++ b/express/blocks/banner/banner.css
@@ -109,6 +109,7 @@ main .banner.standout .content-container em {
 
 main .banner.cool {
   padding: 0 24px;
+  max-width: unset;
 }
 
 main .banner.cool .content-container {
@@ -129,6 +130,8 @@ main .banner.cool p.button-container {
 
 main .banner.cool p.button-container a.button {
   font-size: 17px;
+  padding-left: 1.65em;
+  padding-right: 1.65em;
 }
 
 main .banner.cool h2 {


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- There are two fine tunes from Mariah:
1. For mobile, no matter what the width is, the left and right border (with the gradient) will be strictly 24px. Therefore, the `max-width` of 375px is removed for mobile
2. The CTA button is made slightly wider

**Resolves:** [MWPW-160978](https://jira.corp.adobe.com/browse/MWPW-160978)

**Steps to test the before vs. after and expectations:**
- https://simplified-homepage--express--adobecom.hlx.page/drafts/integration/simplified-homepage?martech=off

**Pages to check for regression and performance:**
- https://banner-adjust-mobile--express--adobecom.hlx.page/drafts/integration/simplified-homepage?martech=off
