### PR TITLE
[Mobile-FQA-Test] Allow mobile-fork to trigger mobile-fqa

### DIFF
--- a/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
+++ b/express/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
@@ -315,7 +315,7 @@ export default function decorate(block) {
   extraContainer.classList.add('extra-container');
   decorateExtra(extraContainer);
 
-  const dropzone = createTag('button', { class: 'dropzone hide' });
+  const dropzone = createTag('button', { class: 'dropzone hide', id: 'mobile-fqa-upload' });
   const [animationContainer, dropzoneContent] = rows[1].children;
   while (dropzoneContent.firstChild) dropzone.append(dropzoneContent.firstChild);
   dropzoneContent.replaceWith(dropzone);
@@ -345,6 +345,8 @@ export default function decorate(block) {
 
   dropzone.addEventListener('click', (e) => {
     e.preventDefault();
+    dropzone.classList.remove('hide');
+    animationContainer.classList.add('hide');
     if (quickAction === 'generate-qr-code') {
       startSDK('', quickAction, block);
     } else {

--- a/express/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.css
+++ b/express/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.css
@@ -1,0 +1,78 @@
+main  .floating-button-wrapper.mobile-fork-button-frictionless, main .mobile-fork-button-frictionless {
+    z-index: 10;
+}
+
+main .mobile-gating-text {
+    height: fit-content;
+    margin: auto;
+    text-align: left;
+    flex-grow: 1;
+    font-weight: 400;
+    font-size: var(--body-font-size-m);
+}
+
+main .mobile-gating-text, main .mobile-fork-button-frictionless .floating-button .mobile-gating-row .icon{
+    width: 22px;
+    height: 22px;
+    margin: auto;
+}
+
+main .mobile-fork-button-frictionless  .mobile-gating-header-row .mobile-gating-exit {
+    border-radius: 24px;
+    margin-left: auto;
+    width: 24px;
+    height: 24px;
+    font-size: var(--body-font-size-xs);
+    background: var(--Palette-sx-gray-100, var(--color-gray-200));
+}
+
+main  .mobile-fork-button-frictionless .floating-button.block {
+    background-color: var(--color-white);
+    border-radius: 28px;
+    box-shadow: 0px 0px 12px 0px #00000029;
+    padding: 16px;
+    width: calc(100% - 16px);
+    margin: 5px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+main .mobile-gating-row {
+    display: flex;
+    gap: 10px;
+    height: 40px;
+}
+
+main .mobile-gating-header {
+    font-size: var(--type-heading-xxs-lh);
+    font-weight: 700; 
+    text-align: center;
+    margin-bottom: 8px;
+}
+
+main .mobile-fork-button-frictionless .floating-button a.button:any-link {
+    border-radius: 20px;
+    font-size: var(--body-font-size-m);
+    min-width: 136px;
+    width: 40%;
+    color: var(--color-white);
+    background-color: var(--color-info-accent);
+    border-color: var(--color-info-accent);
+}   
+
+main .mobile-fork-button-frictionless .floating-button a.button:any-link.accent {
+    color: var(--color-var(--color-white));
+    background-color: var(--color-info-accent);
+    border-color: var(--color-info-accent);
+}   
+
+main .mobile-fork-button-frictionless .floating-button a.button:any-link.outline {
+    background-color: var(--color-white);
+    border: 2px solid var(--Border-Extra-subdued-default, var(--color-gray-200));
+    color: var(--color-black);
+}
+
+main .mobile-fork-button-frictionless.floating-button--hidden .floating-button.block {
+    margin-bottom: -10px
+}

--- a/express/blocks/mobile-fork-button/mobile-fork-button.js
+++ b/express/blocks/mobile-fork-button/mobile-fork-button.js
@@ -88,6 +88,14 @@ function collectFloatingButtonData(fallback) {
         href, text, icon, iconText,
       } = completeSet;
       const aTag = createTag('a', { title: text, href });
+      if (href === '#mobile-fqa-upload') {
+        // mobile-fork-button often pairs with mobile-fqa
+        // this is a temporary solution before we find a better way for cross-block interactions
+        aTag.addEventListener('click', (e) => {
+          e.preventDefault();
+          document.querySelector(href).click();
+        });
+      }
       aTag.textContent = text;
       data.tools.push({
         icon,

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1925,7 +1925,7 @@ async function buildAutoBlocks(main) {
   }
 
   async function loadFloatingCTA(BlockMediator) {
-    const validButtonVersion = ['floating-button', 'multifunction-button', 'mobile-fork-button'];
+    const validButtonVersion = ['floating-button', 'multifunction-button', 'mobile-fork-button', 'mobile-fork-button-frictionless'];
     const device = document.body.dataset?.device;
     const blockName = getMetadata(`${device}-floating-cta`);
     if (blockName && validButtonVersion.includes(blockName) && lastDiv) {


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Allow mobile-fork-button to trigger clicks in frictionless-quick-action-mobile block.

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-162630

**Steps to test the before vs. after and expectations:**
- Open the link in Android 4+GB RAM phone
- Tapping the first CTA in the floating mobile-fork-button should open up the file browser.

**Pages to check for regression and performance:**
- https://mfqa-enhance--express--adobecom.hlx.live/express/experiments/frictionless-qa/remove-background-mobile?martech=off
