### PR TITLE
[Mobile-Frictionless-QA] Fade Extra Content

### DIFF
--- a/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
+++ b/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
@@ -187,7 +187,7 @@
 
 .frictionless-quick-action-mobile .error-toast {
     position: fixed;
-    bottom: 100px;
+    bottom: 50%;
     left: 50%;
     transform: translateX(-50%);
     opacity: 1;

--- a/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
+++ b/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
@@ -8,7 +8,6 @@
     max-width: none;
     text-align: left;
 }
-/* TODO: font-family seems to be inconsistent? */
 
 .frictionless-quick-action-mobile .headline {
     padding-bottom: 12px;
@@ -32,8 +31,6 @@
 }
 
 .frictionless-quick-action-mobile .quick-action-container {
-    padding: 40px 0;
-    min-height: 697px;
     max-width: 1440px;
     width: 100%;
     margin: auto;

--- a/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
+++ b/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
@@ -116,7 +116,9 @@ export function runQuickAction(quickAction, data, block) {
   block.append(quickActionContainer);
   const divs = block.querySelectorAll(':scope > div');
   if (divs[1]) [, uploadContainer] = divs;
+  const extraContainer = block.querySelector('.extra-container');
   fade(uploadContainer, 'out');
+  fade(extraContainer, 'out');
 
   const contConfig = {
     mode: 'inline',
@@ -139,6 +141,7 @@ export function runQuickAction(quickAction, data, block) {
       onIntentChange: () => {
         quickActionContainer?.remove();
         fade(uploadContainer, 'in');
+        fade(extraContainer, 'in');
         document.body.classList.add('editor-modal-loaded');
         window.history.pushState({ hideFrictionlessQa: true }, '', '');
         return {
@@ -277,13 +280,13 @@ async function injectFreePlan(container) {
   return container;
 }
 
-function decorateExtra(extra) {
-  const wrapper = extra.querySelector('div');
+function decorateExtra(extraContainer) {
+  const wrapper = extraContainer.querySelector('div');
   while (wrapper?.firstChild) {
-    extra.append(wrapper.firstChild);
+    extraContainer.append(wrapper.firstChild);
   }
   wrapper.remove();
-  const legalText = extra.querySelector('p:last-of-type');
+  const legalText = extraContainer.querySelector('p:last-of-type');
   legalText.classList.add('legal');
   const freePlanContainer = createTag('div', { class: 'free-plan-container' });
   injectFreePlan(freePlanContainer);
@@ -306,10 +309,12 @@ export default function decorate(block) {
     throw new Error('Invalid Quick Action Type.');
   }
 
-  rows[0].classList.add('headline');
-  rows[1].classList.add('dropzone-container');
-  rows[2].classList.add('extra-container');
-  decorateExtra(rows[2]);
+  const [headline, dropzoneContainer, extraContainer] = rows;
+  headline.classList.add('headline');
+  dropzoneContainer.classList.add('dropzone-container');
+  extraContainer.classList.add('extra-container');
+  decorateExtra(extraContainer);
+
   const dropzone = createTag('button', { class: 'dropzone hide' });
   const [animationContainer, dropzoneContent] = rows[1].children;
   while (dropzoneContent.firstChild) dropzone.append(dropzoneContent.firstChild);
@@ -358,6 +363,7 @@ export default function decorate(block) {
       document.body.classList.remove('editor-modal-loaded');
       inputElement.value = '';
       fade(uploadContainer, 'in');
+      fade(extraContainer, 'in');
       document.body.dataset.suppressfloatingcta = 'false';
     }
   }, { passive: true });


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Hide some of the extra unneeded content after an image has been uploaded

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-162630

**Steps to test the before vs. after and expectations:**
- On an iOS phone, it should show the fallback columns block
- On a real Android phone with 4GB+ memory (BrowserStack is recommended, but since VPN will block the SDK, you need to enable Force local network), it should show the mobile FQA experience
- On the mobile experience, the video should play and once finished, turn into the upload button
- Once a picture has been uploaded, it should hide our content and load the SDK experience
- There is also a commit for enhancing mobile-fork-button to allow it to have a new fallback strategy called "replace". And you should be able to see that the 2 floating mobile-fork-button are different based on devices.
![SC 2024-11-26 at 1 20 02 PM](https://github.com/user-attachments/assets/44b24f09-0b20-4da0-a5cb-301448f2a579)

**Pages to check for regression and performance:**
- https://mfqa-hide-extra--express--adobecom.hlx.live/express/experiments/mobile-fqa/remove-background1?martech=off&hzenv=stage&base=https://103279.quick-actions-prenv.projectx.corp.adobe.com 
