### PR TITLE
Grid Marquee Refine Img/Video Ratio

### DIFF
--- a/express/blocks/grid-marquee/grid-marquee.css
+++ b/express/blocks/grid-marquee/grid-marquee.css
@@ -1,10 +1,7 @@
 .grid-marquee {
   --m-img-w: 152px;
-  --m-img-h: 103px;
-  --t-img-w: 183px;
-  --t-img-h: 152px;
-  --d-img-w: 256px;
-  --d-img-h: 199px;
+  --t-img-w: 181px;
+  --d-img-w: 254px;
 }
 .grid-marquee {
   max-width: initial;
@@ -108,9 +105,6 @@
 .grid-marquee .face img {
   border-radius: 8px;
   width: var(--m-img-w);
-  height: var(--m-img-h);
-  object-fit: cover;
-  object-position: center;
 }
 
 .grid-marquee .drawer {
@@ -292,7 +286,6 @@
 
   .grid-marquee .face img {
     width: var(--t-img-w);
-    height: var(--t-img-h);
   }
 }
 
@@ -332,7 +325,6 @@
 
   .grid-marquee .face img {
     width: var(--d-img-w);
-    height: var(--d-img-h);
   }
 
   .grid-marquee .face {


### PR DESCRIPTION
**Fixes following issues:**
- Grid-marquee image/video ratio refinement

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-161887

**Steps to test the before vs. after and expectations:**
- Expectation: on Desktop, when hovering, each video should cover perfectly the image displayed in its position before hovering.

**Pages to check for regression and performance:**
- https://grid-marquee-ratio--express--adobecom.hlx.live/express/?martech=off
