### PR TITLE
[Grid-Marquee] Fix transform override typo

### DIFF
--- a/express/blocks/grid-marquee/grid-marquee.css
+++ b/express/blocks/grid-marquee/grid-marquee.css
@@ -354,7 +354,7 @@
   .grid-marquee .drawer[aria-hidden='true'] {
     opacity: 0;
     visibility: hidden;
-    bottom: initial;
+    transform: initial;
   }
 
   .grid-marquee .drawer .title-row {


### PR DESCRIPTION
**Fixes following issues:**
- Fix the issue that a hidden drawer accidentally still keeps its transform css property on the widest breakpoint.

**Steps to test the before vs. after and expectations:**
- Hover on one of the cards in grid-marquee
- See that on stage, there could be a flash of hidden drawer content below. On branch link, it should not happen.

**Pages to check for regression and performance:**
- https://grid-marquee-transform--express--adobecom.hlx.page/express/?martech=off&gnav=off
