### PR TITLE
Homepage on Stage - Cards Carousel Style Fixes / Pointer Event Fix

### DIFF
--- a/express/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.css
@@ -115,6 +115,13 @@
   overflow: hidden;
 }
 
+main .gen-ai-cards.homepage .carousel-container a.button.carousel-arrow::before {
+  width: 7px;
+  height: 7px;
+  border-top: solid 3px var(--color-gray-700);
+  border-right: solid 3px var(--color-gray-700);
+}
+
 main .gen-ai-cards.homepage .card .media-wrapper {
   border-radius: 8px;
 }
@@ -245,12 +252,14 @@ main .gen-ai-cards.homepage .carousel-container .carousel-fader-left {
   top: 45px;
   right: 42px;
   left: auto; 
+  pointer-events: none;
 }
 
 main .gen-ai-cards.homepage .carousel-container .carousel-fader-right {
   align-items: end;
   top: 45px;
   right: 15px;
+  pointer-events: none;
 }
 .gen-ai-cards.homepage .gen-ai-cards-heading-section {
   margin-left: 20px;

--- a/express/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.css
@@ -115,11 +115,21 @@
   overflow: hidden;
 }
 
+main .gen-ai-cards.homepage .carousel-container a.button.carousel-arrow {
+  box-shadow: 0px 2px 8px 2px rgba(0, 0, 0, 0.2);
+}
+
 main .gen-ai-cards.homepage .carousel-container a.button.carousel-arrow::before {
   width: 7px;
   height: 7px;
   border-top: solid 3px var(--color-gray-700);
   border-right: solid 3px var(--color-gray-700);
+}
+
+main .gen-ai-cards.homepage .carousel-container .carousel-fader-left.arrow-hidden a.button.carousel-arrow::before,
+main .gen-ai-cards.homepage .carousel-container .carousel-fader-right.arrow-hidden a.button.carousel-arrow::before {
+  border-top: solid 3px var(--color-gray-400);
+  border-right: solid 3px var(--color-gray-400);
 }
 
 main .gen-ai-cards.homepage .card .media-wrapper {


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
The GenAI Cards should:
- on mobile should not detect a right click event when scrolled all the way left and the user clicks on the left chevron and vice versa for the right chevron
- have a carousel left and right chevron that look identical to the Discover Cards chevrons when at full opacity or when lighter at either end of scrolling


**Resolves:** [MWPW-161061](https://jira.corp.adobe.com/browse/MWPW-161061)

**Pages to check for regression and performance:**
On a mobile device (chrome inspector can reproduce) if the gen-ai cards have been scrolled all the way to the left, tapping the left chevron should not cause the carousel to scroll right and vice versa on the very far right of the carousel
Also, the chevrons between the gen-ai cards and the discover page should look identical
- https://carousel-buttons-gen-ai--express--adobecom.hlx.page/express/?martech=off
