### PR TITLE
Shrink Mobile Fork Button Font

### DIFF
--- a/express/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.css
+++ b/express/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.css
@@ -1,6 +1,10 @@
 main  .floating-button-wrapper.mobile-fork-button-frictionless, main .mobile-fork-button-frictionless {
     z-index: 10;
-    --mfb-font-size: 14px
+    --mfb-font-size: 16px;
+}
+
+main .mobile-fork-button-frictionless.long-text {
+    --mfb-font-size: 14px;
 }
 
 main .mobile-gating-text {

--- a/express/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.css
+++ b/express/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.css
@@ -1,5 +1,6 @@
 main  .floating-button-wrapper.mobile-fork-button-frictionless, main .mobile-fork-button-frictionless {
     z-index: 10;
+    --mfb-font-size: 14px
 }
 
 main .mobile-gating-text {
@@ -8,7 +9,7 @@ main .mobile-gating-text {
     text-align: left;
     flex-grow: 1;
     font-weight: 400;
-    font-size: var(--body-font-size-m);
+    font-size: var(--mfb-font-size);
 }
 
 main .mobile-gating-text, main .mobile-fork-button-frictionless .floating-button .mobile-gating-row .icon{
@@ -41,7 +42,7 @@ main  .mobile-fork-button-frictionless .floating-button.block {
 main .mobile-gating-row {
     display: flex;
     gap: 10px;
-    height: 40px;
+    min-height: 40px;
 }
 
 main .mobile-gating-header {
@@ -53,9 +54,10 @@ main .mobile-gating-header {
 
 main .mobile-fork-button-frictionless .floating-button a.button:any-link {
     border-radius: 20px;
-    font-size: var(--body-font-size-m);
-    min-width: 136px;
-    width: 40%;
+    font-size: var(--mfb-font-size);
+    min-width: 150px;
+    margin: auto;
+    width: 50%;
     color: var(--color-white);
     background-color: var(--color-info-accent);
     border-color: var(--color-info-accent);

--- a/express/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.js
+++ b/express/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.js
@@ -8,7 +8,7 @@ import {
   createFloatingButton,
 } from '../shared/floating-cta.js';
 
-const LONG_TEXT_CUTOFF = 70
+const LONG_TEXT_CUTOFF = 70;
 
 const getTextWidth = (text, font) => {
   const canvas = document.createElement('canvas');
@@ -104,8 +104,8 @@ function collectFloatingButtonData(eligible) {
         });
       }
       aTag.textContent = text;
-      if (getTextWidth(text, 16) > LONG_TEXT_CUTOFF){
-        data.longText = true
+      if (getTextWidth(text, 16) > LONG_TEXT_CUTOFF) {
+        data.longText = true;
       }
       data.tools.push({
         icon,

--- a/express/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.js
+++ b/express/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.js
@@ -8,7 +8,15 @@ import {
   createFloatingButton,
 } from '../shared/floating-cta.js';
 
-const LONG_TEXT_CUTOFF = 20
+const LONG_TEXT_CUTOFF = 70
+
+const getTextWidth = (text, font) => {
+  const canvas = document.createElement('canvas');
+  const context = canvas.getContext('2d');
+  context.font = font;
+  const metrics = context.measureText(text);
+  return metrics.width;
+};
 
 function buildAction(entry, buttonType) {
   const wrapper = createTag('div', { class: 'floating-button-inner-row mobile-gating-row' });
@@ -96,7 +104,7 @@ function collectFloatingButtonData(eligible) {
         });
       }
       aTag.textContent = text;
-      if (text.length > LONG_TEXT_CUTOFF){
+      if (getTextWidth(text, 16) > LONG_TEXT_CUTOFF){
         data.longText = true
       }
       data.tools.push({

--- a/express/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.js
+++ b/express/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.js
@@ -8,6 +8,8 @@ import {
   createFloatingButton,
 } from '../shared/floating-cta.js';
 
+const LONG_TEXT_CUTOFF = 20
+
 function buildAction(entry, buttonType) {
   const wrapper = createTag('div', { class: 'floating-button-inner-row mobile-gating-row' });
   const text = createTag('div', { class: 'mobile-gating-text' });
@@ -94,6 +96,9 @@ function collectFloatingButtonData(eligible) {
         });
       }
       aTag.textContent = text;
+      if (text.length > LONG_TEXT_CUTOFF){
+        data.longText = true
+      }
       data.tools.push({
         icon,
         anchor: aTag,
@@ -122,4 +127,5 @@ export default async function decorate(block) {
     const linksPopulated = new CustomEvent('linkspopulated', { detail: blockLinks });
     document.dispatchEvent(linksPopulated);
   }
+  if (data.longText) blockWrapper.classList.add('long-text');
 }

--- a/express/blocks/mobile-fork-button/mobile-fork-button.css
+++ b/express/blocks/mobile-fork-button/mobile-fork-button.css
@@ -61,7 +61,6 @@ main .mobile-fork-button .floating-button a.button:any-link {
     color: var(--color-white);
     background-color: var(--color-info-accent);
     border-color: var(--color-info-accent);
- 
 }   
 
 main .mobile-fork-button .floating-button a.button:any-link.accent {

--- a/express/blocks/mobile-fork-button/mobile-fork-button.css
+++ b/express/blocks/mobile-fork-button/mobile-fork-button.css
@@ -1,5 +1,6 @@
 main  .floating-button-wrapper.mobile-fork-button, main .mobile-fork-button {
     z-index: 10;
+    --mfb-font-size: 14px
 }
 
 main .mobile-gating-text {
@@ -8,7 +9,7 @@ main .mobile-gating-text {
     text-align: left;
     flex-grow: 1;
     font-weight: 400;
-    font-size: 14px;
+    font-size: var(--mfb-font-size);
 }
 
 main .mobile-gating-text, main .mobile-fork-button .floating-button .mobile-gating-row .icon{
@@ -53,7 +54,7 @@ main .mobile-gating-header {
 
 main .mobile-fork-button .floating-button a.button:any-link {
     border-radius: 20px;
-    font-size: 14px;
+    font-size: var(--mfb-font-size);
     min-width: 150px;
     margin: auto;
     width: 50%;

--- a/express/blocks/mobile-fork-button/mobile-fork-button.css
+++ b/express/blocks/mobile-fork-button/mobile-fork-button.css
@@ -1,6 +1,10 @@
 main  .floating-button-wrapper.mobile-fork-button, main .mobile-fork-button {
     z-index: 10;
-    --mfb-font-size: 14px
+    --mfb-font-size: 16px;
+}
+
+main .mobile-fork-button.long-text {
+    --mfb-font-size: 14px;
 }
 
 main .mobile-gating-text {

--- a/express/blocks/mobile-fork-button/mobile-fork-button.css
+++ b/express/blocks/mobile-fork-button/mobile-fork-button.css
@@ -60,6 +60,7 @@ main .mobile-fork-button .floating-button a.button:any-link {
     color: var(--color-white);
     background-color: var(--color-info-accent);
     border-color: var(--color-info-accent);
+    padding: 5px;
 }   
 
 main .mobile-fork-button .floating-button a.button:any-link.accent {

--- a/express/blocks/mobile-fork-button/mobile-fork-button.css
+++ b/express/blocks/mobile-fork-button/mobile-fork-button.css
@@ -8,7 +8,7 @@ main .mobile-gating-text {
     text-align: left;
     flex-grow: 1;
     font-weight: 400;
-    font-size: var(--body-font-size-m);
+    font-size: 14px;
 }
 
 main .mobile-gating-text, main .mobile-fork-button .floating-button .mobile-gating-row .icon{
@@ -53,9 +53,10 @@ main .mobile-gating-header {
 
 main .mobile-fork-button .floating-button a.button:any-link {
     border-radius: 20px;
-    font-size: var(--body-font-size-m);
-    min-width: 136px;
-    width: 40%;
+    font-size: 12px;
+    min-width: 150px;
+    margin: auto;
+    width: 50%;
     color: var(--color-white);
     background-color: var(--color-info-accent);
     border-color: var(--color-info-accent);

--- a/express/blocks/mobile-fork-button/mobile-fork-button.css
+++ b/express/blocks/mobile-fork-button/mobile-fork-button.css
@@ -41,7 +41,7 @@ main  .mobile-fork-button .floating-button.block {
 main .mobile-gating-row {
     display: flex;
     gap: 10px;
-    height: 40px;
+    min-height: 40px;
 }
 
 main .mobile-gating-header {
@@ -53,14 +53,14 @@ main .mobile-gating-header {
 
 main .mobile-fork-button .floating-button a.button:any-link {
     border-radius: 20px;
-    font-size: 12px;
+    font-size: 14px;
     min-width: 150px;
     margin: auto;
     width: 50%;
     color: var(--color-white);
     background-color: var(--color-info-accent);
     border-color: var(--color-info-accent);
-    padding: 5px;
+ 
 }   
 
 main .mobile-fork-button .floating-button a.button:any-link.accent {

--- a/express/blocks/mobile-fork-button/mobile-fork-button.js
+++ b/express/blocks/mobile-fork-button/mobile-fork-button.js
@@ -8,7 +8,7 @@ import {
   createFloatingButton,
 } from '../shared/floating-cta.js';
 
-const LONG_TEXT_CUTOFF = 70
+const LONG_TEXT_CUTOFF = 70;
 
 const getTextWidth = (text, font) => {
   const canvas = document.createElement('canvas');
@@ -54,7 +54,7 @@ function androidDeviceAndRamCheck() {
   return navigator.deviceMemory >= 4 && isAndroid;
 }
 
-function collectFloatingButtonData(block) {
+function collectFloatingButtonData() {
   const metadataMap = Array.from(document.head.querySelectorAll('meta')).reduce((acc, meta) => {
     if (meta?.name && !meta.property) acc[meta.name] = meta.content || '';
     return acc;
@@ -99,8 +99,8 @@ function collectFloatingButtonData(block) {
       } = completeSet;
       const aTag = createTag('a', { title: text, href });
       aTag.textContent = text;
-      if (getTextWidth(text, 16) > LONG_TEXT_CUTOFF){
-        data.longText = true
+      if (getTextWidth(text, 16) > LONG_TEXT_CUTOFF) {
+        data.longText = true;
       }
       data.tools.push({
         icon,

--- a/express/blocks/mobile-fork-button/mobile-fork-button.js
+++ b/express/blocks/mobile-fork-button/mobile-fork-button.js
@@ -8,6 +8,8 @@ import {
   createFloatingButton,
 } from '../shared/floating-cta.js';
 
+const LONG_TEXT_CUTOFF = 10
+
 function buildAction(entry, buttonType) {
   const wrapper = createTag('div', { class: 'floating-button-inner-row mobile-gating-row' });
   const text = createTag('div', { class: 'mobile-gating-text' });
@@ -44,7 +46,7 @@ function androidDeviceAndRamCheck() {
   return navigator.deviceMemory >= 4 && isAndroid;
 }
 
-function collectFloatingButtonData() {
+function collectFloatingButtonData(block) {
   const metadataMap = Array.from(document.head.querySelectorAll('meta')).reduce((acc, meta) => {
     if (meta?.name && !meta.property) acc[meta.name] = meta.content || '';
     return acc;
@@ -89,6 +91,10 @@ function collectFloatingButtonData() {
       } = completeSet;
       const aTag = createTag('a', { title: text, href });
       aTag.textContent = text;
+     
+      if (text.length > LONG_TEXT_CUTOFF){
+        data.longText = true
+      }
       data.tools.push({
         icon,
         anchor: aTag,
@@ -121,4 +127,5 @@ export default async function decorate(block) {
     const linksPopulated = new CustomEvent('linkspopulated', { detail: blockLinks });
     document.dispatchEvent(linksPopulated);
   }
+  if (data.longText) blockWrapper.classList.add('long-text');
 }

--- a/express/blocks/mobile-fork-button/mobile-fork-button.js
+++ b/express/blocks/mobile-fork-button/mobile-fork-button.js
@@ -8,7 +8,15 @@ import {
   createFloatingButton,
 } from '../shared/floating-cta.js';
 
-const LONG_TEXT_CUTOFF = 10
+const LONG_TEXT_CUTOFF = 70
+
+const getTextWidth = (text, font) => {
+  const canvas = document.createElement('canvas');
+  const context = canvas.getContext('2d');
+  context.font = font;
+  const metrics = context.measureText(text);
+  return metrics.width;
+};
 
 function buildAction(entry, buttonType) {
   const wrapper = createTag('div', { class: 'floating-button-inner-row mobile-gating-row' });
@@ -91,8 +99,7 @@ function collectFloatingButtonData(block) {
       } = completeSet;
       const aTag = createTag('a', { title: text, href });
       aTag.textContent = text;
-     
-      if (text.length > LONG_TEXT_CUTOFF){
+      if (getTextWidth(text, 16) > LONG_TEXT_CUTOFF){
         data.longText = true
       }
       data.tools.push({


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Issue/Feature 1
- Adjusts font size and spacing for mobile fork button + mobile fork frictionless buttons for new languages. 
- Implements logic to reduce font size if the computed width of the text exceeds 70px

**Resolves:** [[MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)](https://jira.corp.adobe.com/projects/MWPW/issues/MWPW-164763)

**Steps to test the before vs. after and expectations:**
- Steps for feature 1
- Visit pages and open inspector. Set to android device and refresh. Verify text in buttons is shown fully and that the button matches the design.

<img width="591" alt="Screenshot 2025-01-08 at 10 53 37 AM" src="https://github.com/user-attachments/assets/d5a14e77-0c39-4e1b-be25-257d861d0c1a" />

https://www.figma.com/design/oEKwLBikshx4BgPmhtm7K9/Adobe.com%2Fexpress---SOT-Blocks?node-id=20272-270473&p=f&t=soVZgwzkJdOHuZHn-0

**Pages to check for regression and performance:**
-  https://mfb-shrink-font--express--adobecom.hlx.page/express/feature/image/remove-background
-  https://mfb-shrink-font--express--adobecom.hlx.page/de/express/feature/image/remove-background
-  https://mfb-shrink-font--express--adobecom.hlx.page/fr/express/feature/image/remove-background
-  https://mfb-shrink-font--express--adobecom.hlx.page/jp/express/feature/image/remove-background
-  https://mfb-shrink-font--express--adobecom.hlx.page/br/express/feature/image/remove-background

