### PR TITLE
Mobile Frictionless-QA Test Block

### DIFF
--- a/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
+++ b/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
@@ -16,7 +16,7 @@
 }
 
 .frictionless-quick-action-mobile h1 {
-    font-size: 2.125rem;
+    font-size: 2rem;
     text-align: left;
     line-height: 1.3;
     color: #242424;

--- a/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
+++ b/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
@@ -1,5 +1,5 @@
 .frictionless-quick-action-mobile {
-    --animation-h: 233px;
+    --animation-h: 260px;
 }
 
 .section .frictionless-quick-action-mobile {
@@ -74,7 +74,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    border-radius: 12px;
+    border-radius: 16px;
     background-color: #f8f8f8;
     border: 0;
     padding: 0;

--- a/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
+++ b/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
@@ -12,13 +12,13 @@
 /* TODO: font-family seems to be inconsistent? */
 
 .frictionless-quick-action-mobile .headline {
-    padding-bottom: 8px;
+    padding-bottom: 12px;
 }
 
 .frictionless-quick-action-mobile h1 {
-    font-size: 2rem;
+    font-size: 2.125rem;
     text-align: left;
-    line-height: 1.1;
+    line-height: 1.3;
     color: #242424;
 }
 

--- a/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
+++ b/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
@@ -6,11 +6,12 @@
 .section .frictionless-quick-action-mobile {
     padding: 40px 20px;
     max-width: none;
+    text-align: left;
 }
 /* TODO: font-family seems to be inconsistent? */
 
 .frictionless-quick-action-mobile .headline {
-    padding-bottom: 24px;
+    padding-bottom: 8px;
 }
 
 .frictionless-quick-action-mobile h1 {
@@ -23,6 +24,7 @@
 .frictionless-quick-action-mobile .express-logo {
     width: initial;
     height: 30px;
+    padding-bottom: 8px;
 }
 
 .frictionless-quick-action-mobile input {
@@ -52,6 +54,7 @@
     justify-content: center;
     align-items: center;
     flex-direction: column;
+    text-align: center;
 }
 
 .frictionless-quick-action-mobile .animation-container.hide {
@@ -66,6 +69,8 @@
     align-items: center;
     border-radius: 10px;
     background-color: #f8f8f8;
+    border: 0;
+    padding: 0;
 }
 
 .frictionless-quick-action-mobile .dropzone .border-wrapper {

--- a/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
+++ b/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
@@ -1,0 +1,194 @@
+.frictionless-quick-action-mobile.block {
+    padding: 40px 20px;
+    max-width: none;
+}
+
+.frictionless-quick-action-mobile.block h1 {
+    font-size: 2.8125rem;
+}
+
+.frictionless-quick-action-mobile.block .express-logo {
+    width: initial;
+    height: 30px;
+  }
+
+.frictionless-quick-action-mobile.block h1+p {
+    margin: 16px 0 24px;
+    font-size: 1rem;
+}
+
+.frictionless-quick-action-mobile.block input {
+    display: none;
+}
+
+.frictionless-quick-action-mobile.block .quick-action-container {
+    padding: 40px 0;
+    min-height: 697px;
+    max-width: 1440px;
+    width: 100%;
+    margin: auto;
+    transition: opacity 0.2s;
+}
+
+.frictionless-quick-action-mobile.block h1 em {
+    background: linear-gradient(320deg, #7C84F3, #FF4DD2, #FF993B, #FF4DD2, #7C84F3, #FF4DD2, #FF993B);
+    background-size: 400% 400%;
+    -webkit-animation: quickActionGradient 45s ease infinite;
+    -moz-animation: quickActionGradient 45s ease infinite;
+    animation: quickActionGradient 45s ease infinite;
+    -webkit-background-clip: text;
+    background-clip: text;
+    font-style: normal;
+    -webkit-text-fill-color: transparent;
+}
+
+.frictionless-quick-action-mobile .container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: opacity 0.2s;
+    flex-wrap: wrap;
+}
+
+.frictionless-quick-action-mobile .container > div:nth-child(2) {
+    margin-top: 26px;
+}
+
+.frictionless-quick-action-mobile.block video,
+.frictionless-quick-action-mobile.block img:not(.icon) {
+    max-width: 444px;
+}
+
+.frictionless-quick-action-mobile.block .dropzone-container {
+    cursor: pointer;
+    padding: 24px 0;
+    border-radius: 20px;
+    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.3);
+    width: 630px;
+    height: 284px;
+}
+
+.frictionless-quick-action-mobile.block .dropzone-bg {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    left: 0px;
+    background: url("/express/icons/dash-rectangle.svg") center center / 91% no-repeat;
+}
+
+.frictionless-quick-action-mobile.block .dropzone-container.highlight .dropzone-bg {
+    filter: invert(0%) sepia(0%) saturate(7500%) hue-rotate(327deg) brightness(6%) contrast(104%);
+    transition: 0.3s ease-in-out;
+}
+
+.frictionless-quick-action-mobile.block .dropzone-container:hover, .frictionless-quick-action-mobile.block .dropzone-container.highlight  {
+    background-color: rgb(211, 211, 211, 0.2);
+}
+
+.frictionless-quick-action-mobile.block .dropzone {
+    height: 100%;
+    width: 100%;
+    position: relative;
+}
+
+.frictionless-quick-action-mobile.block .dropzone-bg + p {
+    margin: 0;
+    padding: 39px 24px 0 24px;
+    font-size: var(--heading-font-size-m);
+    font-weight: var(--heading-font-weight);
+    line-height: var(--heading-line-height);
+}
+
+.frictionless-quick-action-mobile.block .dropzone-bg + p em {
+    font-style: normal;
+    color: var(--color-info-accent);
+}
+
+.frictionless-quick-action-mobile.block .dropzone p:last-of-type {
+    font-size: .6875rem;
+    margin: 0;
+}
+
+.frictionless-quick-action-mobile.block .dropzone .button {
+    margin-bottom: 0;
+}
+
+.frictionless-quick-action-mobile .container > div:nth-child(2) > p:last-of-type {
+    margin: 15px 0 0;
+    font-size: 0.75rem;
+}
+
+.frictionless-quick-action-mobile.block .free-plan-widget {
+    background-color: unset;
+    flex-direction: row;
+    padding: unset;
+    margin: 16px auto 0 auto;
+    gap: 8px;
+}
+
+.frictionless-quick-action-mobile.block .free-plan-widget > div {
+    margin: 10px;
+}
+
+.frictionless-quick-action-mobile.block .free-plan-widget img.icon.icon-checkmark {
+    background-color: #f06dad;
+}
+.frictionless-quick-action-mobile.block .quick-action-container {
+    height: 667px;
+}
+
+.frictionless-quick-action-mobile.block .quick-action-container > * {
+    height: 100%;
+}
+
+.frictionless-quick-action-mobile.block .quick-action-container#resize-image-container {
+    height: 1080px;
+}
+
+.frictionless-quick-action-mobile.block > div.hidden {
+    visibility: hidden;
+    position: absolute;
+}
+
+.frictionless-quick-action-mobile.block > div.transparent {
+    opacity: 0;
+}
+
+.frictionless-quick-action-mobile .error-toast {
+    position: fixed;
+    bottom: 100px;
+    left: 50%;
+    transform: translateX(-50%);
+    opacity: 1;
+    transition: opacity 1s;
+    z-index: 10;
+    margin: 0 auto;
+    color: white;
+    background-color: #d31510;
+    padding: 10px 16px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: var(--body-font-size-s);
+    width: fit-content;
+    border-radius: 50px;
+}
+
+.frictionless-quick-action-mobile .error-toast.hide {
+    opacity: 0;
+}
+
+.frictionless-quick-action-mobile .error-toast button {
+    background-color: unset;
+    border: unset;
+    padding: unset;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+}
+
+@media (min-width: 1200) {
+    .frictionless-quick-action-mobile.block .quick-action-container#resize-image-container {
+        height: 1000px;
+    }
+}

--- a/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
+++ b/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
@@ -4,7 +4,8 @@
 }
 
 .section .frictionless-quick-action-mobile {
-    padding: 40px 20px;
+    padding: 24px 20px 0px 20px;
+    margin: auto;
     max-width: none;
     text-align: left;
 }

--- a/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
+++ b/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
@@ -1,27 +1,35 @@
-.frictionless-quick-action-mobile.block {
+.frictionless-quick-action-mobile {
+    --animation-w: 335px;
+    --animation-h: 233px;
+}
+
+.section .frictionless-quick-action-mobile {
     padding: 40px 20px;
     max-width: none;
 }
+/* TODO: font-family seems to be inconsistent? */
 
-.frictionless-quick-action-mobile.block h1 {
-    font-size: 2.8125rem;
+.frictionless-quick-action-mobile .headline {
+    padding-bottom: 24px;
 }
 
-.frictionless-quick-action-mobile.block .express-logo {
+.frictionless-quick-action-mobile h1 {
+    font-size: 2rem;
+    text-align: left;
+    line-height: 1.1;
+    color: #242424;
+}
+
+.frictionless-quick-action-mobile .express-logo {
     width: initial;
     height: 30px;
-  }
-
-.frictionless-quick-action-mobile.block h1+p {
-    margin: 16px 0 24px;
-    font-size: 1rem;
 }
 
-.frictionless-quick-action-mobile.block input {
+.frictionless-quick-action-mobile input {
     display: none;
 }
 
-.frictionless-quick-action-mobile.block .quick-action-container {
+.frictionless-quick-action-mobile .quick-action-container {
     padding: 40px 0;
     min-height: 697px;
     max-width: 1440px;
@@ -30,68 +38,67 @@
     transition: opacity 0.2s;
 }
 
-.frictionless-quick-action-mobile.block h1 em {
-    background: linear-gradient(320deg, #7C84F3, #FF4DD2, #FF993B, #FF4DD2, #7C84F3, #FF4DD2, #FF993B);
-    background-size: 400% 400%;
-    -webkit-animation: quickActionGradient 45s ease infinite;
-    -moz-animation: quickActionGradient 45s ease infinite;
-    animation: quickActionGradient 45s ease infinite;
-    -webkit-background-clip: text;
-    background-clip: text;
-    font-style: normal;
-    -webkit-text-fill-color: transparent;
-}
-
-.frictionless-quick-action-mobile .container {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: opacity 0.2s;
-    flex-wrap: wrap;
-}
-
-.frictionless-quick-action-mobile .container > div:nth-child(2) {
-    margin-top: 26px;
-}
-
-.frictionless-quick-action-mobile.block video,
-.frictionless-quick-action-mobile.block img:not(.icon) {
+.frictionless-quick-action-mobile video,
+.frictionless-quick-action-mobile img:not(.icon) {
     max-width: 444px;
 }
 
-.frictionless-quick-action-mobile.block .dropzone-container {
-    cursor: pointer;
-    padding: 24px 0;
-    border-radius: 20px;
-    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.3);
-    width: 630px;
-    height: 284px;
+.frictionless-quick-action-mobile video {
+    height: var(--animation-h);
 }
 
-.frictionless-quick-action-mobile.block .dropzone-bg {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    left: 0px;
-    background: url("/express/icons/dash-rectangle.svg") center center / 91% no-repeat;
+.frictionless-quick-action-mobile .dropzone-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
 }
 
-.frictionless-quick-action-mobile.block .dropzone-container.highlight .dropzone-bg {
-    filter: invert(0%) sepia(0%) saturate(7500%) hue-rotate(327deg) brightness(6%) contrast(104%);
-    transition: 0.3s ease-in-out;
+.frictionless-quick-action-mobile .animation-container.hide {
+    display: none;
 }
 
-.frictionless-quick-action-mobile.block .dropzone-container:hover, .frictionless-quick-action-mobile.block .dropzone-container.highlight  {
-    background-color: rgb(211, 211, 211, 0.2);
+.frictionless-quick-action-mobile .dropzone {
+    width: var(--animation-w);
+    height: var(--animation-h);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: 10px;
+    background-color: #f8f8f8;
 }
 
-.frictionless-quick-action-mobile.block .dropzone {
-    height: 100%;
-    width: 100%;
-    position: relative;
+.frictionless-quick-action-mobile .dropzone .border-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: calc(100% - 34px);
+    height: calc(100% - 34px);
+    border-radius: 10px;
+    border-image: url("/express/icons/dash-rectangle.svg") 20 / 20px;
 }
 
-.frictionless-quick-action-mobile.block .dropzone-bg + p {
+.frictionless-quick-action-mobile .dropzone .text {
+    font-size: 1.75rem;
+    /* TODO: if winner, need to have dynamic width & height */
+    width: 200px;
+    font-style: normal;
+    display: flex;
+    flex-direction: column;
+    font-weight: 900;
+    line-height: 1.1;
+}
+
+.frictionless-quick-action-mobile .dropzone .text strong {
+    color: #5C5CE0;
+    font-weight: 900;
+}
+
+.frictionless-quick-action-mobile .dropzone.hide {
+    display: none;
+}
+
+.frictionless-quick-action-mobile .dropzone-bg + p {
     margin: 0;
     padding: 39px 24px 0 24px;
     font-size: var(--heading-font-size-m);
@@ -99,58 +106,38 @@
     line-height: var(--heading-line-height);
 }
 
-.frictionless-quick-action-mobile.block .dropzone-bg + p em {
+.frictionless-quick-action-mobile .dropzone-bg + p em {
     font-style: normal;
     color: var(--color-info-accent);
 }
 
-.frictionless-quick-action-mobile.block .dropzone p:last-of-type {
+.frictionless-quick-action-mobile .dropzone p:last-of-type {
     font-size: .6875rem;
     margin: 0;
 }
 
-.frictionless-quick-action-mobile.block .dropzone .button {
+.frictionless-quick-action-mobile .dropzone .button {
     margin-bottom: 0;
 }
 
-.frictionless-quick-action-mobile .container > div:nth-child(2) > p:last-of-type {
-    margin: 15px 0 0;
-    font-size: 0.75rem;
-}
-
-.frictionless-quick-action-mobile.block .free-plan-widget {
-    background-color: unset;
-    flex-direction: row;
-    padding: unset;
-    margin: 16px auto 0 auto;
-    gap: 8px;
-}
-
-.frictionless-quick-action-mobile.block .free-plan-widget > div {
-    margin: 10px;
-}
-
-.frictionless-quick-action-mobile.block .free-plan-widget img.icon.icon-checkmark {
-    background-color: #f06dad;
-}
-.frictionless-quick-action-mobile.block .quick-action-container {
+.frictionless-quick-action-mobile .quick-action-container {
     height: 667px;
 }
 
-.frictionless-quick-action-mobile.block .quick-action-container > * {
+.frictionless-quick-action-mobile .quick-action-container > * {
     height: 100%;
 }
 
-.frictionless-quick-action-mobile.block .quick-action-container#resize-image-container {
+.frictionless-quick-action-mobile .quick-action-container#resize-image-container {
     height: 1080px;
 }
 
-.frictionless-quick-action-mobile.block > div.hidden {
+.frictionless-quick-action-mobile > div.hidden {
     visibility: hidden;
     position: absolute;
 }
 
-.frictionless-quick-action-mobile.block > div.transparent {
+.frictionless-quick-action-mobile > div.transparent {
     opacity: 0;
 }
 
@@ -188,7 +175,7 @@
 }
 
 @media (min-width: 1200) {
-    .frictionless-quick-action-mobile.block .quick-action-container#resize-image-container {
+    .frictionless-quick-action-mobile .quick-action-container#resize-image-container {
         height: 1000px;
     }
 }

--- a/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
+++ b/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
@@ -1,10 +1,9 @@
 .frictionless-quick-action-mobile {
-    --animation-w: 335px;
     --animation-h: 233px;
 }
 
 .section .frictionless-quick-action-mobile {
-    padding: 24px 20px 0px 20px;
+    padding: 24px 16px 0px 16px;
     margin: auto;
     max-width: none;
     text-align: left;
@@ -46,10 +45,6 @@
     max-width: 444px;
 }
 
-.frictionless-quick-action-mobile video {
-    height: var(--animation-h);
-}
-
 .frictionless-quick-action-mobile .dropzone-container {
     display: flex;
     justify-content: center;
@@ -58,18 +53,28 @@
     text-align: center;
 }
 
+.frictionless-quick-action-mobile .animation-container {
+    width: 100%;
+    height: var(--animation-h);
+}
+
+.frictionless-quick-action-mobile .animation-container video {
+    width: 100%;
+    height: 100%;
+}
+
 .frictionless-quick-action-mobile .animation-container.hide {
     display: none;
 }
 
 .frictionless-quick-action-mobile .dropzone {
     font-family: var(--body-font-family);
-    width: var(--animation-w);
+    width: 100%;
     height: var(--animation-h);
     display: flex;
     justify-content: center;
     align-items: center;
-    border-radius: 10px;
+    border-radius: 12px;
     background-color: #f8f8f8;
     border: 0;
     padding: 0;
@@ -125,6 +130,41 @@
 
 .frictionless-quick-action-mobile .dropzone .button {
     margin-bottom: 0;
+}
+
+.frictionless-quick-action-mobile .extra-container {
+    padding-top: 16px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.frictionless-quick-action-mobile .extra-container p {
+    font-size: var(--body-font-size-xs);
+    text-align: center;
+    margin: 0;
+}
+
+.frictionless-quick-action-mobile.block .free-plan-container {
+    min-height: 15px;
+}
+
+.frictionless-quick-action-mobile.block .free-plan-widget {
+    background-color: unset;
+    flex-direction: row;
+    padding: unset;
+    margin: auto;
+    gap: 8px;
+    font-size: var(--body-font-size-xs);
+}
+
+.frictionless-quick-action-mobile.block .free-plan-widget > div {
+    margin: 10px;
+}
+
+.frictionless-quick-action-mobile.block .free-plan-widget img.icon.icon-checkmark {
+    background-color: #f06dad;
 }
 
 .frictionless-quick-action-mobile .quick-action-container {

--- a/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
+++ b/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
@@ -63,6 +63,7 @@
 }
 
 .frictionless-quick-action-mobile .dropzone {
+    font-family: var(--body-font-family);
     width: var(--animation-w);
     height: var(--animation-h);
     display: flex;

--- a/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
+++ b/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
@@ -270,7 +270,27 @@ async function startSDKWithUnconvertedFile(file, quickAction, block) {
   showErrorToast(block, msg);
 }
 
-export default async function decorate(block) {
+async function injectFreePlan(container) {
+  const { buildFreePlanWidget } = await import('../../scripts/utils/free-plan.js');
+  const freePlan = await buildFreePlanWidget({ typeKey: 'features', checkmarks: true });
+  container.append(freePlan);
+  return container;
+}
+
+function decorateExtra(extra) {
+  const wrapper = extra.querySelector('div');
+  while (wrapper?.firstChild) {
+    extra.append(wrapper.firstChild);
+  }
+  wrapper.remove();
+  const legalText = extra.querySelector('p:last-of-type');
+  legalText.classList.add('legal');
+  const freePlanContainer = createTag('div', { class: 'free-plan-container' });
+  injectFreePlan(freePlanContainer);
+  legalText.before(freePlanContainer);
+}
+
+export default function decorate(block) {
   const rows = Array.from(block.children);
   const [quickActionRow] = rows.filter((row) => row.children[0]?.textContent?.toLowerCase()?.trim() === 'quick-action');
   quickActionRow?.remove();
@@ -288,6 +308,8 @@ export default async function decorate(block) {
 
   rows[0].classList.add('headline');
   rows[1].classList.add('dropzone-container');
+  rows[2].classList.add('extra-container');
+  decorateExtra(rows[2]);
   const dropzone = createTag('button', { class: 'dropzone hide' });
   const [animationContainer, dropzoneContent] = rows[1].children;
   while (dropzoneContent.firstChild) dropzone.append(dropzoneContent.firstChild);

--- a/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
+++ b/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
@@ -1,0 +1,383 @@
+import {
+  createTag,
+  getConfig,
+  loadScript,
+  transformLinkToAnimation,
+  addAnimationToggle,
+  fetchPlaceholders,
+  getMetadata,
+  getIconElement,
+} from '../../scripts/utils.js';
+import { buildFreePlanWidget } from '../../scripts/utils/free-plan.js';
+import { sendFrictionlessEventToAdobeAnaltics } from '../../scripts/instrument.js';
+
+let ccEverywhere;
+let quickActionContainer;
+let uploadContainer;
+
+const JPG = 'jpg';
+const JPEG = 'jpeg';
+const PNG = 'png';
+const WEBP = 'webp';
+export const getBaseImgCfg = (...types) => ({
+  group: 'image',
+  max_size: 40 * 1024 * 1024,
+  accept: types.map((type) => `.${type}`).join(', '),
+  input_check: (input) => types.map((type) => `image/${type}`).includes(input),
+});
+export const getBaseVideoCfg = (...types) => ({
+  group: 'video',
+  max_size: 1024 * 1024 * 1024,
+  accept: types.map((type) => `.${type}`).join(', '),
+  input_check: (input) => types.map((type) => `video/${type}`).includes(input),
+});
+const QA_CONFIGS = {
+  'convert-to-jpg': {
+    ...getBaseImgCfg(PNG, WEBP),
+  },
+  'convert-to-png': {
+    ...getBaseImgCfg(JPG, JPEG, WEBP),
+  },
+  'convert-to-svg': {
+    ...getBaseImgCfg(JPG, JPEG, PNG),
+  },
+  'crop-image': {
+    ...getBaseImgCfg(JPG, JPEG, PNG),
+  },
+  'resize-image': {
+    ...getBaseImgCfg(JPG, JPEG, PNG, WEBP),
+  },
+  'remove-background': {
+    ...getBaseImgCfg(JPG, JPEG, PNG),
+  },
+  'generate-qr-code': {
+    ...getBaseImgCfg(JPG, JPEG, PNG),
+    input_check: () => true,
+  },
+};
+
+function fade(element, action) {
+  if (action === 'in') {
+    element.classList.remove('hidden');
+    setTimeout(() => {
+      element.classList.remove('transparent');
+    }, 10);
+  } else if (action === 'out') {
+    element.classList.add('transparent');
+    setTimeout(() => {
+      element.classList.add('hidden');
+    }, 200);
+  }
+}
+
+function selectElementByTagPrefix(p) {
+  const allEls = document.body.querySelectorAll(':scope > *');
+  return Array.from(allEls).find((e) => e.tagName.toLowerCase().startsWith(p.toLowerCase()));
+}
+
+export function runQuickAction(quickAction, data, block) {
+  // TODO: need the button labels from the placeholders sheet if the SDK default doens't work.
+  const exportConfig = [
+    {
+      id: 'download-button',
+      // label: 'Download',
+      action: {
+        target: 'download',
+      },
+      style: {
+        uiType: 'button',
+      },
+      buttonStyle: {
+        variant: 'secondary',
+        treatment: 'fill',
+        size: 'xl',
+      },
+    },
+    {
+      id: 'edit-in-express',
+      // label: 'Edit in Adobe Express for free',
+      action: {
+        target: 'express',
+      },
+      style: {
+        uiType: 'button',
+      },
+      buttonStyle: {
+        variant: 'primary',
+        treatment: 'fill',
+        size: 'xl',
+      },
+    },
+  ];
+
+  const id = `${quickAction}-container`;
+  quickActionContainer = createTag('div', { id, class: 'quick-action-container' });
+  block.append(quickActionContainer);
+  const divs = block.querySelectorAll(':scope > div');
+  if (divs[1]) [, uploadContainer] = divs;
+  fade(uploadContainer, 'out');
+
+  const contConfig = {
+    mode: 'inline',
+    parentElementId: `${quickAction}-container`,
+    backgroundColor: 'transparent',
+    hideCloseButton: true,
+  };
+
+  const docConfig = {
+    asset: {
+      data,
+      dataType: 'base64',
+      type: 'image',
+    },
+  };
+  const appConfig = {
+    metaData: { isFrictionlessQa: 'true' },
+    receiveQuickActionErrors: false,
+    callbacks: {
+      onIntentChange: () => {
+        quickActionContainer?.remove();
+        fade(uploadContainer, 'in');
+        document.body.classList.add('editor-modal-loaded');
+        window.history.pushState({ hideFrictionlessQa: true }, '', '');
+        return {
+          containerConfig: {
+            mode: 'modal',
+            zIndex: 999,
+          },
+        };
+      },
+      onCancel: () => {
+        window.history.back();
+      },
+    },
+  };
+
+  if (!ccEverywhere) return;
+  switch (quickAction) {
+    case 'convert-to-jpg':
+      ccEverywhere.quickAction.convertToJPEG(docConfig, appConfig, exportConfig, contConfig);
+      break;
+    case 'convert-to-png':
+      ccEverywhere.quickAction.convertToPNG(docConfig, appConfig, exportConfig, contConfig);
+      break;
+    case 'convert-to-svg':
+      exportConfig.pop();
+      ccEverywhere.quickAction.convertToSVG(docConfig, appConfig, exportConfig, contConfig);
+      break;
+    case 'crop-image':
+      ccEverywhere.quickAction.cropImage(docConfig, appConfig, exportConfig, contConfig);
+      break;
+    case 'resize-image':
+      ccEverywhere.quickAction.resizeImage(docConfig, appConfig, exportConfig, contConfig);
+      break;
+    case 'remove-background':
+      ccEverywhere.quickAction.removeBackground(docConfig, appConfig, exportConfig, contConfig);
+      break;
+    case 'generate-qr-code':
+      ccEverywhere.quickAction.generateQRCode({}, appConfig, exportConfig, contConfig);
+      break;
+    default: break;
+  }
+}
+
+async function startSDK(data = '', quickAction, block) {
+  const urlParams = new URLSearchParams(window.location.search);
+  const urlOverride = urlParams.get('sdk-override');
+  let valid = false;
+  if (urlOverride) {
+    try {
+      if (new URL(urlOverride).host === 'dev.cc-embed.adobe.com') valid = true;
+    } catch (e) {
+      window.lana.log('Invalid SDK URL');
+    }
+  }
+  const CDN_URL = valid ? urlOverride : 'https://cc-embed.adobe.com/sdk/1p/v4/CCEverywhere.js';
+  const clientId = 'AdobeExpressWeb';
+
+  await loadScript(CDN_URL);
+  if (!window.CCEverywhere) {
+    return;
+  }
+
+  if (!ccEverywhere) {
+    let { ietf } = getConfig().locale;
+    const country = urlParams.get('country');
+    if (country) ietf = getConfig().locales[country]?.ietf;
+    if (ietf === 'zh-Hant-TW') ietf = 'tw-TW';
+    else if (ietf === 'zh-Hans-CN') ietf = 'cn-CN';
+
+    const ccEverywhereConfig = {
+      hostInfo: {
+        clientId,
+        appName: 'express',
+      },
+      configParams: {
+        locale: ietf?.replace('-', '_'),
+        env: urlParams.get('hzenv') === 'stage' ? 'stage' : 'prod',
+      },
+      authOption: () => ({
+        mode: 'delayed',
+      }),
+    };
+
+    ccEverywhere = await window.CCEverywhere.initialize(...Object.values(ccEverywhereConfig));
+  }
+
+  runQuickAction(quickAction, data, block);
+}
+
+let timeoutId = null;
+function showErrorToast(block, msg) {
+  let toast = block.querySelector('.error-toast');
+  const hideToast = () => toast.classList.add('hide');
+  if (!toast) {
+    toast = createTag('div', { class: 'error-toast hide' });
+    toast.prepend(getIconElement('error'));
+    const close = createTag('button', {}, getIconElement('close-white'));
+    close.addEventListener('click', hideToast);
+    toast.append(close);
+    block.append(toast);
+  }
+  toast.textContent = msg;
+  toast.classList.remove('hide');
+  clearTimeout(timeoutId);
+  timeoutId = setTimeout(hideToast, 6000);
+}
+
+async function startSDKWithUnconvertedFile(file, quickAction, block) {
+  if (!file) return;
+  const maxSize = QA_CONFIGS[quickAction].max_size ?? 40 * 1024 * 1024;
+  if (QA_CONFIGS[quickAction].input_check(file.type) && file.size <= maxSize) {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      window.history.pushState({ hideFrictionlessQa: true }, '', '');
+      startSDK(reader.result, quickAction, block);
+    };
+
+    // Read the file as a data URL (Base64)
+    reader.readAsDataURL(file);
+    return;
+  }
+  const placeholders = await fetchPlaceholders();
+  let msg;
+  if (!QA_CONFIGS[quickAction].input_check(file.type)) {
+    msg = placeholders['file-type-not-supported'] ?? 'File type not supported.';
+  } else {
+    msg = placeholders['file-size-not-supported'] ?? 'File size not supported.';
+  }
+  showErrorToast(block, msg);
+}
+
+export default async function decorate(block) {
+  const rows = Array.from(block.children);
+  rows[1].classList.add('container');
+  const quickActionRow = rows.filter((r) => r.children && r.children[0].textContent.toLowerCase().trim() === 'quick-action');
+  const quickAction = quickActionRow?.[0].children[1]?.textContent;
+  if (!quickAction) {
+    throw new Error('Invalid Quick Action Type.');
+  }
+  quickActionRow[0].remove();
+
+  const actionAndAnimationRow = rows[1].children;
+  const animationContainer = actionAndAnimationRow[0];
+  const animation = animationContainer.querySelector('a');
+  const dropzone = actionAndAnimationRow[1];
+  const dropzoneBackground = createTag('div', { class: 'dropzone-bg' });
+  const cta = dropzone.querySelector('a.button');
+  const gtcText = dropzone.querySelector('p:last-child');
+  const actionColumn = createTag('div');
+  const dropzoneContainer = createTag('div', { class: 'dropzone-container' });
+
+  if (animation && animation.href.includes('.mp4')) {
+    transformLinkToAnimation(animation);
+    addAnimationToggle(animationContainer);
+  }
+  if (cta) cta.classList.add('xlarge');
+  dropzone.classList.add('dropzone');
+
+  dropzone.prepend(dropzoneBackground);
+  dropzone.before(actionColumn);
+  dropzoneContainer.append(dropzone);
+  actionColumn.append(dropzoneContainer, gtcText);
+  const inputElement = createTag('input', { type: 'file', accept: QA_CONFIGS[quickAction].accept });
+  inputElement.onchange = () => {
+    const file = inputElement.files[0];
+    startSDKWithUnconvertedFile(file, quickAction, block);
+  };
+  block.append(inputElement);
+
+  dropzoneContainer.addEventListener('click', (e) => {
+    e.preventDefault();
+    if (quickAction === 'generate-qr-code') {
+      startSDK('', quickAction, block);
+    } else {
+      inputElement.click();
+    }
+    document.body.dataset.suppressfloatingcta = 'true';
+  });
+
+  function preventDefaults(e) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  function highlight() {
+    dropzoneContainer.classList.add('highlight');
+  }
+
+  function unhighlight() {
+    dropzoneContainer.classList.remove('highlight');
+  }
+
+  ['dragenter', 'dragover'].forEach((eventName) => {
+    dropzoneContainer.addEventListener(eventName, highlight, false);
+  });
+
+  ['dragenter', 'dragover', 'dragleave', 'drop'].forEach((eventName) => {
+    dropzoneContainer.addEventListener(eventName, preventDefaults, false);
+  });
+
+  ['dragleave', 'drop'].forEach((eventName) => {
+    dropzoneContainer.addEventListener(eventName, unhighlight, false);
+  });
+
+  dropzoneContainer.addEventListener('drop', async (e) => {
+    const dt = e.dataTransfer;
+    const { files } = dt;
+
+    await Promise.all(
+      [...files].map((file) => startSDKWithUnconvertedFile(file, quickAction, block)),
+    );
+    document.body.dataset.suppressfloatingcta = 'true';
+  }, false);
+
+  const freePlanTags = await buildFreePlanWidget({ typeKey: 'branded', checkmarks: true });
+  dropzone.append(freePlanTags);
+
+  window.addEventListener('popstate', (e) => {
+    const editorModal = selectElementByTagPrefix('cc-everywhere-container-');
+    const correctState = e.state?.hideFrictionlessQa;
+    const embedElsFound = quickActionContainer || editorModal;
+    window.history.pushState({ hideFrictionlessQa: true }, '', '');
+    if (correctState || embedElsFound) {
+      quickActionContainer?.remove();
+      editorModal?.remove();
+      document.body.classList.remove('editor-modal-loaded');
+      inputElement.value = '';
+      fade(uploadContainer, 'in');
+      document.body.dataset.suppressfloatingcta = 'false';
+    }
+  }, { passive: true });
+
+  block.dataset.frictionlesstype = quickAction;
+  block.dataset.frictionlessgroup = QA_CONFIGS[quickAction].group ?? 'image';
+
+  if (['on', 'yes'].includes(getMetadata('marquee-inject-logo')?.toLowerCase())) {
+    const logo = getIconElement('adobe-express-logo');
+    logo.classList.add('express-logo');
+    block.prepend(logo);
+  }
+
+  sendFrictionlessEventToAdobeAnaltics(block);
+}

--- a/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
+++ b/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
@@ -200,7 +200,7 @@ async function startSDK(data = '', quickAction, block) {
   if (!window.CCEverywhere) {
     return;
   }
-
+  document.body.dataset.suppressfloatingcta = 'true';
   if (!ccEverywhere) {
     let { ietf } = getConfig().locale;
     const country = urlParams.get('country');
@@ -321,7 +321,6 @@ export default async function decorate(block) {
     } else {
       inputElement.click();
     }
-    document.body.dataset.suppressfloatingcta = 'true';
   });
 
   window.addEventListener('popstate', (e) => {

--- a/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
+++ b/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
@@ -288,7 +288,10 @@ export default async function decorate(block) {
 
   rows[0].classList.add('headline');
   rows[1].classList.add('dropzone-container');
-  const [animationContainer, dropzone] = rows[1].children;
+  const dropzone = createTag('button', { class: 'dropzone hide' });
+  const [animationContainer, dropzoneContent] = rows[1].children;
+  while (dropzoneContent.firstChild) dropzone.append(dropzoneContent.firstChild);
+  dropzoneContent.replaceWith(dropzone);
   animationContainer.classList.add('animation-container');
   const animation = animationContainer.querySelector('a');
 
@@ -300,7 +303,6 @@ export default async function decorate(block) {
     });
     // click to skip animation
   }
-  dropzone.classList.add('dropzone', 'hide');
   const dropzoneText = createTag('div', { class: 'text' });
   while (dropzone.firstChild) {
     dropzoneText.append(dropzone.firstChild);
@@ -341,9 +343,9 @@ export default async function decorate(block) {
   block.dataset.frictionlesstype = quickAction;
   block.dataset.frictionlessgroup = QA_CONFIGS[quickAction].group ?? 'image';
 
-  // const logo = getIconElement('adobe-express-logo');
-  // logo.classList.add('express-logo');
-  // block.prepend(logo);
+  const logo = getIconElement('adobe-express-logo');
+  logo.classList.add('express-logo');
+  block.prepend(logo);
   import('../../scripts/instrument.js').then(({ sendFrictionlessEventToAdobeAnaltics }) => {
     sendFrictionlessEventToAdobeAnaltics(block);
   });

--- a/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
+++ b/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
@@ -77,7 +77,7 @@ export function runQuickAction(quickAction, data, block) {
   const exportConfig = [
     {
       id: 'download-button',
-      // label: 'Download',
+      label: 'Download to Phone',
       action: {
         target: 'download',
       },
@@ -92,7 +92,7 @@ export function runQuickAction(quickAction, data, block) {
     },
     {
       id: 'edit-in-express',
-      // label: 'Edit in Adobe Express for free',
+      label: 'Edit in Adobe Express for free',
       action: {
         target: 'express',
       },

--- a/express/blocks/shared/floating-cta.css
+++ b/express/blocks/shared/floating-cta.css
@@ -168,7 +168,8 @@ body[data-device="mobile"] main .floating-button-wrapper[data-audience="mobile"]
 body[data-device="desktop"] main .floating-button-wrapper[data-audience="desktop"][data-section-status="loaded"] {
     display: flex;
 }
-body[data-suppressfloatingcta="true"] main .floating-button-wrapper[data-audience="desktop"][data-section-status="loaded"] {
+body[data-suppressfloatingcta="true"] main .floating-button-wrapper[data-audience="desktop"][data-section-status="loaded"],
+body[data-suppressfloatingcta="true"] main .floating-button-wrapper[data-audience="mobile"][data-section-status="loaded"] {
     display: none;
 }
 

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -662,7 +662,7 @@ export async function decorateBlock(block) {
     // split and add options with a dash
     // (fullscreen-center -> fullscreen-center + fullscreen + center)
     const extra = [];
-    const skipList = ['same-fcta', 'meta-powered', 'mfqa-fallback'];
+    const skipList = ['same-fcta', 'meta-powered'];
     block.classList.forEach((className, index) => {
       if (index === 0 || skipList.includes(className)) return; // block name or skip, no split
       const split = className.split('-');

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -662,7 +662,7 @@ export async function decorateBlock(block) {
     // split and add options with a dash
     // (fullscreen-center -> fullscreen-center + fullscreen + center)
     const extra = [];
-    const skipList = ['same-fcta', 'meta-powered'];
+    const skipList = ['same-fcta', 'meta-powered', 'mfqa-fallback'];
     block.classList.forEach((className, index) => {
       if (index === 0 || skipList.includes(className)) return; // block name or skip, no split
       const split = className.split('-');


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Implemented a frictionless-quick-action-mobile block that will temporarily be used to test Remove Background for Android with 4GB+ Memory.
- Eventually as the product supports all devices, this will be merged into our current frictionless-quick-action block
- Unit tests and documentations are skipped as this is a test

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-162630

**Steps to test the before vs. after and expectations:**
- On an iOS phone, it should show the fallback columns block
- On a real Android phone with 4GB+ memory (BrowserStack is recommended, but since VPN will block the SDK, you need to enable Force local network), it should show the mobile FQA experience
- On the mobile experience, the video should play and once finished, turn into the upload button

**Pages to check:**
- https://mfqa--express--adobecom.hlx.live/express/experiments/mobile-fqa/remove-background1?martech=off&hzenv=stage&base=https://103279.quick-actions-prenv.projectx.corp.adobe.com
