### PR TITLE
ensure icons have proportional height and width in feature-list

### DIFF
--- a/express/blocks/feature-list/feature-list.css
+++ b/express/blocks/feature-list/feature-list.css
@@ -9,6 +9,7 @@ main .section .feature-list {
 
 main .section .feature-list img {
     height: 48px;
+    width: auto;
 }
 
 main .section .feature-list > div {


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Ensure yellow icons on entitled page are proportional and not stretched

**Resolves:** [MWPW-158974](https://jira.corp.adobe.com/browse/MWPW-158974)

**Steps to test the before vs. after and expectations:**
**Before**: 
<img width="1331" alt="before" src="https://github.com/user-attachments/assets/5ab759e3-e4d8-4ee8-a929-8f29b7acd872">
**After**: 
<img width="1376" alt="after" src="https://github.com/user-attachments/assets/daf0a353-9697-461f-b7c9-73608f008747">

**Pages to check for regression and performance:**
- https://jp-entitled--express--adobecom.hlx.page/drafts/jsandlan/entitled
