### PR TITLE
Table of Contents SEO Updates - Undo Revert

### DIFF
--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -67,6 +67,7 @@ export default function decorate(block, name, doc) {
   if (isStepNumberDefined) {
     numberStepStart = +rows[0].querySelectorAll('div')[1].innerText.trim();
     rows[0].remove();
+    rows.splice(0, 1);
   }
 
   const narrowVariant = block?.classList.contains('narrow');

--- a/express/features/table-of-contents-seo/table-of-contents-seo.css
+++ b/express/features/table-of-contents-seo/table-of-contents-seo.css
@@ -7,7 +7,7 @@
   background-color: #f4f4f4;
   padding-top: 10px;
   padding-bottom: 10px;
-  width: 300px;
+  width: 200px;
   white-space: nowrap;
   text-align: left; 
   border-radius: 0 12px 12px 0;
@@ -26,7 +26,6 @@
   display: flex;
   align-items: flex-start;
   padding-left: 14px;
-  padding-right: 50px;
   text-align: left;
   white-space: normal;
   overflow-wrap: break-word;
@@ -38,6 +37,7 @@
 
 .toc .toc-entry a {
   color: var(--color-info-accent);
+  text-decoration: none;
 }
 
 .toc.mobile-toc .toc-entry .toc-normal {
@@ -50,10 +50,11 @@
 
 .toc-entry .vertical-line {
   width: 4px;
-  height: 100%;
+  height: 20px;
   background-color: transparent;
   position: absolute;
   left: 0;
+  top: 0;
 }
 
 .toc-entry.active .vertical-line {
@@ -64,6 +65,8 @@
   margin-right: 5px;
   flex-shrink: 0;
   align-self: flex-start;
+  color: var(--color-info-accent);
+  flex-shrink: 0;
 }
 
 .toc-title,
@@ -71,6 +74,7 @@
   display: flex;
   align-items: center;
   padding-left: 20px; 
+  padding-right: 20px;
 }
 
 .toc-title > div,
@@ -82,11 +86,6 @@
   display: flex;
   align-items: center;
   margin-left: -6px;
-}
-
-.toc-entry .toc-number {
-  flex-shrink: 0;
-  font-weight: bold;
 }
 
 .number-circle {
@@ -114,13 +113,64 @@
 }
 
 .mobile-toc {
-  color: var(--color-info-accent);
+  max-width: none;
+  border-top: 1px solid #D0D0D0;
+  background-color: #f8f8f8;
+}
+
+.mobile-toc .toc-title {
+  height: 36px;
+  margin-bottom: 0;
+}
+
+.mobile-toc .toc-title-wrapper {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
   padding: 10px;
-  margin-bottom: 15px;
-  background-color: #f4f4f4;
-  border-radius: 16px;
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.05), 0 -6px 12px rgba(0, 0, 0, 0.05), 
-            6px 0 12px rgba(0, 0, 0, 0.05), -6px 0 12px rgba(0, 0, 0, 0.05);
+}
+
+.mobile-toc .toc-content {
+  display: none;
+}
+
+.mobile-toc .toc-content.open {
+  margin-top: 8px;
+  display: block;
+  padding-left: 10px;
+  padding-bottom: 10px;
+}
+
+.sticky {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 1;
+}
+
+.toc-chevron {
+  padding-right: 10px;
+  padding-top: 8px;
+}
+
+.toc-chevron::before {
+  border-style: solid;
+  border-width: 0.15em 0.15em 0 0;
+  content: '';
+  display: inline-block;
+  height: 0.45em;
+  left: 0.15em;
+  position: relative;
+  top: 0.15em;
+  transform: rotate(-45deg);
+  vertical-align: top;
+  width: 0.45em;
+  transition: transform 0.05s ease;
+}
+
+.toc-chevron.up:before {
+  transform: rotate(135deg);
 }
 
 @media (min-width: 600px) {

--- a/express/features/table-of-contents-seo/table-of-contents-seo.css
+++ b/express/features/table-of-contents-seo/table-of-contents-seo.css
@@ -114,7 +114,7 @@
 
 .mobile-toc {
   max-width: none;
-  border-top: 1px solid #D0D0D0;
+  border: 1px solid #D0D0D0;
   background-color: #f8f8f8;
 }
 

--- a/express/features/table-of-contents-seo/table-of-contents-seo.css
+++ b/express/features/table-of-contents-seo/table-of-contents-seo.css
@@ -1,6 +1,6 @@
 .table-of-contents-seo {
   position: fixed;
-  z-index: 25;
+  z-index: 1;
   top: 50%;
   transform: translateY(-50%);
   left: 0;

--- a/express/features/table-of-contents-seo/table-of-contents-seo.css
+++ b/express/features/table-of-contents-seo/table-of-contents-seo.css
@@ -18,6 +18,7 @@
 .toc-title {
   font-weight: bold;
   margin-bottom: 10px; 
+  color: var(--color-info-accent);
 }
 
 .toc-entry {

--- a/express/features/table-of-contents-seo/table-of-contents-seo.css
+++ b/express/features/table-of-contents-seo/table-of-contents-seo.css
@@ -112,10 +112,11 @@
   transform: translate(-50%, -50%);
 }
 
-.mobile-toc {
-  max-width: none;
+main .section.section-wrapper .mobile-toc {
   border: 1px solid #D0D0D0;
   background-color: #f8f8f8;
+  margin: 0;
+  max-width: none;
 }
 
 .mobile-toc .toc-title {

--- a/express/features/table-of-contents-seo/table-of-contents-seo.css
+++ b/express/features/table-of-contents-seo/table-of-contents-seo.css
@@ -117,6 +117,7 @@ main .section.section-wrapper .mobile-toc {
   background-color: #f8f8f8;
   margin: 0;
   max-width: none;
+  z-index: 2;
 }
 
 .mobile-toc .toc-title {
@@ -147,7 +148,7 @@ main .section.section-wrapper .mobile-toc {
   position: fixed;
   top: 0;
   width: 100%;
-  z-index: 1;
+  z-index: 2;
 }
 
 .toc-chevron {

--- a/express/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/features/table-of-contents-seo/table-of-contents-seo.js
@@ -101,7 +101,7 @@ function addTOCItemClickEvent(tocItem, heading) {
     } else {
       console.error(`Element with id "${heading.id}" not found.`);
     }
-    document.querySelector('.toc-content').style.display = 'none';
+    document.querySelector('.toc-content').classList.toggle('open');
   });
 }
 
@@ -121,11 +121,24 @@ function toggleSticky(tocClone, sticky) {
 }
 
 function handleTOCCloning(toc, tocEntries) {
-  const parentDiv = document.querySelector('.columns').parentElement;
+  const mainElement = document.querySelector('main');
 
-  if (parentDiv) {
+  if (mainElement) {
     const tocClone = toc.cloneNode(true);
     tocClone.classList.add('mobile-toc');
+
+    const titleWrapper = document.createElement('div');
+    titleWrapper.classList.add('toc-title-wrapper');
+
+    const tocTitle = tocClone.querySelector('.toc-title');
+
+    const tocChevron = document.createElement('span');
+    tocChevron.className = 'toc-chevron';
+
+    titleWrapper.appendChild(tocTitle);
+    titleWrapper.appendChild(tocChevron);
+
+    tocClone.insertBefore(titleWrapper, tocClone.firstChild);
 
     const tocContent = document.createElement('div');
     tocContent.className = 'toc-content';
@@ -135,17 +148,18 @@ function handleTOCCloning(toc, tocEntries) {
     });
 
     tocClone.appendChild(tocContent);
-    parentDiv.insertAdjacentElement('afterend', tocClone);
+    mainElement.insertAdjacentElement('beforebegin', tocClone);
 
-    const tocTitle = tocClone.querySelector('.toc-title');
-    tocTitle.addEventListener('click', () => {
-      tocContent.style.display = tocContent.style.display === 'none' ? 'block' : 'none';
+    titleWrapper.addEventListener('click', () => {
+      tocContent.classList.toggle('open');
+      tocChevron.classList.toggle('up');
     });
 
     const clonedTOCEntries = tocContent.querySelectorAll('.toc-entry');
     clonedTOCEntries.forEach((tocEntry, index) => {
       addTOCItemClickEvent(tocEntry, tocEntries[index].heading);
     });
+
     const sticky = tocClone.offsetTop - MOBILE_NAV_HEIGHT;
     window.addEventListener('scroll', () => toggleSticky(tocClone, sticky));
   }
@@ -286,6 +300,7 @@ function handleActiveTOCHighlighting(tocEntries) {
 
 function buildMetadataConfigObject() {
   const title = getMetadata('toc-title');
+  const showContentNumbers = getMetadata('toc-content-numbers');
   const contents = [];
   let i = 1;
   let content = getMetadata(`content-${i}`);
@@ -303,7 +318,7 @@ function buildMetadataConfigObject() {
   const config = contents.reduce((acc, el) => ({
     ...acc,
     ...el,
-  }), { title });
+  }), { title, 'toc-content-numbers': showContentNumbers });
 
   return config;
 }

--- a/express/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/features/table-of-contents-seo/table-of-contents-seo.js
@@ -51,8 +51,17 @@ function setNormalStyle(element) {
 
 function addHoverEffect(tocEntries) {
   tocEntries.forEach(({ tocItem }) => {
-    tocItem.addEventListener('mouseenter', () => setBoldStyle(tocItem));
-    tocItem.addEventListener('mouseleave', () => setNormalStyle(tocItem));
+    tocItem.addEventListener('mouseenter', () => {
+      if (!tocItem.classList.contains('active')) {
+        setBoldStyle(tocItem);
+      }
+    });
+
+    tocItem.addEventListener('mouseleave', () => {
+      if (!tocItem.classList.contains('active')) {
+        setNormalStyle(tocItem);
+      }
+    });
   });
 }
 

--- a/express/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/features/table-of-contents-seo/table-of-contents-seo.js
@@ -265,18 +265,18 @@ function setTOCPosition(toc, tocContainer) {
   tocContainer.style.position = targetTop <= window.scrollY + viewportMidpoint ? 'fixed' : 'absolute';
   tocContainer.style.display = 'block';
 
-  const promotionWrapper = document.querySelector('.promotion-wrapper');
+  const footer = document.querySelector('footer');
 
-  if (promotionWrapper) {
-    const promoRect = promotionWrapper.getBoundingClientRect();
-    const promoTop = Math.round(window.scrollY + promoRect.top);
+  if (footer) {
+    const footerRect = footer.getBoundingClientRect();
+    const footerTop = Math.round(window.scrollY + footerRect.top);
     const tocBottom = Math.round(window.scrollY + tocContainer.getBoundingClientRect().bottom);
 
-    const positionDifference = tocBottom - promoTop;
+    const positionDifference = tocBottom - footerTop;
 
     if (positionDifference >= 0) {
       tocContainer.style.position = 'absolute';
-      tocContainer.style.top = `${promoTop - tocContainer.offsetHeight + 92}px`;
+      tocContainer.style.top = `${footerTop - tocContainer.offsetHeight + 92}px`;
     } else if (targetTop <= window.scrollY + viewportMidpoint) {
       tocContainer.style.position = 'fixed';
       tocContainer.style.top = `${viewportMidpoint}px`;

--- a/express/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/features/table-of-contents-seo/table-of-contents-seo.js
@@ -264,6 +264,24 @@ function setTOCPosition(toc, tocContainer) {
 
   tocContainer.style.position = targetTop <= window.scrollY + viewportMidpoint ? 'fixed' : 'absolute';
   tocContainer.style.display = 'block';
+
+  const promotionWrapper = document.querySelector('.promotion-wrapper');
+
+  if (promotionWrapper) {
+    const promoRect = promotionWrapper.getBoundingClientRect();
+    const promoTop = Math.round(window.scrollY + promoRect.top);
+    const tocBottom = Math.round(window.scrollY + tocContainer.getBoundingClientRect().bottom);
+
+    const positionDifference = tocBottom - promoTop;
+
+    if (positionDifference >= 0) {
+      tocContainer.style.position = 'absolute';
+      tocContainer.style.top = `${promoTop - tocContainer.offsetHeight + 92}px`;
+    } else if (targetTop <= window.scrollY + viewportMidpoint) {
+      tocContainer.style.position = 'fixed';
+      tocContainer.style.top = `${viewportMidpoint}px`;
+    }
+  }
 }
 
 function handleSetTOCPos(toc, tocContainer) {

--- a/express/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/features/table-of-contents-seo/table-of-contents-seo.js
@@ -232,28 +232,38 @@ function addTOCEntries(toc, config, doc) {
 }
 
 function setTOCPosition(toc, tocContainer) {
+  const promotionWrapper = document.querySelector('div.promotion-wrapper');
   const firstLink = toc.querySelector('.toc-entry a');
-  if (!firstLink || !tocContainer) {
-    return;
-  }
+
+  if (!firstLink || !tocContainer || !promotionWrapper) return;
 
   const href = firstLink.getAttribute('href');
   const partialId = href.slice(1).substring(0, 10);
   const targetElement = document.querySelector(`[id^="${partialId}"]`);
 
-  if (!targetElement) {
-    return;
-  }
+  if (!targetElement) return;
 
   const rect = targetElement.getBoundingClientRect();
   const targetTop = Math.round(window.scrollY + rect.top);
   const viewportMidpoint = window.innerHeight / 2;
 
-  tocContainer.style.top = targetTop <= window.scrollY + viewportMidpoint
-    ? `${viewportMidpoint}px`
-    : `${targetTop}px`;
+  // Get the top position of the promotion-wrapper div
+  const promotionTop = Math.round(
+    window.scrollY + promotionWrapper.getBoundingClientRect().top,
+  );
 
-  tocContainer.style.position = targetTop <= window.scrollY + viewportMidpoint ? 'fixed' : 'absolute';
+  if (window.scrollY + viewportMidpoint + tocContainer.offsetHeight > promotionTop) {
+    // Stop the TOC just above the promotion-wrapper
+    tocContainer.style.position = 'absolute';
+    tocContainer.style.top = `${promotionTop - tocContainer.offsetHeight}px`;
+  } else if (targetTop <= window.scrollY + viewportMidpoint) {
+    tocContainer.style.position = 'fixed';
+    tocContainer.style.top = `${viewportMidpoint}px`;
+  } else {
+    tocContainer.style.position = 'absolute';
+    tocContainer.style.top = `${targetTop}px`;
+  }
+
   tocContainer.style.display = 'block';
 }
 

--- a/express/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/features/table-of-contents-seo/table-of-contents-seo.js
@@ -101,7 +101,7 @@ function addTOCItemClickEvent(tocItem, heading) {
     } else {
       console.error(`Element with id "${heading.id}" not found.`);
     }
-    document.querySelector('.toc-content').classList.toggle('open');
+    document.querySelector('.toc-content')?.classList.toggle('open');
   });
 }
 

--- a/express/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/features/table-of-contents-seo/table-of-contents-seo.js
@@ -232,28 +232,32 @@ function addTOCEntries(toc, config, doc) {
 }
 
 function setTOCPosition(toc, tocContainer) {
+  const footer = document.querySelector('footer');
   const firstLink = toc.querySelector('.toc-entry a');
-  if (!firstLink || !tocContainer) {
-    return;
-  }
+  if (!firstLink || !tocContainer || !footer) return;
 
   const href = firstLink.getAttribute('href');
   const partialId = href.slice(1).substring(0, 10);
   const targetElement = document.querySelector(`[id^="${partialId}"]`);
-
-  if (!targetElement) {
-    return;
-  }
+  if (!targetElement) return;
 
   const rect = targetElement.getBoundingClientRect();
+  const footerRect = footer.getBoundingClientRect();
   const targetTop = Math.round(window.scrollY + rect.top);
+  const footerTop = Math.round(window.scrollY + footerRect.top);
   const viewportMidpoint = window.innerHeight / 2;
 
-  tocContainer.style.top = targetTop <= window.scrollY + viewportMidpoint
-    ? `${viewportMidpoint}px`
-    : `${targetTop}px`;
+  if (window.scrollY + viewportMidpoint + tocContainer.offsetHeight > footerTop) {
+    tocContainer.style.position = 'absolute';
+    tocContainer.style.top = `${footerTop - tocContainer.offsetHeight}px`;
+  } else if (targetTop <= window.scrollY + viewportMidpoint) {
+    tocContainer.style.position = 'fixed';
+    tocContainer.style.top = `${viewportMidpoint}px`;
+  } else {
+    tocContainer.style.position = 'absolute';
+    tocContainer.style.top = `${targetTop}px`;
+  }
 
-  tocContainer.style.position = targetTop <= window.scrollY + viewportMidpoint ? 'fixed' : 'absolute';
   tocContainer.style.display = 'block';
 }
 

--- a/express/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/features/table-of-contents-seo/table-of-contents-seo.js
@@ -1,5 +1,4 @@
 /* eslint-disable import/named, import/extensions */
-
 import {
   createTag,
   getIconElement,
@@ -111,12 +110,15 @@ function findCorrespondingHeading(headingText, doc) {
 }
 
 function toggleSticky(tocClone, sticky) {
+  const main = document.querySelector('main .section.section-wrapper');
   if (window.scrollY >= sticky + MOBILE_NAV_HEIGHT) {
     tocClone.classList.add('sticky');
     tocClone.style.top = `${MOBILE_NAV_HEIGHT}px`;
+    main.style.marginBottom = '60px';
   } else {
     tocClone.classList.remove('sticky');
     tocClone.style.top = '';
+    main.style.marginBottom = '0';
   }
 }
 

--- a/express/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/features/table-of-contents-seo/table-of-contents-seo.js
@@ -232,34 +232,28 @@ function addTOCEntries(toc, config, doc) {
 }
 
 function setTOCPosition(toc, tocContainer) {
-  const footer = document.querySelector('footer');
   const firstLink = toc.querySelector('.toc-entry a');
-  if (!firstLink || !tocContainer || !footer) return;
+  if (!firstLink || !tocContainer) {
+    return;
+  }
 
   const href = firstLink.getAttribute('href');
   const partialId = href.slice(1).substring(0, 10);
   const targetElement = document.querySelector(`[id^="${partialId}"]`);
-  if (!targetElement) return;
 
-  const rect = targetElement.getBoundingClientRect();
-  const footerRect = footer.getBoundingClientRect();
-  const targetTop = Math.round(window.scrollY + rect.top);
-  const footerTop = Math.round(window.scrollY + footerRect.top);
-  const viewportHeight = window.innerHeight;
-
-  const tocHeight = tocContainer.offsetHeight;
-
-  if (window.scrollY + tocHeight >= footerTop - viewportHeight) {
-    tocContainer.style.position = 'absolute';
-    tocContainer.style.top = `${footerTop - tocHeight}px`;
-  } else if (window.scrollY >= targetTop - viewportHeight / 2) {
-    tocContainer.style.position = 'fixed';
-    tocContainer.style.top = `${viewportHeight / 2}px`;
-  } else {
-    tocContainer.style.position = 'absolute';
-    tocContainer.style.top = `${targetTop}px`;
+  if (!targetElement) {
+    return;
   }
 
+  const rect = targetElement.getBoundingClientRect();
+  const targetTop = Math.round(window.scrollY + rect.top);
+  const viewportMidpoint = window.innerHeight / 2;
+
+  tocContainer.style.top = targetTop <= window.scrollY + viewportMidpoint
+    ? `${viewportMidpoint}px`
+    : `${targetTop}px`;
+
+  tocContainer.style.position = targetTop <= window.scrollY + viewportMidpoint ? 'fixed' : 'absolute';
   tocContainer.style.display = 'block';
 }
 

--- a/express/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/features/table-of-contents-seo/table-of-contents-seo.js
@@ -245,14 +245,16 @@ function setTOCPosition(toc, tocContainer) {
   const footerRect = footer.getBoundingClientRect();
   const targetTop = Math.round(window.scrollY + rect.top);
   const footerTop = Math.round(window.scrollY + footerRect.top);
-  const viewportMidpoint = window.innerHeight / 2;
+  const viewportHeight = window.innerHeight;
 
-  if (window.scrollY + viewportMidpoint + tocContainer.offsetHeight > footerTop) {
+  const tocHeight = tocContainer.offsetHeight;
+
+  if (window.scrollY + tocHeight >= footerTop - viewportHeight) {
     tocContainer.style.position = 'absolute';
-    tocContainer.style.top = `${footerTop - tocContainer.offsetHeight}px`;
-  } else if (targetTop <= window.scrollY + viewportMidpoint) {
+    tocContainer.style.top = `${footerTop - tocHeight}px`;
+  } else if (window.scrollY >= targetTop - viewportHeight / 2) {
     tocContainer.style.position = 'fixed';
-    tocContainer.style.top = `${viewportMidpoint}px`;
+    tocContainer.style.top = `${viewportHeight / 2}px`;
   } else {
     tocContainer.style.position = 'absolute';
     tocContainer.style.top = `${targetTop}px`;

--- a/express/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/features/table-of-contents-seo/table-of-contents-seo.js
@@ -121,7 +121,7 @@ function toggleSticky(tocClone, sticky) {
 }
 
 function handleTOCCloning(toc, tocEntries) {
-  const mainElement = document.querySelector('main');
+  const mainElement = document.querySelector('.section.section-wrapper').firstElementChild;
 
   if (mainElement) {
     const tocClone = toc.cloneNode(true);
@@ -148,7 +148,7 @@ function handleTOCCloning(toc, tocEntries) {
     });
 
     tocClone.appendChild(tocContent);
-    mainElement.insertAdjacentElement('beforebegin', tocClone);
+    mainElement.insertAdjacentElement('afterend', tocClone);
 
     titleWrapper.addEventListener('click', () => {
       tocContent.classList.toggle('open');

--- a/express/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/features/table-of-contents-seo/table-of-contents-seo.js
@@ -232,38 +232,28 @@ function addTOCEntries(toc, config, doc) {
 }
 
 function setTOCPosition(toc, tocContainer) {
-  const promotionWrapper = document.querySelector('div.promotion-wrapper');
   const firstLink = toc.querySelector('.toc-entry a');
-
-  if (!firstLink || !tocContainer || !promotionWrapper) return;
+  if (!firstLink || !tocContainer) {
+    return;
+  }
 
   const href = firstLink.getAttribute('href');
   const partialId = href.slice(1).substring(0, 10);
   const targetElement = document.querySelector(`[id^="${partialId}"]`);
 
-  if (!targetElement) return;
+  if (!targetElement) {
+    return;
+  }
 
   const rect = targetElement.getBoundingClientRect();
   const targetTop = Math.round(window.scrollY + rect.top);
   const viewportMidpoint = window.innerHeight / 2;
 
-  // Get the top position of the promotion-wrapper div
-  const promotionTop = Math.round(
-    window.scrollY + promotionWrapper.getBoundingClientRect().top,
-  );
+  tocContainer.style.top = targetTop <= window.scrollY + viewportMidpoint
+    ? `${viewportMidpoint}px`
+    : `${targetTop}px`;
 
-  if (window.scrollY + viewportMidpoint + tocContainer.offsetHeight > promotionTop) {
-    // Stop the TOC just above the promotion-wrapper
-    tocContainer.style.position = 'absolute';
-    tocContainer.style.top = `${promotionTop - tocContainer.offsetHeight}px`;
-  } else if (targetTop <= window.scrollY + viewportMidpoint) {
-    tocContainer.style.position = 'fixed';
-    tocContainer.style.top = `${viewportMidpoint}px`;
-  } else {
-    tocContainer.style.position = 'absolute';
-    tocContainer.style.top = `${targetTop}px`;
-  }
-
+  tocContainer.style.position = targetTop <= window.scrollY + viewportMidpoint ? 'fixed' : 'absolute';
   tocContainer.style.display = 'block';
 }
 

--- a/express/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/features/table-of-contents-seo/table-of-contents-seo.js
@@ -232,10 +232,10 @@ function addTOCEntries(toc, config, doc) {
 }
 
 function setTOCPosition(toc, tocContainer) {
-  const footer = document.querySelector('footer');
+  const promotionWrapper = document.querySelector('div.promotion-wrapper');
   const firstLink = toc.querySelector('.toc-entry a');
 
-  if (!firstLink || !tocContainer || !footer) return;
+  if (!firstLink || !tocContainer || !promotionWrapper) return;
 
   const href = firstLink.getAttribute('href');
   const partialId = href.slice(1).substring(0, 10);
@@ -247,13 +247,15 @@ function setTOCPosition(toc, tocContainer) {
   const targetTop = Math.round(window.scrollY + rect.top);
   const viewportMidpoint = window.innerHeight / 2;
 
-  const footerTop = Math.round(
-    window.scrollY + footer.getBoundingClientRect().top,
+  // Get the top position of the promotion-wrapper div
+  const promotionTop = Math.round(
+    window.scrollY + promotionWrapper.getBoundingClientRect().top,
   );
 
-  if (window.scrollY + viewportMidpoint + tocContainer.offsetHeight > footerTop) {
+  if (window.scrollY + viewportMidpoint + tocContainer.offsetHeight > promotionTop) {
+    // Stop the TOC just above the promotion-wrapper
     tocContainer.style.position = 'absolute';
-    tocContainer.style.top = `${footerTop - tocContainer.offsetHeight}px`;
+    tocContainer.style.top = `${promotionTop - tocContainer.offsetHeight}px`;
   } else if (targetTop <= window.scrollY + viewportMidpoint) {
     tocContainer.style.position = 'fixed';
     tocContainer.style.top = `${viewportMidpoint}px`;

--- a/express/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/features/table-of-contents-seo/table-of-contents-seo.js
@@ -232,10 +232,10 @@ function addTOCEntries(toc, config, doc) {
 }
 
 function setTOCPosition(toc, tocContainer) {
-  const promotionWrapper = document.querySelector('div.promotion-wrapper');
+  const footer = document.querySelector('footer');
   const firstLink = toc.querySelector('.toc-entry a');
 
-  if (!firstLink || !tocContainer || !promotionWrapper) return;
+  if (!firstLink || !tocContainer || !footer) return;
 
   const href = firstLink.getAttribute('href');
   const partialId = href.slice(1).substring(0, 10);
@@ -247,15 +247,13 @@ function setTOCPosition(toc, tocContainer) {
   const targetTop = Math.round(window.scrollY + rect.top);
   const viewportMidpoint = window.innerHeight / 2;
 
-  // Get the top position of the promotion-wrapper div
-  const promotionTop = Math.round(
-    window.scrollY + promotionWrapper.getBoundingClientRect().top,
+  const footerTop = Math.round(
+    window.scrollY + footer.getBoundingClientRect().top,
   );
 
-  if (window.scrollY + viewportMidpoint + tocContainer.offsetHeight > promotionTop) {
-    // Stop the TOC just above the promotion-wrapper
+  if (window.scrollY + viewportMidpoint + tocContainer.offsetHeight > footerTop) {
     tocContainer.style.position = 'absolute';
-    tocContainer.style.top = `${promotionTop - tocContainer.offsetHeight}px`;
+    tocContainer.style.top = `${footerTop - tocContainer.offsetHeight}px`;
   } else if (targetTop <= window.scrollY + viewportMidpoint) {
     tocContainer.style.position = 'fixed';
     tocContainer.style.top = `${viewportMidpoint}px`;

--- a/express/scripts/express-delayed.js
+++ b/express/scripts/express-delayed.js
@@ -152,11 +152,19 @@ function preloadSUSILight() {
   import('../blocks/fragment/fragment.js');
 }
 
+function loadTOC() {
+  if (getMetadata('toc-seo') === 'on') {
+    loadStyle('/express/features/table-of-contents-seo/table-of-contents-seo.css');
+    import('../features/table-of-contents-seo/table-of-contents-seo.js').then(({ default: setTOCSEO }) => setTOCSEO());
+  }
+}
+
 /**
  * Executes everything that happens a lot later, without impacting the user experience.
  */
 export default async function loadDelayed() {
   try {
+    loadTOC();
     preloadSUSILight();
     if (await canPEP()) {
       const { default: loadLoginUserAutoRedirect } = await import('../features/direct-path-to-product/direct-path-to-product.js');

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2420,21 +2420,9 @@ export async function loadTemplate() {
   await Promise.all([styleLoaded, scriptLoaded]);
 }
 
-function loadTOC() {
-  if (getMetadata('toc-seo') === 'on') {
-    const handler = () => {
-      loadStyle('/express/features/table-of-contents-seo/table-of-contents-seo.css');
-      import('../features/table-of-contents-seo/table-of-contents-seo.js').then(({ default: setTOCSEO }) => setTOCSEO());
-    };
-    window.addEventListener('express:LCP:loaded', handler);
-  }
-}
-
 async function loadPostLCP(config) {
   // post LCP actions go here
   sampleRUM('lcp');
-  loadTOC();
-
   window.dispatchEvent(new Event('express:LCP:loaded'));
   if (config.mep?.targetEnabled === 'gnav') {
     await loadMartech({ persEnabled: true, postLCP: true });


### PR DESCRIPTION
Fixes following issues|Adds following features:

- Resolve bug where how to steps starts at 2 instead of 1
- Add chevron / toggle chevron up and down to mobile toc
- Make Table Of Contents sticky on mobile and positioned just below the nav
- Allow Authors to use short hand titles for the table of contents
- Allow Authors to control whether numbers are shown for each header corresponding to each table of contents link

Resolves: [MWPW-160248](https://jira.corp.adobe.com/browse/MWPW-160248)
Original PR: https://github.com/adobecom/express/pull/1209
