### PR TITLE
[Template][Mobile vs Desktop] Allow Overriding from-scratch link based on Device

### DIFF
--- a/express/scripts/content-replace.js
+++ b/express/scripts/content-replace.js
@@ -349,7 +349,7 @@ async function updateNonBladeContent(main) {
 
   if (templateX) {
     await replaceDefaultPlaceholders(templateX, {
-      link: getMetadata('create-link-x') || getMetadata('create-link') || '/',
+      link: getMetadata(`create-link-${document.body.dataset.device}`) || getMetadata('create-link-x') || getMetadata('create-link') || '/',
       tasks: getMetadata('tasks-x'),
     });
   }


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Allow Overriding from-scratch link based on Device. Priority of metadata precedence would be create-link-{device}>create-link-x>create-link with fallback in the same order

**Resolves:** https://jira.corp.adobe.com/browse/DOTCOM-134018

**Steps to test the before vs. after and expectations:**
- Open the target link in desktop, check the "Start from scratch" link and see it should have nothing
- Reload in mobile, check the "Start from scratch" link and see it should have a testing param ?mobile=true

**Pages to check for regression and performance:**
- https://scratchlink-by-device--express--adobecom.hlx.page/express/templates/website-page/wedding?martech=off