### PR TITLE
MWPW-192736: Add check for milolibs query param

### DIFF
--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -2744,6 +2744,7 @@ export const [setLibs, getLibs] = (() => {
         return libs;
       }
       const branch = new URLSearchParams(window.location.search).get('milolibs') || 'main';
+      if (!/^[a-zA-Z0-9_-]+$/.test(branch)) throw new Error('Invalid branch name.');
       if (branch === 'local') {
         libs = 'http://localhost:6456/libs';
         return libs;


### PR DESCRIPTION
Whitelist branch parameter with `/^[a-zA-Z0-9_-]+$/`; throw on any other characters.

## Ticket
https://jira.corp.adobe.com/browse/MWPW-192736

## Test URLs
Before: https://stage--express--adobecom.aem.page/
After: https://MWPW-192736--express--zagi25.aem.page/

---
_This PR was generated by Claude (Anthropic's Claude Code CLI)._