### PR TITLE
Focusable Pricing Card Tooltips

### DIFF
--- a/express/blocks/pricing-cards/pricing-cards.css
+++ b/express/blocks/pricing-cards/pricing-cards.css
@@ -162,20 +162,33 @@ Border style variants
 End border style variants
 */
 
+.pricing-cards .tooltip > button:focus-within .tooltip-text {
+  opacity: 1;
+}
+
+.pricing-cards .tooltip>button {
+  border: none;
+  background-color: transparent;
+  padding: 0px;
+  font-family: "adobe-clean";
+  position: relative;
+}
+
 .pricing-cards .tooltip-icon {
   position: relative;
   top: 2px;
 }
+
 .pricing-cards .tooltip-text.overflow-left {
   right: inherit;
   left: -20px;
-
 }
+
 .pricing-cards .tooltip-text.overflow-right {
   left: inherit;
   right: -20px;
-
 }
+
 .pricing-cards .tooltip-text {
   pointer-events: none;
   opacity: 0;
@@ -185,13 +198,11 @@ End border style variants
   color: white;
   border-radius: 8px;
   position: absolute;
-  bottom: 100%;
-  min-width: 200px;
-  left: -105px;
-  width: fit-content;
-  margin-bottom: 19px;
+  bottom: 100%; 
+  width:  200px;
+  left: -105px; 
+  margin-bottom: 5px;
   transition: bottom 0.5s;
-  width: 100%;
 }
 
 .pricing-cards .tooltip-text::after {
@@ -204,12 +215,11 @@ End border style variants
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   border-top: 5px solid black;
-  
 }
 
 .pricing-cards .tooltip-text.overflow-left::after {
   right: inherit;
-  left: 20px;
+  left: 23px;
 }
 
 .pricing-cards .tooltip-text.overflow-right::after {

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -203,7 +203,7 @@ function handleTooltip(pricingArea) {
   const icon = getIconElement('info', 44, 'Info', 'tooltip-icon');
   icon.append(span);
   const iconWrapper = createTag('button');
-  icon.setAttribute('tabindex',1) 
+  icon.setAttribute('tabindex', 1);
   iconWrapper.append(icon);
   iconWrapper.append(span);
   tooltipDiv.append(iconWrapper);

--- a/express/blocks/pricing-cards/pricing-cards.js
+++ b/express/blocks/pricing-cards/pricing-cards.js
@@ -202,7 +202,8 @@ function handleTooltip(pricingArea) {
   span.innerText = tooltipText;
   const icon = getIconElement('info', 44, 'Info', 'tooltip-icon');
   icon.append(span);
-  const iconWrapper = createTag('span');
+  const iconWrapper = createTag('button');
+  icon.setAttribute('tabindex',1) 
   iconWrapper.append(icon);
   iconWrapper.append(span);
   tooltipDiv.append(iconWrapper);

--- a/express/blocks/simplified-pricing-cards/simplified-pricing-cards.css
+++ b/express/blocks/simplified-pricing-cards/simplified-pricing-cards.css
@@ -312,6 +312,10 @@ main .section>.simplified-pricing-cards-wrapper {
 
 /* Tooltip CSS */
 
+.simplified-pricing-cards .tooltip > button:focus-within .tooltip-text {
+  opacity: 1;
+}
+
 .simplified-pricing-cards .tooltip-icon {
   position: relative;
   top: 2px;
@@ -326,12 +330,19 @@ main .section>.simplified-pricing-cards-wrapper {
   border-radius: 8px;
   position: absolute;
   bottom: 100%;
-  min-width: 200px;
+  width:  200px;
   left: -105px;
-  width: fit-content;
-  margin-bottom: 19px;
+  margin-bottom: 10px;
   transition: bottom 0.5s;
   pointer-events: none;
+}
+
+.simplified-pricing-cards .tooltip>button {
+  border: none;
+  background-color: transparent;
+  padding: 0px;
+  font-family: "adobe-clean";
+  position: relative;
 }
 
 .simplified-pricing-cards .tooltip-text.overflow-left {
@@ -348,14 +359,16 @@ main .section>.simplified-pricing-cards-wrapper {
   content: '';
   position: absolute;
   bottom: -5px;
-  left: 50%;
-  border: 5px solid transparent;
-  border-top-color: var(--color-black)
-}
+  left: -105px; 
+  border-top-color: var(--color-black);
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 5px solid black;
+} 
 
 .simplified-pricing-cards .tooltip-text.overflow-left::after {
   right: inherit;
-  left: 20px;
+  left: 23px;
 }
 
 .simplified-pricing-cards .tooltip-text.overflow-right::after {

--- a/express/blocks/simplified-pricing-cards/simplified-pricing-tooltip.js
+++ b/express/blocks/simplified-pricing-cards/simplified-pricing-tooltip.js
@@ -5,7 +5,6 @@ import {
 
 export function adjustElementPosition() {
   const elements = document.querySelectorAll('.tooltip-text');
-
   if (elements.length === 0) return;
   for (const element of elements) {
     const rect = element.getBoundingClientRect();

--- a/express/blocks/simplified-pricing-cards/simplified-pricing-tooltip.js
+++ b/express/blocks/simplified-pricing-cards/simplified-pricing-tooltip.js
@@ -40,7 +40,7 @@ export function handleTooltip(pricingArea) {
   span.innerText = tooltipText;
   const icon = getIconElement('info', 44, 'Info', 'tooltip-icon');
   icon.append(span);
-  icon.setAttribute('tabindex',1)
+  icon.setAttribute('tabindex', 1);
   const iconWrapper = createTag('button');
   iconWrapper.append(icon);
   iconWrapper.append(span);

--- a/express/blocks/simplified-pricing-cards/simplified-pricing-tooltip.js
+++ b/express/blocks/simplified-pricing-cards/simplified-pricing-tooltip.js
@@ -12,7 +12,7 @@ export function adjustElementPosition() {
     if (rect.right > window.innerWidth) {
       element.classList.remove('overflow-left');
       element.classList.add('overflow-right');
-    } else if (rect.left < 0) {
+    } else if (rect.left < 40) {
       element.classList.remove('overflow-right');
       element.classList.add('overflow-left');
     }
@@ -41,7 +41,8 @@ export function handleTooltip(pricingArea) {
   span.innerText = tooltipText;
   const icon = getIconElement('info', 44, 'Info', 'tooltip-icon');
   icon.append(span);
-  const iconWrapper = createTag('span');
+  icon.setAttribute('tabindex',1)
+  const iconWrapper = createTag('button');
   iconWrapper.append(icon);
   iconWrapper.append(span);
   tooltipDiv.append(iconWrapper);


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Issue/Feature 1

    changed the wrapper element to button so that it is focusable
    tooltip now stays open if focused via keyboard, can be dismissed by changing focus.
    revamped some CSS
    added missing caret at the bottom in the simplified version of the tooltip

**Resolves:**  https://jira.corp.adobe.com/browse/MWPW-160772
   

**Pages to check for regression and performance:**
- https://tooltip-pricing-card-hover--express--adobecom.hlx.page/express
- https://tooltip-pricing-card-hover--express--adobecom.hlx.page/express/pricing
- https://tooltip-pricing-card-hover--express--adobecom.hlx.page/de/express/pricing

 Visit the two pages above on the three device resolutions and press tab until the tooltip shows up. Verify that it is completely visible inside the device screen and that it goes away when you tab again.
 
<img width="553" alt="Screenshot 2025-01-13 at 1 50 37 PM" src="https://github.com/user-attachments/assets/7be796e3-8f89-4293-8317-693cd53185c4" />



