### PR TITLE
iPad GA - Banner variant and Quotes block

### DIFF
--- a/express/blocks/banner/banner.css
+++ b/express/blocks/banner/banner.css
@@ -108,7 +108,7 @@ main .banner.standout .content-container em {
 }
 
 main .banner.cool {
-  padding: 0 24px;
+  padding: 0 16px;
   max-width: unset;
 }
 
@@ -141,9 +141,10 @@ main .banner.cool h2 {
   padding: 0 15px;
 }
 
-@media (min-width: 600px) {
+@media (min-width: 768px) {
   main .banner.cool {
-    max-width: 820px;
+    padding: 0 32px;
+    max-width: unset;
   }
   main .banner.cool .content-container {
     padding: 38px 45px 20px;
@@ -156,12 +157,12 @@ main .banner.cool h2 {
   }
 }
 
-@media (min-width: 900px) {
+@media (min-width: 1280px) {
   main div:has(> .banner.cool) {
     padding: 65px 0;
   }
   main .banner.cool {
-    padding: 0 82px;
+    padding: 0 40px;
     max-width: unset;
   }
   main .banner.cool .content-container {
@@ -179,9 +180,10 @@ main .banner.cool h2 {
   }
 }
 
-@media (min-width: 1200px) {
+@media (min-width: 1680px) {
   main .banner.cool {
-    max-width: 1200px;
+    padding: 0;
+    max-width: 1600px;
   }
 }
 

--- a/express/blocks/banner/banner.css
+++ b/express/blocks/banner/banner.css
@@ -18,7 +18,7 @@ main .section.banner-standout-container {
 }
 
 main div:has(> .banner.cool) {
-  padding: 40px 0;
+  padding: 24px 0;
 }
 
 main .section.banner-compact-container {
@@ -142,6 +142,9 @@ main .banner.cool h2 {
 }
 
 @media (min-width: 768px) {
+  main div:has(> .banner.cool) {
+    padding: 40px 0;
+  }
   main .banner.cool {
     padding: 0 32px;
     max-width: unset;
@@ -159,7 +162,7 @@ main .banner.cool h2 {
 
 @media (min-width: 1280px) {
   main div:has(> .banner.cool) {
-    padding: 65px 0;
+    padding: 48px 0;
   }
   main .banner.cool {
     padding: 0 40px;

--- a/express/blocks/quotes/quotes.css
+++ b/express/blocks/quotes/quotes.css
@@ -175,7 +175,6 @@ main .quotes.singular .mobile-container .author-photo picture img {
 }
 
 main .quotes.singular .quote-details {
-  /* width: 90%; */
   margin: 0 16px;
   font-size: 22px;
   font-weight: 800;
@@ -208,17 +207,13 @@ main .quotes.singular .mobile-container .author-panel .author-photo {
   main .quotes.singular .quote {
     width: 83.3%;
     max-width: 968px;
-    /* padding: 64px 32px; */
     min-height: 315px;
   }
 }
 
 @media (min-width: 1280px) {
   main .quotes.singular .quote {
-    /* width: 75%;
-    max-width: 830px; */
     width: 75%;
-    /* max-width: unset; */
     font-weight: 600;
   }
   main .quotes.singular .quote-details {
@@ -229,7 +224,6 @@ main .quotes.singular .mobile-container .author-panel .author-photo {
 @media (min-width: 1680px) {
   main .quotes.singular .quote {
     max-width: 1120px;
-    /* width: 75%; */
   }
 }
 

--- a/express/blocks/quotes/quotes.css
+++ b/express/blocks/quotes/quotes.css
@@ -103,7 +103,6 @@ main .quotes.singular .quote-container .mobile-container {
 }
 
 main .quotes.singular .quote-container .mobile-container .quote {
-  /* max-width: 375px; */
   margin: 0;
 }
 

--- a/express/blocks/quotes/quotes.css
+++ b/express/blocks/quotes/quotes.css
@@ -103,11 +103,12 @@ main .quotes.singular .quote-container .mobile-container {
 }
 
 main .quotes.singular .quote-container .mobile-container .quote {
-  max-width: 375px;
+  /* max-width: 375px; */
+  margin: 0;
 }
 
 /* toggles between the mobile and desktop layout */
-@media (min-width: 600px) {
+@media (min-width: 768px) {
   main .quotes.singular .quote-container .desktop-container {
     display: block;
   }
@@ -135,7 +136,7 @@ main .quotes.singular .quote {
   flex-flow: row;
   background: transparent;
   justify-content: center;
-  padding: 70px 0;
+  padding: 64px 0;
   min-height: 370px;
 }
 
@@ -174,7 +175,8 @@ main .quotes.singular .mobile-container .author-photo picture img {
 }
 
 main .quotes.singular .quote-details {
-  width: 90%;
+  /* width: 90%; */
+  margin: 0 16px;
   font-size: 22px;
   font-weight: 800;
   text-align: left;
@@ -202,17 +204,21 @@ main .quotes.singular .mobile-container .author-panel .author-photo {
   margin-right: 15px;
 }
 
-@media (min-width: 600px) {
+@media (min-width: 768px) {
   main .quotes.singular .quote {
-    width: 80%;
+    width: 83.3%;
+    max-width: 968px;
+    /* padding: 64px 32px; */
     min-height: 315px;
   }
 }
 
-@media (min-width: 900px) {
+@media (min-width: 1280px) {
   main .quotes.singular .quote {
+    /* width: 75%;
+    max-width: 830px; */
     width: 75%;
-    max-width: 830px;
+    /* max-width: unset; */
     font-weight: 600;
   }
   main .quotes.singular .quote-details {
@@ -220,9 +226,10 @@ main .quotes.singular .mobile-container .author-panel .author-photo {
   }
 }
 
-@media (min-width: 1200px) {
+@media (min-width: 1680px) {
   main .quotes.singular .quote {
-    max-width: 1024px;
+    max-width: 1120px;
+    /* width: 75%; */
   }
 }
 

--- a/express/blocks/quotes/quotes.js
+++ b/express/blocks/quotes/quotes.js
@@ -31,7 +31,7 @@ export default function decorate($block) {
       const backgroundDesktopCSS = `no-repeat calc(-400px + 25%) -20px / 640px url("${backgroundUrl}"), no-repeat calc(450px + 75%) -20px / 640px url("${backgroundUrl}")`;
       $desktopContainerBackground.style.background = backgroundDesktopCSS;
 
-      const backgroundMobileCSS = `no-repeat -20px -20px / 750px url("${backgroundUrl}")`;
+      const backgroundMobileCSS = `no-repeat -80px -48px / 750px url("${backgroundUrl}")`;
       $mobileContainerBackground.style.background = backgroundMobileCSS;
 
       $rows.shift();


### PR DESCRIPTION
This is responsiveness for iPad, for the new breakpoints and adjustments below 768px, and above 1280px, for both the banner and quotes block in the homepage

**Fixes following issues|Adds following features:**
- iPad GA Responsiveness - Banner variant and Quotes block

**Resolves:** [MWPW-161048](https://jira.corp.adobe.com/browse/MWPW-161048)

**Steps to test the before vs. after and expectations:**
- https://ipad-ga-banner-before--express--adobecom.hlx.page/express/?martech=off

**Pages to check for regression and performance:**
- https://ipad-ga-banner-after--express--adobecom.hlx.page/express/?martech=off


