### PR TITLE
Add variant to center header text on quick action carousel on mobile, ipad and desktop

### DIFF
--- a/express/blocks/cta-carousel/cta-carousel.css
+++ b/express/blocks/cta-carousel/cta-carousel.css
@@ -172,6 +172,17 @@
     transition: background-color .2s;
 }
 
+.cta-carousel.center-heading .cta-carousel-heading-section {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+.cta-carousel.center-heading .cta-carousel-heading-section .cta-carousel-link {
+    align-self: flex-end;
+    margin-left: auto;
+}
+
 .cta-carousel.quick-action .card.gen-ai-action .card-sleeve .gen-ai-input-form .gen-ai-submit {
     left: 56px;
     bottom: 24px;
@@ -346,15 +357,5 @@
     .cta-carousel .cta-carousel-heading-section {
         flex-direction: row;
         align-items: flex-end;
-    }
-    .cta-carousel.center-heading .cta-carousel-heading-section {
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-    }
-    .cta-carousel.center-heading .cta-carousel-heading-section .cta-carousel-link {
-        align-self: flex-end;
-        margin-left: auto;
     }
 }

--- a/express/blocks/cta-carousel/cta-carousel.css
+++ b/express/blocks/cta-carousel/cta-carousel.css
@@ -178,6 +178,11 @@
     justify-content: center;
     align-items: center;
 }
+
+.cta-carousel.center-heading .cta-carousel-heading-section h2 {
+    text-align: center;
+}
+
 .cta-carousel.center-heading .cta-carousel-heading-section .cta-carousel-link {
     align-self: flex-end;
     margin-left: auto;


### PR DESCRIPTION
Center Header Text On Quick Action Carousel on mobile, iPad, and desktop

**Resolves:**: https://jira.corp.adobe.com/browse/MWPW-162393

**Before**
https://www.stage.adobe.com/express/entitled
<img width="1069" alt="before" src="https://github.com/user-attachments/assets/f246d05a-a7d9-4aca-9c4e-049f741fdbf0">

**After**
<img width="982" alt="after" src="https://github.com/user-attachments/assets/cf93ff74-eb5c-4910-8b21-aa815cbbf3c6">

**Pages to check for regression and performance:**
- https://qa-mobile-header-express--adobecom.hlx.page/drafts/jsandlan/entitled
