### PR TITLE
remove config fallback for georouting

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -44,7 +44,6 @@ const config = {
   local: { express: 'stage.projectx.corp.adobe.com', commerce: 'commerce-stg.adobe.com' },
   stage: { express: 'stage.projectx.corp.adobe.com', commerce: 'commerce-stg.adobe.com' },
   prod: { express: 'express.adobe.com', commerce: 'commerce.adobe.com' },
-  geoRouting: 'on',
   fallbackRouting: 'on',
   locales,
   codeRoot: '/express',

--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2428,7 +2428,7 @@ async function loadPostLCP(config) {
   } else {
     loadMartech();
   }
-  const georouting = getMetadata('georouting') || config.geoRouting;
+  const georouting = getMetadata('georouting');
   if (georouting === 'on') {
     const { default: loadGeoRouting } = await import('../features/georoutingv2/georoutingv2.js');
     await loadGeoRouting(config, createTag, getMetadata, loadBlock, loadStyle);


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Prevents fallback config from allowing georouter outside of routes allowed by the Metadata spreadsheet controlled by Ernest.

**Resolves:** [MWPW-162338](https://jira.corp.adobe.com/browse/MWPW-162338)

**Steps to test the before vs. after and expectations:**
**Before**
https://www.adobe.com/de/express/create/poster
<img width="1276" alt="Before" src="https://github.com/user-attachments/assets/f990522c-765d-49af-9781-7f9e24bf7a0e">

**After**
https://remove-georouter-config--express--adobecom.hlx.page/de/express/create/poster
<img width="1575" alt="After" src="https://github.com/user-attachments/assets/265705d1-19b2-4ce1-aae0-e1b1f36a8739">

