### PR TITLE
add ability to add videos into how-to-steps from sharepoint

### DIFF
--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -138,10 +138,7 @@ export default function decorate(block, name, doc) {
       if (isVideo) {
         const video = createTag('video', { width: '320', height: '240', controls: true });
         const sourceMp4 = createTag('source', { src: p.innerHTML, type: 'video/mp4' });
-
         video.appendChild(sourceMp4);
-        video.appendChild(document.createTextNode('Your browser does not support the video tag.'));
-
         content = video;
       } else {
         content = p;

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -137,7 +137,7 @@ export default function decorate(block, name, doc) {
 
       if (isVideo) {
         const video = createTag('video', { width: '320', height: '240', controls: true });
-        const sourceMp4 = createTag('source', { src: p.innerHTML, type: 'video/mp4' });
+        const sourceMp4 = createTag('source', { src: p.innerHTML.trim(), type: 'video/mp4' });
         video.appendChild(sourceMp4);
         content = video;
       } else {

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -131,11 +131,29 @@ export default function decorate(block, name, doc) {
       h3.innerHTML = cells[0].textContent.trim();
       const p = createTag('p');
       p.innerHTML = cells[1].innerHTML;
+
+      const isVideo = p.innerHTML.includes('.mp4');
+      let content;
+
+      if (isVideo) {
+        const video = createTag('video', { width: '320', height: '240', controls: true });
+        const sourceMp4 = createTag('source', { src: p.innerHTML, type: 'video/mp4' });
+
+        video.appendChild(sourceMp4);
+        video.appendChild(document.createTextNode('Your browser does not support the video tag.'));
+
+        content = video;
+      } else {
+        content = p;
+      }
+
       const text = createTag('div', { class: 'tip-text' });
       text.append(h3);
-      text.append(p);
+      text.append(content);
+
       const number = createTag('div', { class: 'tip-number' });
       number.innerHTML = `<span>${index}</span>`;
+
       cells[0].remove();
       cells[1].innerHTML = '';
       cells[1].classList.add('tip');


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Adds the ability for authors to add sharepoint videos into the How To Steps block

**Resolves:** [MWPW-161141](https://jira.corp.adobe.com/browse/MWPW-161141)

**Steps to test the before vs. after and expectations:**
- Steps for feature 1

**Pages to check for regression and performance:**
- https://how-to-steps-video--express--adobecom.hlx.page/drafts/jsandlan/long-form-flyer
<img width="1238" alt="video" src="https://github.com/user-attachments/assets/87939451-f571-4087-9fa5-010c29557a93">

