### PR TITLE
ensure dark variant enforces padding left, right and bottom

### DIFF
--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -6,7 +6,7 @@ main .columns-container,
 main .columns-dark-container,
 main .columns-center-container,
 main .columns-top-container,
-main .columns-highlight-container {
+main .columns-highlight-container, .columns-highlight-dark-container {
   padding-left: 15px;
   padding-right: 15px;
   padding-bottom: 40px;
@@ -379,10 +379,6 @@ main .columns.highlight > div {
   border-radius: 20px;
   overflow: hidden;
   margin: 20px 0;
-}
-
-main .columns.highlight.dark {
-  padding-bottom: 100px;
 }
 
 main .columns.highlight.dark .columns-video:last-of-type {


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- ensure dark variant enforces padding left, right and bottom

**Resolves:** [MWPW-162632](https://jira.corp.adobe.com/browse/MWPW-162632)

**Steps to test the before vs. after and expectations:**

**Before**
https://www.stage.adobe.com/express/entitled
<img width="542" alt="before - padding" src="https://github.com/user-attachments/assets/71fd4ef9-3b2e-48c9-b8a2-81454bd403a6">
<img width="589" alt="before - margin" src="https://github.com/user-attachments/assets/8590e6d4-b048-4f90-875c-cb10a0d7bea7">

**After**
https://entitled-fix-columns-rule--express--adobecom.hlx.page/drafts/jsandlan/entitled
<img width="854" alt="after - padding" src="https://github.com/user-attachments/assets/ac06ca75-2898-4126-a8fb-b9dac9f029d2">
<img width="776" alt="after - margin" src="https://github.com/user-attachments/assets/a39f8db6-4536-489a-a6b0-c051a36b6ef2">

**Pages to check for regression and performance:**
- https://entitled-fix-columns-rule--express--adobecom.hlx.page/drafts/jsandlan/entitled
