### PR TITLE
Add Black Border to GenAI Cards

### DIFF
--- a/express/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/blocks/gen-ai-cards/gen-ai-cards.css
@@ -235,7 +235,7 @@ main .gen-ai-cards.homepage .card .media-wrapper {
   margin: 4px auto;
   width: max-content;
   color: var(--body-color);
-  border: 0;
+  border: 2px solid black;
 }
 
 .gen-ai-cards .card .links-wrapper a:hover {


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Add black 2px border to gen-ai card CTA

**Resolves:** [MWPW-160965](https://jira.corp.adobe.com/browse/MWPW-160965)

**Pages to check for regression and performance:**
- https://gen-ai-button-border--express--adobecom.hlx.page/express/?martech=off
