### PR TITLE
Grid Marquee Drawer Links Hover

### DIFF
--- a/express/blocks/grid-marquee/grid-marquee.css
+++ b/express/blocks/grid-marquee/grid-marquee.css
@@ -187,6 +187,10 @@
   gap: 16px;
 }
 
+.grid-marquee .panel .drawer-cta:hover {
+  text-decoration: underline;
+}
+
 .grid-marquee .drawer .icon {
   width: 22px;
   height: 22px;


### PR DESCRIPTION
**Fixes following issues:**
- Adds hover underline effect to grid-marquee's desktop drawer CTAs

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-161469

**Steps to test the before vs. after and expectations:**
- Open the url in a screen wider than 1280px
- Hover on one of the cards and see that more links are being displayed
- Hover on those links and they should now be underlined when hovered

**Pages to check for regression and performance:**
- https://grid-marquee-hover--express--adobecom.hlx.live/express/?martech=off&gnav=off
