### PR TITLE
Mobile: How to steps carousel block not centered for DE pages.

### DIFF
--- a/express/blocks/how-to-steps-carousel/how-to-steps-carousel.css
+++ b/express/blocks/how-to-steps-carousel/how-to-steps-carousel.css
@@ -11,10 +11,8 @@ main .how-to-steps-carousel-container > picture > img {
 main .how-to-steps-carousel-container > div {
   background-color: var(--color-gray-100);
   border-radius: 40px;
-
   margin: 0 24px;
   padding: 56px 24px;
-  width: 100%;
   max-width: fit-content;
 }
 


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Mobile: How to steps carousel block not centered for DE pages.

**Resolves:** [MWPW-165032](https://jira.corp.adobe.com/browse/MWPW-165032)

**Steps to test the before vs. after and expectations:**
- Set browser inspector to iPhone and check if How To Steps Carousel Block has gutters on either side and the text wraps
- Set browser inspector to Android and check if How To Steps Carousel Block has gutters on either side and the text wraps

**Pages to check for regression and performance:**
- https://phone-wrap-how-to-steps-carousel--express--adobecom.hlx.page/de/express/create/chart/bar
