### PR TITLE
MWPW-183330 Block SBOM-grype from creating tickets

### DIFF
--- a/.kodiak/config.yaml
+++ b/.kodiak/config.yaml
@@ -14,6 +14,9 @@ notifications:
       filters:
         include:
           risk_rating: R3 # Please do not change this unless instructed to do so.
+        exclude:
+          tool_type:
+            - "sbom_grype" # Exclude SBOM tickets which duplicate findings already created by snyk
       fields:
         customfield_11800: MWPW-164516 # Jira epic security tickets will be assigned to.
         customfield_12900: 


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
Prevents duplicate CVE tickets from being created by grype

**Resolves:** [MWPW-183330](https://jira.corp.adobe.com/browse/MWPW-183330)

**Steps to test the before vs. after and expectations:**
- Existing CVE tickets created by grype will be closed
- New CVE tickets from grype will be blocked

**Pages to check for regression and performance:**
- https://thedoc31-patch-2--express--adobecom.hlx.page/express/?martech=off
