### PR TITLE
October Cleanup

### DIFF
--- a/express/blocks/grid-marquee/grid-marquee.css
+++ b/express/blocks/grid-marquee/grid-marquee.css
@@ -6,7 +6,7 @@
   --d-img-w: 256px;
   --d-img-h: 199px;
 }
-.grid-marquee.block {
+.grid-marquee {
   max-width: initial;
 }
 .grid-marquee .express-logo {

--- a/express/blocks/grid-marquee/grid-marquee.js
+++ b/express/blocks/grid-marquee/grid-marquee.js
@@ -144,16 +144,20 @@ function toCard(drawer) {
 
 async function formatDynamicCartLink(a) {
   try {
-    const pattern = new RegExp(/.*commerce.*adobe\.com.*/gm);
+    const pattern = /.*commerce.*adobe\.com.*/gm;
     if (!pattern.test(a.href)) return a;
     a.style.visibility = 'hidden';
     const {
       fetchPlanOnePlans,
       buildUrl,
     } = await import('../../scripts/utils/pricing.js');
-    const response = await fetchPlanOnePlans(a.href);
-    const newTrialHref = buildUrl(response.url, response.country,
-      response.language, response.offerId);
+    const {
+      url,
+      country,
+      language,
+      offerId,
+    } = await fetchPlanOnePlans(a.href);
+    const newTrialHref = buildUrl(url, country, language, offerId);
     a.href = newTrialHref;
   } catch (error) {
     window.lana.log(`Failed to fetch prices for page plan: ${error}`);

--- a/express/blocks/grid-marquee/grid-marquee.js
+++ b/express/blocks/grid-marquee/grid-marquee.js
@@ -125,7 +125,7 @@ function toCard(drawer) {
   panelsFrag.append(...panels);
   panels.forEach((panel) => panel.classList.add('panel'));
   const videoAnchor = face.querySelector('a');
-  videoAnchor.parentElement.tagName === 'P' ? videoAnchor.parentElement.remove() : videoAnchor?.remove();
+  videoAnchor?.remove();
   const card = createTag('button', {
     class: 'card',
     'aria-controls': `drawer-${titleText}`,
@@ -205,6 +205,7 @@ export default function init(el) {
   logo.classList.add('express-logo');
   const cards = items.map((item) => toCard(item));
   const cardsContainer = createTag('div', { class: 'cards-container' }, cards.map(({ card }) => card));
+  [...cardsContainer.querySelectorAll('p:empty')].forEach((p) => p.remove());
   foreground.append(logo, decorateHeadline(headline), cardsContainer, ...(el.classList.contains('ratings') ? [makeRatings()] : []));
   background.classList.add('background');
   el.append(foreground);

--- a/express/blocks/grid-marquee/grid-marquee.js
+++ b/express/blocks/grid-marquee/grid-marquee.js
@@ -144,25 +144,21 @@ function toCard(drawer) {
 
 async function formatDynamicCartLink(a, plan) {
   try {
+    const pattern = new RegExp(/.*commerce.*adobe\.com.*/gm);
+    if (!pattern.test(a.href)) return a;
+    a.style.visibility = 'hidden';
     const {
       fetchPlanOnePlans,
       buildUrl,
     } = await import('../../scripts/utils/pricing.js');
-    const pattern = new RegExp(/.*commerce.*adobe\.com.*/gm);
-    if (pattern.test(a.href)) {
-      let response;
-      if (!plan) {
-        response = await fetchPlanOnePlans(a.href);
-      } else {
-        response = plan;
-      }
-      const newTrialHref = buildUrl(response.url, response.country,
-        response.language, response.offerId);
-      a.href = newTrialHref;
-    }
+    const response = plan || await fetchPlanOnePlans(a.href);
+    const newTrialHref = buildUrl(response.url, response.country,
+      response.language, response.offerId);
+    a.href = newTrialHref;
   } catch (error) {
     window.lana.log(`Failed to fetch prices for page plan: ${error}`);
   }
+  a.style.visibility = 'visible';
   return a;
 }
 

--- a/express/blocks/grid-marquee/grid-marquee.js
+++ b/express/blocks/grid-marquee/grid-marquee.js
@@ -125,7 +125,7 @@ function toCard(drawer) {
   panelsFrag.append(...panels);
   panels.forEach((panel) => panel.classList.add('panel'));
   const videoAnchor = face.querySelector('a');
-  videoAnchor?.remove();
+  videoAnchor.parentElement.tagName === 'P' ? videoAnchor.parentElement.remove() : videoAnchor?.remove();
   const card = createTag('button', {
     class: 'card',
     'aria-controls': `drawer-${titleText}`,

--- a/express/blocks/grid-marquee/grid-marquee.js
+++ b/express/blocks/grid-marquee/grid-marquee.js
@@ -142,7 +142,7 @@ function toCard(drawer) {
   return { card, lazyCB };
 }
 
-async function formatDynamicCartLink(a, plan) {
+async function formatDynamicCartLink(a) {
   try {
     const pattern = new RegExp(/.*commerce.*adobe\.com.*/gm);
     if (!pattern.test(a.href)) return a;
@@ -151,7 +151,7 @@ async function formatDynamicCartLink(a, plan) {
       fetchPlanOnePlans,
       buildUrl,
     } = await import('../../scripts/utils/pricing.js');
-    const response = plan || await fetchPlanOnePlans(a.href);
+    const response = await fetchPlanOnePlans(a.href);
     const newTrialHref = buildUrl(response.url, response.country,
       response.language, response.offerId);
     a.href = newTrialHref;

--- a/express/scripts/martech.js
+++ b/express/scripts/martech.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line object-curly-newline
-import { getConfig, getMetadata, loadIms, loadLink, loadScript, getMobileOperatingSystem } from './utils.js';
+import { getConfig, getMetadata, loadIms, loadLink, loadScript } from './utils.js';
 
 const ALLOY_SEND_EVENT = 'alloy_sendEvent';
 const ALLOY_SEND_EVENT_ERROR = 'alloy_sendEvent_error';
@@ -214,37 +214,12 @@ const loadMartechFiles = async (config, url, edgeConfigId) => {
     };
     window.edgeConfigId = edgeConfigId;
 
-    // TODO: remove after aexg4848
-    let trackEligibility = null;
-    if (getMetadata('target-only-mobile-web') === 'on') {
-      if (navigator.userAgent.includes('Mobile') && getMobileOperatingSystem() === 'Android' && navigator.deviceMemory >= 4) {
-        setDeep(window, 'alloy_all.data.__adobe.target.mobile_web_enough_ram', true);
-        trackEligibility = true;
-      } else {
-        setDeep(window, 'alloy_all.data.__adobe.target.mobile_web_enough_ram', false);
-        trackEligibility = false;
-      }
-    }
-
     const env = ['stage', 'local'].includes(config.env.name) ? '.qa' : '';
     // TODO: milo is hosting their own martech script in repo
     const martechPath = `main.standard${env}.min.js`;
     await loadScript(`https://www.adobe.com/marketingtech/${martechPath}`);
     // eslint-disable-next-line no-underscore-dangle
     window._satellite.track('pageload');
-    // TODO: remove after aexg4848
-    if (trackEligibility !== null) {
-      // eslint-disable-next-line no-underscore-dangle
-      window._satellite.track('event', {
-        data: {
-          web: {
-            webInteraction: {
-              name: `mobile_web_enough_ram: ${trackEligibility.toString()}`,
-            },
-          },
-        },
-      });
-    }
   };
 
   await filesLoadedPromise();

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2626,12 +2626,12 @@ export async function loadArea(area = document) {
   wordBreakJapanese(area);
 
   // appending express-specific branch parameters
-  const links = isDoc ? area.querySelectorAll('main a[href*="adobesparkpost"]') : area.querySelectorAll(':scope a[href*="adobesparkpost"]');
-  if (links.length) {
-    window.addEventListener('express:LCP:loaded', () => {
+  window.addEventListener('express:LCP:loaded', () => {
+    const links = isDoc ? area.querySelectorAll('main a[href*="adobesparkpost"]') : area.querySelectorAll(':scope a[href*="adobesparkpost"]');
+    if (links.length) {
       import('./branchlinks.js').then((mod) => mod.default(links));
-    });
-  }
+    }
+  });
 
   const areaBlocks = [];
   for (const section of sections) {

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -1018,7 +1018,7 @@ body[data-device="mobile"] main .floating-button-wrapper[data-audience="mobile"]
   display: block;
 }
 
-main > div:not(.banner-container) .block:not(.pricing-summary, .pricing-cards, .pricing-table, .puf, .split-action, .link-list, .wayfinder, .ratings) a.button.same-fcta {
+main > div:not(.banner-container) .block:not(.pricing-summary, .pricing-cards, .pricing-table, .simplified-pricing-cards, .puf, .split-action, .link-list, .wayfinder, .ratings) a.button.same-fcta {
   display: none;
 }
 

--- a/test/unit/blocks/grid-marquee/grid-marquee.test.js
+++ b/test/unit/blocks/grid-marquee/grid-marquee.test.js
@@ -1,6 +1,9 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import { delay } from '../../../helpers/waitfor.js';
+import { setConfig } from '../../../../express/scripts/utils.js';
+
+setConfig({});
 
 const { default: decorate } = await import(
   '../../../../express/blocks/grid-marquee/grid-marquee.js'


### PR DESCRIPTION
**Adds following features:**
- Delay branchlinks' querySelectors until postLCP for a tiny bit of LCP boost
- Remove code for Target configurations around Safari/Android on Mobile that used to be needed for a test.
- Cleanup some minor things for grid-marquee block, like empty p tag and floatingCTA update

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-161140

**Steps to test the before vs. after and expectations:**
- Everything on the url should remain unchanged and functional

**Pages to check for regression and performance:**
- https://oct-cleanup--express--adobecom.hlx.live/express/?martech=off
