### PR TITLE
adds additional paths to allow georouter

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -14,6 +14,7 @@ import {
 const locales = {
   '': { ietf: 'en-US', tk: 'jdq5hay.css' },
   br: { ietf: 'pt-BR', tk: 'inq1xob.css' },
+  cn: { ietf: 'zh-Hans-CN', tk: 'puu3xkp' },
   de: { ietf: 'de-DE', tk: 'vin7zsi.css' },
   dk: { ietf: 'da-DK', tk: 'aaz7dvd.css' },
   es: { ietf: 'es-ES', tk: 'oln4yqj.css' },
@@ -28,6 +29,7 @@ const locales = {
   nl: { ietf: 'nl-NL', tk: 'cya6bri.css' },
   no: { ietf: 'no-NO', tk: 'aaz7dvd.css' },
   se: { ietf: 'sv-SE', tk: 'fpk1pcd.css' },
+  tr: { ietf: 'tr-TR', tk: 'ley8vds.css' },
   tw: { ietf: 'zh-Hant-TW', tk: 'jay0ecd' },
   uk: { ietf: 'en-GB', tk: 'pps7abe.css' },
 };

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -14,7 +14,6 @@ import {
 const locales = {
   '': { ietf: 'en-US', tk: 'jdq5hay.css' },
   br: { ietf: 'pt-BR', tk: 'inq1xob.css' },
-  cn: { ietf: 'zh-Hans-CN', tk: 'puu3xkp' },
   de: { ietf: 'de-DE', tk: 'vin7zsi.css' },
   dk: { ietf: 'da-DK', tk: 'aaz7dvd.css' },
   es: { ietf: 'es-ES', tk: 'oln4yqj.css' },
@@ -29,7 +28,6 @@ const locales = {
   nl: { ietf: 'nl-NL', tk: 'cya6bri.css' },
   no: { ietf: 'no-NO', tk: 'aaz7dvd.css' },
   se: { ietf: 'sv-SE', tk: 'fpk1pcd.css' },
-  tr: { ietf: 'tr-TR', tk: 'ley8vds.css' },
   tw: { ietf: 'zh-Hant-TW', tk: 'jay0ecd' },
   uk: { ietf: 'en-GB', tk: 'pps7abe.css' },
 };

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2430,8 +2430,11 @@ async function loadPostLCP(config) {
     loadMartech();
   }
   const georouting = getMetadata('georouting') || config.geoRouting;
-  const isHomepage = window.location.pathname.endsWith('/express/');
-  if (georouting === 'on' && isHomepage) {
+  const permittedPaths = ['/express/', '/entitled',
+    '/business', '/teams',
+    '/nonprofits', '/learn/students', 'pricing'];
+  const isPermitted = permittedPaths.some((path) => window.location.pathname.endsWith(path));
+  if (georouting === 'on' && isPermitted) {
     const { default: loadGeoRouting } = await import('../features/georoutingv2/georoutingv2.js');
     await loadGeoRouting(config, createTag, getMetadata, loadBlock, loadStyle);
   }

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2426,13 +2426,11 @@ export async function fetchAllowedGeoRouterPaths() {
     try {
       const resp = await fetch('/express/allowed-georouter-paths.json');
       const json = await resp.json();
-      console.log('are we here', json);
       json.data.forEach((entry) => {
-        console.log('entry', entry);
         window.allowedGeoRouterPaths.push(entry);
       });
     } catch (e) {
-      // ignore
+      console.error('Error fetching allowed geo-router paths:', e);
     }
   }
   return window.allowedGeoRouterPaths;


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Allow georouter on additional pages beyond /express

**Resolves:** [MWPW-162338](https://jira.corp.adobe.com/browse/MWPW-162338)

**Steps to test the before vs. after and expectations:**
- Steps for feature 1

**Before**
**Georouter will not appear on these pages**
-  https://www.adobe.com/id_id/express/
-  https://www.adobe.com/de/express/
-  https://www.adobe.com/de/express/entitled
-  https://www.adobe.com/de/express/business
-  https://www.adobe.com/de/express/business/teams
-  https://www.adobe.com/de/express/nonprofits
-  https://www.adobe.com/de/express/learn/students
-  https://www.adobe.com/de/express//education/express
-  https://www.adobe.com/de/express/pricing

**Pages to check for regression and performance:**
**After**
**Georouter will now appear on these pages**
-  https://allow-georouter-on-additional-pages--express--adobecom.hlx.page/id_id/express/
-  https://allow-georouter-on-additional-pages--express--adobecom.hlx.page/de/express/
-  https://allow-georouter-on-additional-pages--express--adobecom.hlx.page/de/express/entitled
-  https://allow-georouter-on-additional-pages--express--adobecom.hlx.page/de/express/business
-  https://allow-georouter-on-additional-pages--express--adobecom.hlx.page/de/express/business/teams
-  https://allow-georouter-on-additional-pages--express--adobecom.hlx.page/in/express/nonprofits
-  https://allow-georouter-on-additional-pages--express--adobecom.hlx.page/in/express/learn/students
-  https://allow-georouter-on-additional-pages--express--adobecom.hlx.page/de/education/express/
-  https://allow-georouter-on-additional-pages--express--adobecom.hlx.page/de/express/pricing
