### PR TITLE
Prevent UK Georouter From Showing Redundant Redirect Options

### DIFF
--- a/express/features/georoutingv2/georoutingv2.js
+++ b/express/features/georoutingv2/georoutingv2.js
@@ -338,7 +338,12 @@ export default async function loadGeoRouting(
   try {
     let akamaiCode = await getAkamaiCode();
     if (akamaiCode && !getCodes(urlGeoData).includes(akamaiCode)) {
-      const localeMatches = getMatches(json.georouting.data, akamaiCode);
+      let localeMatches = getMatches(json.georouting.data, akamaiCode);
+      if (akamaiCode === 'gb') {
+        localeMatches = localeMatches.filter((localeMatch) => localeMatch.prefix !== 'gb');
+      } else if (akamaiCode === 'uk') {
+        localeMatches = localeMatches.filter((localeMatch) => localeMatch.prefix !== 'uk');
+      }
       const details = await getDetails(urlGeoData, localeMatches, json.geos.data);
       if (details) {
         await showModal(details);

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2442,7 +2442,8 @@ async function loadPostLCP(config) {
     loadMartech();
   }
   const georouting = getMetadata('georouting') || config.geoRouting;
-  if (georouting === 'on') {
+  const isHomepage = window.location.pathname.endsWith('/express/');
+  if (georouting === 'on' && isHomepage) {
     const { default: loadGeoRouting } = await import('../features/georoutingv2/georoutingv2.js');
     await loadGeoRouting(config, createTag, getMetadata, loadBlock, loadStyle);
   }


### PR DESCRIPTION
**Prevent UK Georouter From Showing Redundant Redirect Options**

**Fixes following issues|Adds following features:**
- Prevents additional georouting option being suggested for UK when both options are English
- Prevent georouter from appearing on pages outside the homepage

**Resolves:** [MWPW-160876](https://jira.corp.adobe.com/browse/MWPW-160876)

**Steps to test the before vs. after and expectations:**
- Set VPN to London and go to https://www.adobe.com/express/ to see the duplicate option presented and on https://www.adobe.com/express/print to see the duplicate option presented when not on homepage. 
- Georouter should only appear on the homepage when it does appear

**Pages to check for regression and performance:**
- https://uk-georouter-patch--express--adobecom.hlx.page/express/?martech=off
- https://uk-georouter-patch--express--adobecom.hlx.page/express/print?martech=off

**One Georouting Option**
<img width="1454" alt="uk georouter - one option" src="https://github.com/user-attachments/assets/f1d250d2-fc97-48be-a024-4ab08cdf4a79">

**Georouter Does Not Appear If Not Homepage**
<img width="1650" alt="georouter not shown outside of homepage" src="https://github.com/user-attachments/assets/daaa0165-2089-4725-88c2-37376f71d770">
