### PR TITLE
Add variant to center header text on quick action carousel

### DIFF
--- a/express/blocks/cta-carousel/cta-carousel.css
+++ b/express/blocks/cta-carousel/cta-carousel.css
@@ -347,4 +347,10 @@
         flex-direction: row;
         align-items: flex-end;
     }
+    .cta-carousel.center-heading .cta-carousel-heading-section {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+    }
 }

--- a/express/blocks/cta-carousel/cta-carousel.css
+++ b/express/blocks/cta-carousel/cta-carousel.css
@@ -353,4 +353,8 @@
         justify-content: center;
         align-items: center;
     }
+    .cta-carousel.center-heading .cta-carousel-heading-section .cta-carousel-link {
+        align-self: flex-end;
+        margin-left: auto;
+    }
 }


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Issue/Feature 1

**Resolves:** [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-162393)

**Before**
https://www.stage.adobe.com/express/entitled
<img width="1069" alt="before" src="https://github.com/user-attachments/assets/f246d05a-a7d9-4aca-9c4e-049f741fdbf0">

**After**
<img width="982" alt="after" src="https://github.com/user-attachments/assets/cf93ff74-eb5c-4910-8b21-aa815cbbf3c6">

**Pages to check for regression and performance:**
- https://quick-action-carousel-center-header--express--adobecom.hlx.page/drafts/jsandlan/entitled
