### PR TITLE
Fix Stretched Homepage Discover Cards Image For Express International

### DIFF
--- a/express/blocks/discover-cards/discover-cards.css
+++ b/express/blocks/discover-cards/discover-cards.css
@@ -104,7 +104,7 @@ main .section .discover-cards {
         padding-top: 9px;
     }
     .discover-cards .cards-container .card picture img.short { 
-        width: 351px;
+        width: auto;
         height: 198px; 
     }
     .discover-cards .cards-container.gallery {


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Issue/Feature 1

**Resolves:** [MWPW-162755](https://jira.corp.adobe.com/browse/MWPW-162755)

**Before**: 
https://www.stage.adobe.com/kr/express/
<img width="1679" alt="kr" src="https://github.com/user-attachments/assets/392d9524-e085-4bc2-89ce-0ceff5b16c0e">


**Pages to check for regression and performance:**
**After**:
- https://intl-homepage-images--express--adobecom.hlx.page/kr/express/?martech=off
<img width="1722" alt="kr - after" src="https://github.com/user-attachments/assets/517be216-68b8-4596-b0c7-d2e2a0068fe9">

- https://intl-homepage-images--express--adobecom.hlx.page/express/?martech=off
No regression for US site
<img width="1684" alt="us - no regression" src="https://github.com/user-attachments/assets/09da0fce-5854-4e1e-922a-3220b8905c3d">
