### PR TITLE
[Grid-Marquee] Attach the first anchor to the video

### DIFF
--- a/express/blocks/grid-marquee/grid-marquee.css
+++ b/express/blocks/grid-marquee/grid-marquee.css
@@ -154,6 +154,8 @@
   display: flex;
   justify-content: center;
   padding: 16px;
+  cursor: pointer;
+  background: none;
 }
 
 .grid-marquee .drawer video {
@@ -355,7 +357,7 @@
   }
 
   .grid-marquee .drawer .video-container {
-    border-top: 0;
+    border: 0;
     padding: 0 16px 12px 16px;
   }
 

--- a/express/blocks/grid-marquee/grid-marquee.js
+++ b/express/blocks/grid-marquee/grid-marquee.js
@@ -43,15 +43,6 @@ async function decorateDrawer(videoSrc, poster, titleText, panels, panelsFrag, d
   });
   titleRow.append(createTag('strong', { class: 'drawer-title' }, titleText), closeButton);
   await yieldToMain();
-  const video = createTag('video', {
-    playsinline: '',
-    muted: '',
-    loop: '',
-    preload: 'metadata',
-    title: titleText,
-    poster,
-  }, `<source src="${videoSrc}" type="video/mp4">`);
-  const videoWrapper = createTag('div', { class: 'video-container' }, video);
 
   const icons = panelsFrag.querySelectorAll('.icon');
   const anchors = [...panelsFrag.querySelectorAll('a')];
@@ -62,8 +53,22 @@ async function decorateDrawer(videoSrc, poster, titleText, panels, panelsFrag, d
     if (match?.[1]) {
       icon.append(getIconElement(match[1]));
     }
-    anchor?.prepend(icon);
+    anchor.prepend(icon);
   });
+
+  const video = createTag('video', {
+    playsinline: '',
+    muted: '',
+    loop: '',
+    preload: 'metadata',
+    title: titleText,
+    poster,
+  }, `<source src="${videoSrc}" type="video/mp4">`);
+  const videoWrapper = createTag('button', { class: 'video-container' }, video);
+  // link video to first anchor
+  videoWrapper.addEventListener('click', () => anchors[0]?.click());
+  videoWrapper.setAttribute('title', anchors[0]?.title);
+
   content.append(titleRow, videoWrapper, panelsFrag);
   drawer.append(content);
   if (panels.length <= 1) {


### PR DESCRIPTION
**Adds following features:**
- Shows the cursor as pointer when the videos in grid-marquee are hovered. When clicked, it should link to the first anchor links below.

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-163054 see comments

**Steps to test the before vs. after and expectations:**
- Hover over the pods and click the video and check if it's linked as the first anchor

**Pages to check for regression and performance:**
- https://grid-marquee-card-click--express--adobecom.hlx.live/express/?martech=off&gnav=off
