### PR TITLE
MWPW-161854 ignore json files in the codebus

### DIFF
--- a/.hlxignore
+++ b/.hlxignore
@@ -1,5 +1,7 @@
 .*
 *.md
+*.json
+!*/**/*.json
 LICENSE
 package.json
 package-lock.json


### PR DESCRIPTION
ignores top level json files in the hlx codebus. 

**Resolves:** [MWPW-161854](https://jira.corp.adobe.com/browse/MWPW-161854)

**Steps to test the before vs. after and expectations:**
- none

**Pages to check for regression and performance:**
- https://MWPW-161854-hlxignore-json--express--adobecom.hlx.page/express/?martech=off
