### PR TITLE
[Hot Fix] Add branchlink Parameters for Interactive Marquee Enticements

### DIFF
--- a/express/features/horizontal-masonry/horizontal-masonry.js
+++ b/express/features/horizontal-masonry/horizontal-masonry.js
@@ -19,12 +19,12 @@ export const windowHelper = {
 
 async function handleGenAISubmit(form, link, placeholders) {
   const input = form.querySelector('input');
-  if (input.value.trim() === '') return;
+  if (!link || input.value.trim() === '') return;
   const mod = await import('../../scripts/branchlinks.js');
   const genAILink = mod.getTrackingAppendedURL(link, placeholders).replace(promptTokenRegex, encodeURI(input.value).replaceAll(' ', '+'));
   const urlObj = new URL(genAILink);
   urlObj.searchParams.delete('referrer');
-  if (genAILink) windowHelper.redirect(urlObj.toString());
+  windowHelper.redirect(urlObj.toString());
 }
 
 function createEnticement(enticementDetail, enticementPlaceholder,
@@ -55,8 +55,10 @@ function createEnticement(enticementDetail, enticementPlaceholder,
 function createPromptLinkElement(promptLink, prompt, placeholders) {
   const icon = getIconElement('external-link', 22);
   icon.classList.add('link');
-  icon.addEventListener('click', () => {
-    const urlObj = new URL(promptLink);
+  icon.addEventListener('click', async () => {
+    const mod = await import('../../scripts/branchlinks.js');
+    const genAILink = mod.getTrackingAppendedURL(promptLink, placeholders);
+    const urlObj = new URL(genAILink);
     urlObj.searchParams.delete('referrer');
     urlObj.searchParams.append('prompt', prompt);
     windowHelper.redirect(urlObj.toString());


### PR DESCRIPTION
**Fixes following issues:**
- Clicking prepared prompts in the grids takes users to product but does not open up the generation modal

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-162458

**Steps to test the before vs. after and expectations:**
- Go to url and click one of the 4 masonry image to get redirected
- If you're not signed in, you'll be prompted to. But either way once in product, you should be greeted with a templtae generation modal

**Pages to check for regression and performance:**
- https://link-fix-horizontal-masonry--express--adobecom.hlx.live/express/create/ai/template-generator?martech=off
