### PR TITLE
Columns (Highlight) block fixes

### DIFF
--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -375,6 +375,14 @@ main .columns.highlight > div {
   margin: 20px 0;
 }
 
+main .columns.highlight.dark {
+  padding-bottom: 20px;
+}
+
+main .columns.highlight.dark .columns-video:last-of-type {
+  margin-bottom: 0;
+}
+
 main .columns.highlight > div:first-child {
   margin-top: 50px;
 }

--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -950,6 +950,10 @@ main .columns.fullsize.top .column .columns-iconlist .columns-iconlist-descripti
   main .columns .trial-cta {
     float: left;
   }
+
+  main .columns .columns-video {
+    min-height: 356px;
+  }
 }
 
 @media (min-width: 1200px) {

--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -376,7 +376,7 @@ main .columns.highlight > div {
 }
 
 main .columns.highlight.dark {
-  padding-bottom: 20px;
+  padding-bottom: 100px;
 }
 
 main .columns.highlight.dark .columns-video:last-of-type {


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Adds space between last columns video element and the bottom of the container
- Adds min-height of 356px to each columns video element

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-162632
**Before**
https://www.stage.adobe.com/express/entitled
min-height
<img width="1359" alt="min-height-before" src="https://github.com/user-attachments/assets/6c26cb2e-2ff2-45f3-a8cb-e9a477145598">
bottom-padding
<img width="1368" alt="bottom-padding-before" src="https://github.com/user-attachments/assets/b0aef275-de19-4d43-a4fd-693bc8930012">
**After**
min-height
<img width="1400" alt="min-height" src="https://github.com/user-attachments/assets/292786fa-c569-4be6-a793-4a2723050df5">
bottom-padding
<img width="1504" alt="bottom-padding" src="https://github.com/user-attachments/assets/0ee2efa1-2e81-4386-8667-921a08444fc4">

**Pages to check for regression and performance:**
- https://columns-highlight-block-fixes--express--adobecom.hlx.page/express/entitled
