### PR TITLE
css changes on very wide screens for homepage cards

### DIFF
--- a/express/blocks/discover-cards/discover-cards.css
+++ b/express/blocks/discover-cards/discover-cards.css
@@ -14,10 +14,13 @@ main .section .discover-cards {
     padding-left: 20px;
     padding-right: 20px;
 }
+.discover-cards .cards-container {
+    max-width: 1700px;
+}
 .discover-cards .cards-container .card {
     min-width: 294px;
     height: 427px;
-    border-radius: 8px;
+    border-radius: 16px;
     border: 1px solid;
     border-image: linear-gradient(180deg, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.2)) 1;
     background: linear-gradient(180deg, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.6));
@@ -63,7 +66,7 @@ main .section .discover-cards {
 .discover-cards .card .button-container {
     position: absolute;
     bottom: 5px;
-    left: 3px;
+    left: 6px;
     right: 16px;
     text-align: left;
 }
@@ -83,6 +86,7 @@ main .section .discover-cards {
 @media (min-width: 600px) {  
     .discover-cards .cards-container .card {
         min-width: 399px;
+        max-width: 399px;
         height: 478px;
     }
     .discover-cards .center-title h3 {
@@ -116,9 +120,17 @@ main .section .discover-cards {
     .discover-cards .cards-container .card:first-child {
         margin-left: 60px;
     }
+    .discover-cards .card .button-container {
+        bottom: 11px;
+        left: 13px;
+    }
 }
 
 @media (min-width: 1200px) {  
+    .discover-cards .cards-container {
+        margin-left: auto;
+        margin-right: auto;
+    }
     .discover-cards .cards-container.gallery {
         scroll-padding-left: 100px;
     }  

--- a/express/blocks/discover-cards/discover-cards.css
+++ b/express/blocks/discover-cards/discover-cards.css
@@ -20,9 +20,8 @@ main .section .discover-cards {
 .discover-cards .cards-container .card {
     min-width: 294px;
     height: 427px;
+    border: 1px solid white;
     border-radius: 16px;
-    border: 1px solid;
-    border-image: linear-gradient(180deg, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.2)) 1;
     background: linear-gradient(180deg, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.6));
     flex: 1 1 calc(33.33% - 32px);
     box-sizing: border-box;

--- a/express/blocks/discover-cards/discover-cards.css
+++ b/express/blocks/discover-cards/discover-cards.css
@@ -127,8 +127,7 @@ main .section .discover-cards {
 
 @media (min-width: 1200px) {  
     .discover-cards .cards-container {
-        margin-left: auto;
-        margin-right: auto;
+        margin: auto;
     }
     .discover-cards .cards-container.gallery {
         scroll-padding-left: 100px;


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- position the CTA correctly in the card per the Figma designs
- cards should maintain a max-width of 399px and center correctly on screens over 1700px
- set card border-radius to 16px

**Resolves:** [MWPW-161329](https://jira.corp.adobe.com/browse/MWPW-161329)

**Pages to check for regression and performance:**
- https://cards-css-fixes--express--adobecom.hlx.page/express/?martech=off
![homepage](https://github.com/user-attachments/assets/b83915ac-a27c-450d-b871-671f6ee5e2c9)


